### PR TITLE
feat(agent-activity): a finished task leaves a durable summary; the archive is split by day

### DIFF
--- a/skills/agent-activity/SKILL.md
+++ b/skills/agent-activity/SKILL.md
@@ -68,8 +68,13 @@ skill hook. The hook never depends on the agent remembering anything:
   "consolidated" with `task.into` = X's message event id (the reply lives under that message).
 - **Bounded, one writer at a time.** Every append and the rotation that follows it run under one
   `flock` on `agent-activity.jsonl.lock`, so no row is lost or duplicated when hooks from several
-  sessions write at once. The live log keeps the newest 400 rows (older rows move to `agent-activity.archive.jsonl`),
-  and the session bindings file drops a task once its done row exists, so the per-tool-call reads stay small.
+  sessions write at once. The live log keeps the newest 400 rows (older rows move to
+  `agent-activity.archive.<YYYY-MM-DD>.jsonl` by the row's own UTC day), and the session bindings
+  file drops a task once its done row exists, so the per-tool-call reads stay small.
+- **A finished task leaves a summary.** Every `done` row with a task also appends one line to
+  `agent-activity.summaries.jsonl` — `{ts, started, rows, days, line, room, task}` — so the client can
+  fold the card of an old message from it after the rows have rotated out, and expand it from the
+  `days` archive files. Served like the log, at `/media/state/agent-activity.summaries.jsonl`.
 - **Fail closed.** A session with no bound open task writes nothing; a task another session claimed
   is never written to, so narration cannot cross rooms. The writer's own calls never become rows.
 - The hook exits 0 on every path; it must not block the tool it observed.

--- a/skills/agent-activity/hooks/activity-hook.py
+++ b/skills/agent-activity/hooks/activity-hook.py
@@ -134,7 +134,10 @@ def bind(p: dict, task_id: str, session_id: str) -> None:
         fcntl.flock(lk, fcntl.LOCK_EX)
         binds = load_json(p["bind"], {})
         binds[task_id] = session_id
+        # The same open set completion uses: the live log plus the writer's index, so a task whose
+        # rows rotated out keeps its binding while another session picks up the next task.
         alive = open_tasks(p["log"])
+        alive.update(indexed_open_tasks(p["ws"]))
         binds = {t: sid for t, sid in binds.items() if t in alive or t == task_id}
         tmp = p["bind"].with_name(f".{p['bind'].name}.{os.getpid()}.{secrets.token_hex(3)}.tmp")
         tmp.write_text(json.dumps(binds, indent=1), encoding="utf-8")

--- a/skills/agent-activity/hooks/activity-hook.py
+++ b/skills/agent-activity/hooks/activity-hook.py
@@ -74,6 +74,22 @@ def open_tasks(log: Path) -> dict[str, dict]:
     return out
 
 
+def indexed_open_tasks(ws: Path) -> dict[str, dict]:
+    """{task_id: {"task", "room"}} from the writer's index, in the shape open_tasks() returns."""
+    try:
+        sys.path.insert(0, str(WRITER.parent))
+        from activity import open_task_index
+        idx = open_task_index(ws)
+    except Exception:  # noqa: BLE001 - the hook never fails the tool it observed
+        return {}
+    out: dict[str, dict] = {}
+    for tid, e in idx.items():
+        t = e.get("task") if isinstance(e, dict) else None
+        if isinstance(t, dict) and isinstance(t.get("id"), str):
+            out[tid] = {"task": t, "room": e.get("room") if isinstance(e.get("room"), str) else None}
+    return out
+
+
 def bound_task(p: dict, session_id: str) -> tuple[dict | None, str | None]:
     """The open task this session is bound to; None when none is (fail closed)."""
     binds = load_json(p["bind"], {})
@@ -324,6 +340,10 @@ def handle(payload: dict, p: dict, run=subprocess.run) -> list[tuple[str, str]]:
         blob = json.dumps(inp, ensure_ascii=False) if isinstance(inp, dict) else ""
         binds = load_json(p["bind"], {})
         opened = open_tasks(p["log"])
+        # A long task's rows may have rotated out of the live log; the writer's index still holds it
+        # open, so its result write still closes it and still leaves a summary.
+        for tid, e in indexed_open_tasks(p["ws"]).items():
+            opened.setdefault(tid, e)
         # The result write closes the task only once the file exists: the tool ran, was not denied,
         # and produced the artifact. The text says what the result did (a marker body reached nobody).
         for tid in result_file_refs(blob):

--- a/skills/agent-activity/scripts/activity.py
+++ b/skills/agent-activity/scripts/activity.py
@@ -40,6 +40,42 @@ def day_of(ts: float) -> str:
     return time.strftime("%Y-%m-%d", time.gmtime(ts))
 
 
+def index_path(workspace: Path | None = None) -> Path:
+    """Per open task: {task, room, started, rows, days}. Updated on every append under the writer
+    lock, so a summary is exact after any rotation; an entry leaves when its task is summarized."""
+    return (workspace or resolve_workspace()) / "state" / "agent-activity.index.json"
+
+
+def _load_index(path: Path) -> dict:
+    try:
+        d = json.loads(path.read_text(encoding="utf-8"))
+        return d if isinstance(d, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def _save_index(path: Path, d: dict) -> None:
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    tmp.write_text(json.dumps(d, ensure_ascii=False), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def day_range(start_ts: float, end_ts: float) -> list[str]:
+    """Every UTC day from start to end inclusive: the complete list of archive files that can hold
+    a row of the span, never just its two ends."""
+    out, t = [], start_ts
+    while day_of(t) <= day_of(end_ts):
+        out.append(day_of(t))
+        t += 86400
+    return out
+
+
+def open_task_index(workspace: Path | None = None) -> dict:
+    """The tasks the index still holds open: what the hook falls back to when a task's rows have
+    rotated out of the live log but its result now exists."""
+    return _load_index(index_path(workspace))
+
+
 def default_room(workspace: Path | None = None) -> str | None:
     """The room of the owner's latest AG2 Space message; a row with no room shows only in the dock."""
     p = (workspace or resolve_workspace()) / "state" / "last-owner-activity.json"
@@ -86,33 +122,32 @@ def append(line: str, *, kind: str, room: str | None, task: dict | None = None,
         fcntl.flock(lk, fcntl.LOCK_EX)
         with open(path, "a", encoding="utf-8") as f:
             f.write(json.dumps(rec, ensure_ascii=False) + "\n")
-        if done and task and isinstance(task.get("id"), str):
-            summarize(path, rec, workspace)
+        if task and isinstance(task.get("id"), str):
+            ip = index_path(workspace)
+            idx = _load_index(ip)
+            e = idx.get(task["id"]) or {"started": rec["ts"], "rows": 0, "task": task, "room": room}
+            e["rows"] = int(e.get("rows", 0)) + 1
+            e["started"] = min(float(e.get("started", rec["ts"])), rec["ts"])
+            e["task"] = dict(e.get("task") or {}, **task)
+            if room:
+                e["room"] = room
+            if done:
+                idx.pop(task["id"], None)
+                summarize(rec, e, workspace)
+            else:
+                idx[task["id"]] = e
+            _save_index(ip, idx)
         rotate(path, live_rows if live_rows is not None else LIVE_ROWS)
     return rec
 
 
-def summarize(path: Path, done_rec: dict, workspace: Path | None = None) -> dict:
-    """Append the task's durable summary: when it started, how many rows it had, and which archive
-    days hold them, so a card for an old message can be folded from this line and expanded from the
-    day files. Called with the writer lock held, before the rotation that may move the rows out."""
-    tid = done_rec["task"]["id"]
-    started, count = done_rec["ts"], 0
-    try:
-        for line in path.read_text(encoding="utf-8").splitlines():
-            try:
-                r = json.loads(line)
-            except ValueError:
-                continue
-            t = r.get("task") if isinstance(r, dict) else None
-            if isinstance(t, dict) and t.get("id") == tid and isinstance(r.get("ts"), (int, float)):
-                count += 1
-                started = min(started, r["ts"])
-    except OSError:
-        pass
-    days = sorted({day_of(started), day_of(done_rec["ts"])})
-    summary = {"ts": done_rec["ts"], "started": started, "rows": max(count, 1), "days": days,
-               "line": done_rec["line"], "task": done_rec["task"]}
+def summarize(done_rec: dict, entry: dict, workspace: Path | None = None) -> dict:
+    """Append the task's durable summary from the index entry — exact whether or not its rows have
+    rotated out — with `days` as every UTC day of the span, the complete archive fetch list.
+    Called with the writer lock held."""
+    started = float(entry.get("started", done_rec["ts"]))
+    summary = {"ts": done_rec["ts"], "started": started, "rows": max(int(entry.get("rows", 1)), 1),
+               "days": day_range(started, done_rec["ts"]), "line": done_rec["line"], "task": done_rec["task"]}
     if done_rec.get("room"):
         summary["room"] = done_rec["room"]
     sp = summaries_path(workspace)

--- a/skills/agent-activity/scripts/activity.py
+++ b/skills/agent-activity/scripts/activity.py
@@ -30,6 +30,16 @@ def log_path(workspace: Path | None = None) -> Path:
     return (workspace or resolve_workspace()) / "state" / "agent-activity.jsonl"
 
 
+def summaries_path(workspace: Path | None = None) -> Path:
+    """One line per finished task: what the folded card shows after the task's rows have left the
+    live log. Never rotated; ~200 bytes a task."""
+    return (workspace or resolve_workspace()) / "state" / "agent-activity.summaries.jsonl"
+
+
+def day_of(ts: float) -> str:
+    return time.strftime("%Y-%m-%d", time.gmtime(ts))
+
+
 def default_room(workspace: Path | None = None) -> str | None:
     """The room of the owner's latest AG2 Space message; a row with no room shows only in the dock."""
     p = (workspace or resolve_workspace()) / "state" / "last-owner-activity.json"
@@ -76,8 +86,39 @@ def append(line: str, *, kind: str, room: str | None, task: dict | None = None,
         fcntl.flock(lk, fcntl.LOCK_EX)
         with open(path, "a", encoding="utf-8") as f:
             f.write(json.dumps(rec, ensure_ascii=False) + "\n")
+        if done and task and isinstance(task.get("id"), str):
+            summarize(path, rec, workspace)
         rotate(path, live_rows if live_rows is not None else LIVE_ROWS)
     return rec
+
+
+def summarize(path: Path, done_rec: dict, workspace: Path | None = None) -> dict:
+    """Append the task's durable summary: when it started, how many rows it had, and which archive
+    days hold them, so a card for an old message can be folded from this line and expanded from the
+    day files. Called with the writer lock held, before the rotation that may move the rows out."""
+    tid = done_rec["task"]["id"]
+    started, count = done_rec["ts"], 0
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            try:
+                r = json.loads(line)
+            except ValueError:
+                continue
+            t = r.get("task") if isinstance(r, dict) else None
+            if isinstance(t, dict) and t.get("id") == tid and isinstance(r.get("ts"), (int, float)):
+                count += 1
+                started = min(started, r["ts"])
+    except OSError:
+        pass
+    days = sorted({day_of(started), day_of(done_rec["ts"])})
+    summary = {"ts": done_rec["ts"], "started": started, "rows": max(count, 1), "days": days,
+               "line": done_rec["line"], "task": done_rec["task"]}
+    if done_rec.get("room"):
+        summary["room"] = done_rec["room"]
+    sp = summaries_path(workspace)
+    with open(sp, "a", encoding="utf-8") as f:
+        f.write(json.dumps(summary, ensure_ascii=False) + "\n")
+    return summary
 
 
 LIVE_ROWS = 400
@@ -92,8 +133,20 @@ def rotate(path: Path, keep: int = LIVE_ROWS) -> None:
         return
     if len(rows) <= keep:
         return
-    with open(path.with_name(path.stem + ".archive.jsonl"), "a", encoding="utf-8") as arch:
-        arch.write("\n".join(rows[:-keep]) + "\n")
+    # One archive file per UTC day of the row's own timestamp, so a reader expanding an old card
+    # fetches one small immutable file, not the whole history; a torn row goes to the undated file.
+    by_day: dict[str, list[str]] = {}
+    for line in rows[:-keep]:
+        try:
+            ts = json.loads(line).get("ts")
+            day = day_of(ts) if isinstance(ts, (int, float)) else None
+        except (ValueError, AttributeError):
+            day = None
+        by_day.setdefault(day, []).append(line)
+    for day, lines in by_day.items():
+        name = f"{path.stem}.archive.{day}.jsonl" if day else f"{path.stem}.archive.jsonl"
+        with open(path.with_name(name), "a", encoding="utf-8") as arch:
+            arch.write("\n".join(lines) + "\n")
     tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
     tmp.write_text("\n".join(rows[-keep:]) + "\n", encoding="utf-8")
     os.replace(tmp, path)

--- a/tests/agent-activity.test.py
+++ b/tests/agent-activity.test.py
@@ -319,6 +319,29 @@ class MessageEvent(unittest.TestCase):
         self.assertEqual(out, [("done", "replied")])
         self.assertEqual((runs[-1][2], runs[-1][runs[-1].index("--event") + 1]), ("done", "$evr"))
 
+    def test_a_second_sessions_pickup_keeps_the_binding_of_a_task_whose_rows_rotated_out(self):
+        # A bound BEFORE rotation, 4 rows evict it from the live log, another session binds B:
+        # A's binding must survive the prune and A's later result write must still close it.
+        p = hook.paths(self.ws); runs = []
+        self._task("task-a2", event="$eva"); self._task("task-b2", event="$evb")
+        card.append("picked up", kind="processing", room="!r:s", task={"id": "task-a2", "event": "$eva"}, workspace=self.ws, live_rows=2)
+        hook.bind(p, "task-a2", "S1")
+        for i in range(4):
+            card.append(f"noise {i}", kind="notice", room=None, workspace=self.ws, live_rows=2)
+        self.assertNotIn("task-a2", hook.open_tasks(p["log"]), "precondition: A left the live log")
+        card.append("picked up", kind="processing", room="!r:s", task={"id": "task-b2", "event": "$evb"}, workspace=self.ws, live_rows=2)
+        hook.bind(p, "task-b2", "S2")
+        self.assertEqual(hook.load_json(p["bind"], {}).get("task-a2"), "S1", "A's binding survived B's pickup")
+        (self.ws / "results").mkdir(exist_ok=True); (self.ws / "results" / "task-a2.txt").write_text("done.\n")
+        out = hook.handle({"hook_event_name": "PostToolUse", "session_id": "S1", "tool_name": "Write",
+                           "tool_input": {"file_path": str(self.ws / "results" / "task-a2.txt")}}, p, lambda cmd, **kw: runs.append(cmd))
+        self.assertEqual(out, [("done", "replied")])
+        # The stubbed emit did not write; the real writer's done row closes A in the index, and the
+        # next bind prunes it while keeping B.
+        card.append("replied", kind="done", room="!r:s", task={"id": "task-a2", "event": "$eva"}, done=True, workspace=self.ws, live_rows=2)
+        hook.bind(p, "task-b2", "S2")
+        self.assertEqual(sorted(hook.load_json(p["bind"], {})), ["task-b2"])
+
     def test_a_dedup_pointer_result_closes_as_consolidated_into_the_holder_message(self):
         p = hook.paths(self.ws); runs = []
         self._task("task-x1", event="$evx"); self._task("task-h1", event="$evh")

--- a/tests/agent-activity.test.py
+++ b/tests/agent-activity.test.py
@@ -42,6 +42,14 @@ def _append_many(ws, writer, count, live_rows):
                  workspace=_pl.Path(ws), live_rows=live_rows)
 
 
+def _archived(ws):
+    """Every archived row, across the per-day files (and the undated one for torn rows)."""
+    out = []
+    for f in sorted(Path(ws, "state").glob("agent-activity.archive*.jsonl")):
+        out += f.read_text().splitlines()
+    return out
+
+
 def _bind_in_process(ws, task_id, sid):
     import pathlib as _pl
     h = load_at(REPO / "skills" / "agent-activity" / "hooks" / "activity-hook.py")
@@ -78,7 +86,7 @@ class Writer(unittest.TestCase):
         for i in range(card.LIVE_ROWS + 3):
             card.append(f"row {i}", kind="notice", room=None, workspace=self.ws)
         live = card.log_path(self.ws).read_text().splitlines()
-        arch = (self.ws / "state" / "agent-activity.archive.jsonl").read_text().splitlines()
+        arch = _archived(self.ws)
         self.assertEqual((len(live), len(arch)), (card.LIVE_ROWS, 3))
         self.assertIn('"row 0"', arch[0]); self.assertIn(f'"row {card.LIVE_ROWS + 2}"', live[-1])
 
@@ -90,7 +98,7 @@ class Writer(unittest.TestCase):
             pool.starmap(_append_many, [(str(self.ws), f"w{i}", 30, 25) for i in range(8)])
             pool.close(); pool.join()  # workers exit on their own: a terminate() under coverage deadlocks them
         live = card.log_path(self.ws).read_text().splitlines()
-        arch = (self.ws / "state" / "agent-activity.archive.jsonl").read_text().splitlines()
+        arch = _archived(self.ws)
         lines = [json.loads(l)["line"] for l in live + arch]
         expected = [f"w{i}-{j}" for i in range(8) for j in range(30)]
         self.assertEqual(sorted(lines), sorted(expected), f"lost={set(expected)-set(lines)} dup={len(lines)-len(set(lines))}")
@@ -154,6 +162,46 @@ class WriterCli(unittest.TestCase):
         p.write_text("id: task-file\nchannel_id: !team:s\nuser_id: @q:s\ntask: hello\n")
         rc, rec = self.run_main("append", "x", "--task-file", str(p), "--task-id", "task-cli")
         self.assertEqual((rec["task"]["id"], rec["task"]["from"], rec["room"]), ("task-cli", "@q:s", "!team:s"))
+
+
+class Durable(unittest.TestCase):
+    """A finished task leaves a summary line, and the archive is split by the rows' own day."""
+
+    def setUp(self):
+        self.ws = Path(tempfile.mkdtemp())
+        (self.ws / "state").mkdir()
+
+    def test_a_done_row_writes_a_summary_with_started_rows_and_days(self):
+        t = {"id": "task-s1", "event": "$ev", "from": "@q:s"}
+        card.append("picked up", kind="processing", room="!r:s", task=t, workspace=self.ws)
+        card.append("Bash: tests", kind="working", room="!r:s", task=t, workspace=self.ws)
+        card.append("other task", kind="working", room="!r:s", task={"id": "task-s2"}, workspace=self.ws)
+        rec = card.append("replied", kind="done", room="!r:s", task=t, done=True, workspace=self.ws)
+        lines = card.summaries_path(self.ws).read_text().splitlines()
+        self.assertEqual(len(lines), 1)
+        s = json.loads(lines[0])
+        first = json.loads(card.log_path(self.ws).read_text().splitlines()[0])["ts"]
+        self.assertEqual((s["task"], s["line"], s["room"], s["rows"], s["started"], s["ts"]),
+                         (t, "replied", "!r:s", 3, first, rec["ts"]))
+        self.assertEqual(s["days"], [card.day_of(rec["ts"])])
+
+    def test_a_done_row_without_a_task_leaves_no_summary(self):
+        card.append("closed", kind="done", room=None, done=True, workspace=self.ws)
+        self.assertFalse(card.summaries_path(self.ws).exists())
+
+    def test_rotation_splits_the_archive_by_the_rows_own_day(self):
+        path = card.log_path(self.ws)
+        rows = [{"ts": 1_700_000_000 + i * 86400, "line": f"day{i}", "kind": "notice"} for i in range(3)]
+        rows.append({"ts": rows[-1]["ts"] + 10, "line": "kept", "kind": "notice"})
+        text = "\n".join([json.dumps(rows[0]), "not json"] + [json.dumps(r) for r in rows[1:]]) + "\n"
+        path.write_text(text)
+        card.rotate(path, keep=1)
+        files = sorted(f.name for f in Path(self.ws, "state").glob("agent-activity.archive*.jsonl"))
+        self.assertEqual(files, ["agent-activity.archive.2023-11-14.jsonl", "agent-activity.archive.2023-11-15.jsonl",
+                                 "agent-activity.archive.2023-11-16.jsonl", "agent-activity.archive.jsonl"])
+        self.assertIn("day1", (self.ws / "state" / "agent-activity.archive.2023-11-15.jsonl").read_text())
+        self.assertEqual((self.ws / "state" / "agent-activity.archive.jsonl").read_text(), "not json\n")
+        self.assertEqual(path.read_text().strip(), json.dumps(rows[-1]))
 
 
 class MessageEvent(unittest.TestCase):

--- a/tests/agent-activity.test.py
+++ b/tests/agent-activity.test.py
@@ -184,6 +184,37 @@ class Durable(unittest.TestCase):
         self.assertEqual((s["task"], s["line"], s["room"], s["rows"], s["started"], s["ts"]),
                          (t, "replied", "!r:s", 3, first, rec["ts"]))
         self.assertEqual(s["days"], [card.day_of(rec["ts"])])
+        self.assertNotIn("task-s1", card.open_task_index(self.ws), "a summarized task leaves the index")
+        self.assertIn("task-s2", card.open_task_index(self.ws), "an open task stays in it")
+
+    def test_the_summary_is_exact_after_its_rows_have_rotated_out(self):
+        # The reviewers' case: with the window compressed, every row of the task has left the live
+        # log by the time it finishes. The summary must still say 3 rows and the real start.
+        t = {"id": "task-r1", "event": "$ev"}
+        card.append("picked up", kind="processing", room="!r:s", task=t, workspace=self.ws, live_rows=2)
+        first = json.loads(card.log_path(self.ws).read_text().splitlines()[0])["ts"]
+        card.append("Bash: tests", kind="working", room="!r:s", task=t, workspace=self.ws, live_rows=2)
+        for i in range(4):
+            card.append(f"noise {i}", kind="notice", room=None, workspace=self.ws, live_rows=2)
+        live = [json.loads(l).get("task", {}).get("id") for l in card.log_path(self.ws).read_text().splitlines()]
+        self.assertNotIn("task-r1", live, "precondition: the task's rows have rotated out")
+        rec = card.append("replied", kind="done", room="!r:s", task=t, done=True, workspace=self.ws, live_rows=2)
+        s = json.loads(card.summaries_path(self.ws).read_text().splitlines()[-1])
+        self.assertEqual((s["rows"], s["started"], s["ts"]), (3, first, rec["ts"]))
+
+    def test_days_is_every_utc_day_of_the_span_not_its_two_ends(self):
+        self.assertEqual(card.day_range(1_757_000_000, 1_757_000_000), ["2025-09-04"])
+        self.assertEqual(card.day_range(1_756_900_000, 1_757_100_000), ["2025-09-03", "2025-09-04", "2025-09-05"])
+        e = {"started": 1_756_900_000, "rows": 4, "task": {"id": "task-d"}, "room": "!r:s"}
+        s = card.summarize({"ts": 1_757_100_000, "line": "replied", "task": {"id": "task-d"}, "room": "!r:s"}, e, self.ws)
+        self.assertEqual(s["days"], ["2025-09-03", "2025-09-04", "2025-09-05"])
+
+    def test_a_torn_index_and_an_unreadable_log_leave_the_writer_working(self):
+        card.index_path(self.ws).parent.mkdir(parents=True, exist_ok=True)
+        card.index_path(self.ws).write_text("not json")
+        rec = card.append("x", kind="working", room="!r:s", task={"id": "task-t"}, workspace=self.ws)
+        self.assertEqual(card.open_task_index(self.ws)["task-t"]["rows"], 1)
+        self.assertEqual(card.summaries_path(self.ws).exists(), False)
 
     def test_a_done_row_without_a_task_leaves_no_summary(self):
         card.append("closed", kind="done", room=None, done=True, workspace=self.ws)
@@ -271,6 +302,22 @@ class MessageEvent(unittest.TestCase):
         (self.ws / "results" / "task-x3.txt").write_text("[deduped: task-unknown]\n")
         self.assertEqual(hook.consolidated_into(self.ws, "task-x3"), "", "a dedup whose holder is gone still reads as consolidated")
         del p
+
+    def test_a_result_write_closes_a_task_whose_rows_rotated_out_of_the_live_log(self):
+        # Bind + processing through the writer, evict it with noise past the window, then the result
+        # write: the done row and the summary must still land, from the writer's index.
+        p = hook.paths(self.ws); runs = []
+        self._task("task-rot", event="$evr")
+        card.append("picked up", kind="processing", room="!r:s", task={"id": "task-rot", "event": "$evr"}, workspace=self.ws, live_rows=2)
+        for i in range(4):
+            card.append(f"noise {i}", kind="notice", room=None, workspace=self.ws, live_rows=2)
+        self.assertNotIn("task-rot", hook.open_tasks(p["log"]), "precondition: gone from the live log")
+        hook.bind(p, "task-rot", "S1")
+        (self.ws / "results").mkdir(exist_ok=True); (self.ws / "results" / "task-rot.txt").write_text("done.\n")
+        out = hook.handle({"hook_event_name": "PostToolUse", "session_id": "S1", "tool_name": "Write",
+                           "tool_input": {"file_path": str(self.ws / "results" / "task-rot.txt")}}, p, lambda cmd, **kw: runs.append(cmd))
+        self.assertEqual(out, [("done", "replied")])
+        self.assertEqual((runs[-1][2], runs[-1][runs[-1].index("--event") + 1]), ("done", "$evr"))
 
     def test_a_dedup_pointer_result_closes_as_consolidated_into_the_holder_message(self):
         p = hook.paths(self.ws); runs = []


### PR DESCRIPTION
**Stacked on #3981** (merge #3981 first; this branch contains it). Child-only diff: `scripts/activity.py`, `SKILL.md`, tests.

## What

The desktop draws a message's activity card from the live log's last 400 rows. On a busy host that window is a few hours (measured on the owner's Mac today: 400 rows spanned 5.35 h), so every answered message loses its card the same day. Owner's ask 2026-09-06: keep the folded card forever (1) and let it expand from history (2).

- **Summary at done.** Every `done` row with a task appends one line to `state/agent-activity.summaries.jsonl`: `{ts, started, rows, days, line, room, task}` — `started`/`rows` counted from the task's rows still in the live log at that moment (under the same writer lock, before rotation), `days` the UTC days from start to done. ~200 bytes a task, never rotated. The client folds an old message's card from this line; `task.event` (from #3981) is what it mounts by.
- **Archive by day.** `rotate()` writes `agent-activity.archive.<YYYY-MM-DD>.jsonl` by the row's own timestamp instead of one growing file; a torn row still goes to the undated file. Expanding an old card is then one fetch of a small immutable day file named in the summary — the loopback route already serves any file under `state/` (probed: archive 200, unknown name 404, traversal 404).

## Evidence
```
tests/agent-activity.test.py   Ran 37 tests in 0.296s OK   (34 on #3981)
```
Mutations, one line each, tests kept, restored after:
- summary never written → `FAILED (errors=1)`: `test_a_done_row_writes_a_summary_with_started_rows_and_days`
- rotation back to one undated file → `FAILED (failures=1)`: `test_rotation_splits_the_archive_by_the_rows_own_day`

`scripts/review-checks.sh --diff`: PASS.

## Worst case
Two new files under `state/`, both append-only; the live log and every existing row keep their shape. The old single archive file is left as it is (no migration): nothing in the repo reads it (`git grep archive.jsonl` → only this skill and its tests). The client half (fold from summaries, fetch day files on expand) is a cinny-webclient PR that follows.

— sutando-qingyun-air
