### PR TITLE
feat(activity): the activity bus — a TaskRun state machine the card projects; the row writer moves to core

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -16,6 +16,8 @@ One entry per agent-facing module. 5 without a usable header comment.
 
 - **`access_store.py`** — Single writer contract for Discord access.json.
 - **`accessibility_probe.sh`** — Unbounded, this probe blocks forever on a session with nobody to answer the AppleScript prompt, and startup never reaches the services after it.
+- **`activity_bus.py`** — ActivityCard is the UI projection of a durable TaskRun state machine; runtime instrumentation only enriches that state machine with observations.
+- **`activity_rows.py`** — The agent-activity row writer: one JSON row per line at <workspace>/state/agent-activity.jsonl, the live window the desktop renders, its per-day archive, and the per-task summary left at done.
 - **`agent-api.py`** — Sutando agent API — simple HTTP endpoint for agent-to-agent communication.
 - **`agent_endpoint.py`** — Agent Endpoint resolver — resolve(endpoint, mode) → a transport route.
 - **`archive-stale-results.py`** — Archive stale `results/*.txt` files to `results/archive-YYYY-MM-DD/`.

--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -17,7 +17,7 @@ One entry per agent-facing module. 5 without a usable header comment.
 - **`access_store.py`** — Single writer contract for Discord access.json.
 - **`accessibility_probe.sh`** — Unbounded, this probe blocks forever on a session with nobody to answer the AppleScript prompt, and startup never reaches the services after it.
 - **`activity_bus.py`** — ActivityCard is the UI projection of a durable TaskRun state machine; runtime instrumentation only enriches that state machine with observations.
-- **`activity_rows.py`** — The agent-activity row writer: one JSON row per line at <workspace>/state/agent-activity.jsonl, the live window the desktop renders, its per-day archive, and the per-task summary left at done.
+- **`activity_rows.py`** — The agent-activity row writer: one JSON row per line at <workspace>/state/agent-activity.jsonl, the live window the desktop renders, its per-day archive, the per-task index that keeps a summary exact after rotation, and the summary left at done.
 - **`agent-api.py`** — Sutando agent API — simple HTTP endpoint for agent-to-agent communication.
 - **`agent_endpoint.py`** — Agent Endpoint resolver — resolve(endpoint, mode) → a transport route.
 - **`archive-stale-results.py`** — Archive stale `results/*.txt` files to `results/archive-YYYY-MM-DD/`.

--- a/skills/agent-activity/scripts/activity.py
+++ b/skills/agent-activity/scripts/activity.py
@@ -20,70 +20,11 @@ import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
-from workspace_default import resolve_workspace  # noqa: E402
-
-KINDS = ("processing", "thinking", "working", "notice", "done")
-TEXT_MAX = 160
-
-
-def log_path(workspace: Path | None = None) -> Path:
-    return (workspace or resolve_workspace()) / "state" / "agent-activity.jsonl"
-
-
-def summaries_path(workspace: Path | None = None) -> Path:
-    """One line per finished task: what the folded card shows after the task's rows have left the
-    live log. Never rotated; ~200 bytes a task."""
-    return (workspace or resolve_workspace()) / "state" / "agent-activity.summaries.jsonl"
-
-
-def day_of(ts: float) -> str:
-    return time.strftime("%Y-%m-%d", time.gmtime(ts))
-
-
-def index_path(workspace: Path | None = None) -> Path:
-    """Per open task: {task, room, started, rows, days}. Updated on every append under the writer
-    lock, so a summary is exact after any rotation; an entry leaves when its task is summarized."""
-    return (workspace or resolve_workspace()) / "state" / "agent-activity.index.json"
-
-
-def _load_index(path: Path) -> dict:
-    try:
-        d = json.loads(path.read_text(encoding="utf-8"))
-        return d if isinstance(d, dict) else {}
-    except (OSError, ValueError):
-        return {}
-
-
-def _save_index(path: Path, d: dict) -> None:
-    tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
-    tmp.write_text(json.dumps(d, ensure_ascii=False), encoding="utf-8")
-    os.replace(tmp, path)
-
-
-def day_range(start_ts: float, end_ts: float) -> list[str]:
-    """Every UTC day from start to end inclusive: the complete list of archive files that can hold
-    a row of the span, never just its two ends."""
-    out, t = [], start_ts
-    while day_of(t) <= day_of(end_ts):
-        out.append(day_of(t))
-        t += 86400
-    return out
-
-
-def open_task_index(workspace: Path | None = None) -> dict:
-    """The tasks the index still holds open: what the hook falls back to when a task's rows have
-    rotated out of the live log but its result now exists."""
-    return _load_index(index_path(workspace))
-
-
-def default_room(workspace: Path | None = None) -> str | None:
-    """The room of the owner's latest AG2 Space message; a row with no room shows only in the dock."""
-    p = (workspace or resolve_workspace()) / "state" / "last-owner-activity.json"
-    try:
-        d = json.loads(p.read_text())
-    except (OSError, ValueError):
-        return None
-    return d.get("channel_id") if d.get("channel") == "ag2space" else None
+from workspace_default import resolve_workspace  # noqa: E402,F401
+from activity_rows import (  # noqa: E402,F401  (the writer lives in core; the CLI keeps these names)
+    KINDS, LIVE_ROWS, TEXT_MAX, append, day_of, day_range, default_room, index_path, log_path, open_task_index,
+    rotate, summaries_path, summarize,
+)
 
 
 def task_from_file(path: Path) -> tuple[dict, str | None]:
@@ -101,90 +42,6 @@ def task_from_file(path: Path) -> tuple[dict, str | None]:
     if fields.get("source_message_id"):
         task["event"] = fields["source_message_id"]  # the client mounts the card under this message
     return task, fields.get("channel_id") or None
-
-
-def append(line: str, *, kind: str, room: str | None, task: dict | None = None,
-           done: bool = False, workspace: Path | None = None, live_rows: int | None = None) -> dict:
-    if kind not in KINDS:
-        raise ValueError(f"kind must be one of {KINDS}")
-    rec: dict = {"ts": time.time(), "line": line.strip(), "kind": kind}
-    if room:
-        rec["room"] = room
-    if task:
-        rec["task"] = task
-    if done:
-        rec["done"] = True
-    path = log_path(workspace)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    # One lock for the append AND the rotation; the log is opened only under it, so no writer holds
-    # an inode that a concurrent rotation replaces.
-    with open(path.with_suffix(".lock"), "w") as lk:
-        fcntl.flock(lk, fcntl.LOCK_EX)
-        with open(path, "a", encoding="utf-8") as f:
-            f.write(json.dumps(rec, ensure_ascii=False) + "\n")
-        if task and isinstance(task.get("id"), str):
-            ip = index_path(workspace)
-            idx = _load_index(ip)
-            e = idx.get(task["id"]) or {"started": rec["ts"], "rows": 0, "task": task, "room": room}
-            e["rows"] = int(e.get("rows", 0)) + 1
-            e["started"] = min(float(e.get("started", rec["ts"])), rec["ts"])
-            e["task"] = dict(e.get("task") or {}, **task)
-            if room:
-                e["room"] = room
-            if done:
-                idx.pop(task["id"], None)
-                summarize(rec, e, workspace)
-            else:
-                idx[task["id"]] = e
-            _save_index(ip, idx)
-        rotate(path, live_rows if live_rows is not None else LIVE_ROWS)
-    return rec
-
-
-def summarize(done_rec: dict, entry: dict, workspace: Path | None = None) -> dict:
-    """Append the task's durable summary from the index entry — exact whether or not its rows have
-    rotated out — with `days` as every UTC day of the span, the complete archive fetch list.
-    Called with the writer lock held."""
-    started = float(entry.get("started", done_rec["ts"]))
-    summary = {"ts": done_rec["ts"], "started": started, "rows": max(int(entry.get("rows", 1)), 1),
-               "days": day_range(started, done_rec["ts"]), "line": done_rec["line"], "task": done_rec["task"]}
-    if done_rec.get("room"):
-        summary["room"] = done_rec["room"]
-    sp = summaries_path(workspace)
-    with open(sp, "a", encoding="utf-8") as f:
-        f.write(json.dumps(summary, ensure_ascii=False) + "\n")
-    return summary
-
-
-LIVE_ROWS = 400
-
-
-def rotate(path: Path, keep: int = LIVE_ROWS) -> None:
-    """The live file keeps the newest `keep` rows; older rows move to <name>.archive.jsonl, so every
-    reader that re-parses the live file per event stays bounded. Called with the writer lock held."""
-    try:
-        rows = path.read_text(encoding="utf-8").splitlines()
-    except OSError:
-        return
-    if len(rows) <= keep:
-        return
-    # One archive file per UTC day of the row's own timestamp, so a reader expanding an old card
-    # fetches one small immutable file, not the whole history; a torn row goes to the undated file.
-    by_day: dict[str, list[str]] = {}
-    for line in rows[:-keep]:
-        try:
-            ts = json.loads(line).get("ts")
-            day = day_of(ts) if isinstance(ts, (int, float)) else None
-        except (ValueError, AttributeError):
-            day = None
-        by_day.setdefault(day, []).append(line)
-    for day, lines in by_day.items():
-        name = f"{path.stem}.archive.{day}.jsonl" if day else f"{path.stem}.archive.jsonl"
-        with open(path.with_name(name), "a", encoding="utf-8") as arch:
-            arch.write("\n".join(lines) + "\n")
-    tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
-    tmp.write_text("\n".join(rows[-keep:]) + "\n", encoding="utf-8")
-    os.replace(tmp, path)
 
 
 def queued(task_file: Path, workspace: Path | None = None) -> int:

--- a/src/activity_bus.py
+++ b/src/activity_bus.py
@@ -205,7 +205,7 @@ class ActivityStore:
 
     def _default_project(self, row: dict) -> None:
         append_row(row["line"], kind=row["kind"], room=row["room"], task=row["task"], done=row["done"],
-                   workspace=self.ws, pid=row.get("pid"))
+                   workspace=self.ws, pid=row.get("pid"), ts=row.get("ts"))
 
     def path(self, task_id: str) -> Path:
         return self.dir / f"{task_id}.json"

--- a/src/activity_bus.py
+++ b/src/activity_bus.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""ActivityCard is the UI projection of a durable TaskRun state machine; runtime instrumentation
+only enriches that state machine with observations.
+
+Two vocabularies, never one enum: TaskPhase is the state machine the scheduler owns
+(RECEIVED → QUEUED → RUNNING ↔ WAITING → COMPLETED | FAILED | CANCELLED, terminal phases sticky);
+RuntimeEvent is an observation a provider made (a hook, a pane observer, a heartbeat, an app
+server). Only `reduce()` turns an observation into a phase change. State is the source of truth;
+the rows the client renders, the snapshot file and any later server stream are projections of it.
+
+Dedup is by key, not by "does a row of this phase exist": a lifecycle transition by
+(task_id, generation, from_phase, to_phase), a runtime event by (activity_session_id, seq).
+A task legitimately runs RUNNING → WAITING → RUNNING many times; each is its own generation.
+"""
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Callable
+
+from activity_rows import append as append_row
+from workspace_default import resolve_workspace
+
+PHASES = ("RECEIVED", "QUEUED", "RUNNING", "WAITING", "COMPLETED", "FAILED", "CANCELLED")
+TERMINAL = frozenset({"COMPLETED", "FAILED", "CANCELLED"})
+TRANSITIONS: dict[str, frozenset[str]] = {
+    "RECEIVED": frozenset({"QUEUED", "RUNNING", "FAILED", "CANCELLED"}),
+    "QUEUED": frozenset({"RUNNING", "FAILED", "CANCELLED"}),
+    "RUNNING": frozenset({"WAITING", "COMPLETED", "FAILED", "CANCELLED"}),
+    "WAITING": frozenset({"RUNNING", "COMPLETED", "FAILED", "CANCELLED"}),
+}
+EVENT_KINDS = ("Status", "Thinking", "Working", "ToolStarted", "ToolFinished",
+               "InteractionRequired", "Heartbeat", "RuntimeStarted", "RuntimeStopped")
+
+
+@dataclass
+class TaskActivityState:
+    """The durable TaskRun. Everything the card shows derives from this, never the reverse."""
+
+    task_id: str
+    phase: str = "RECEIVED"
+    generation: int = 0  # bumps each time the task enters RUNNING: one per run
+    seq: int = 0  # last runtime-event sequence applied, across sessions
+    message_event_id: str | None = None
+    room: str | None = None
+    sender: str | None = None
+    text: str | None = None
+    activity_session_id: str | None = None
+    worker: str | None = None
+    started_at: float | None = None
+    last_activity_at: float | None = None
+    summary: str = ""
+    into: str | None = None  # a consolidated reply: the holder message's event id
+    applied: list[str] = field(default_factory=list)
+    sessions: dict[str, int] = field(default_factory=dict)
+    telemetry: int = 0
+
+
+@dataclass(frozen=True)
+class LifecycleTransition:
+    task_id: str
+    to_phase: str
+    from_phase: str | None = None  # None = whatever the state is in now
+    generation: int | None = None  # None = the state's current generation
+    ts: float | None = None
+    reason: str = ""
+    message_event_id: str | None = None
+    room: str | None = None
+    sender: str | None = None
+    text: str | None = None
+    worker: str | None = None
+    into: str | None = None
+
+    def key(self, state: TaskActivityState) -> str:
+        gen = self.generation if self.generation is not None else state.generation
+        frm = self.from_phase or state.phase
+        return f"{self.task_id}:{gen}:{frm}:{self.to_phase}"
+
+
+@dataclass(frozen=True)
+class RuntimeEvent:
+    task_id: str
+    activity_session_id: str
+    seq: int
+    kind: str
+    ts: float | None = None
+    text: str = ""
+    tool: str | None = None
+    requirement_id: str | None = None
+
+
+def _task_dict(state: TaskActivityState) -> dict:
+    t: dict = {"id": state.task_id}
+    if state.sender:
+        t["from"] = state.sender
+    if state.text:
+        t["text"] = state.text
+    if state.message_event_id:
+        t["event"] = state.message_event_id
+    if state.into:
+        t["into"] = state.into
+    return t
+
+
+def _row(state: TaskActivityState, kind: str, line: str, ts: float, done: bool = False) -> dict:
+    return {"kind": kind, "line": line, "ts": ts, "room": state.room, "task": _task_dict(state), "done": done}
+
+
+_PHASE_ROW = {
+    "QUEUED": ("notice", "queued"),
+    "RUNNING": ("processing", "picked up"),
+    "WAITING": ("notice", "waiting for you"),
+    "COMPLETED": ("done", "replied"),
+    "FAILED": ("done", "failed"),
+    "CANCELLED": ("done", "cancelled"),
+}
+
+
+def reduce(state: TaskActivityState, item: LifecycleTransition | RuntimeEvent) -> tuple[TaskActivityState, list[dict]]:
+    """Pure: returns the next state and the rows that project this step. Duplicates and
+    out-of-order items change nothing; a terminal phase never regresses."""
+    now = item.ts if item.ts is not None else time.time()
+    rows: list[dict] = []
+    if isinstance(item, LifecycleTransition):
+        key = item.key(state)
+        if key in state.applied:
+            return state, rows
+        frm = item.from_phase or state.phase
+        if frm != state.phase or state.phase in TERMINAL or item.to_phase not in TRANSITIONS.get(state.phase, frozenset()):
+            # Not a valid move from where the task is: a stale or replayed transition. Telemetry only.
+            state.telemetry += 1
+            return state, rows
+        for f in ("message_event_id", "room", "sender", "text", "worker", "into"):
+            v = getattr(item, f)
+            if v:
+                setattr(state, f, v)
+        if item.to_phase == "RUNNING":
+            state.generation += 1
+        state.applied.append(key)
+        state.phase = item.to_phase
+        state.last_activity_at = now
+        if state.started_at is None and item.to_phase in ("RUNNING", "QUEUED"):
+            state.started_at = now
+        if item.reason:
+            state.summary = item.reason
+        kind, line = _PHASE_ROW[item.to_phase]
+        if item.to_phase == "COMPLETED" and state.into:
+            line = "consolidated"
+        elif item.reason and item.to_phase in TERMINAL:
+            line = f"{line}: {item.reason}" if item.to_phase != "COMPLETED" else item.reason
+        rows.append(_row(state, kind, line, now, done=item.to_phase in TERMINAL))
+        return state, rows
+    # a runtime observation
+    last = state.sessions.get(item.activity_session_id, 0)
+    if item.seq <= last:
+        return state, rows  # duplicate or out of order: the later seq already won
+    state.sessions[item.activity_session_id] = item.seq
+    state.seq = max(state.seq, item.seq)
+    if item.kind not in EVENT_KINDS:
+        return state, rows
+    if state.phase in TERMINAL:
+        state.telemetry += 1  # a late hook event after the end is kept, never reopens the task
+        return state, rows
+    state.last_activity_at = now
+    state.activity_session_id = state.activity_session_id or item.activity_session_id
+    if item.kind == "RuntimeStarted" and state.phase in ("RECEIVED", "QUEUED", "WAITING"):
+        state, more = reduce(state, LifecycleTransition(state.task_id, "RUNNING", ts=now, reason=item.text))
+        rows += more
+    elif item.kind == "InteractionRequired" and state.phase == "RUNNING":
+        state, more = reduce(state, LifecycleTransition(state.task_id, "WAITING", ts=now, reason=item.text))
+        rows += more
+    elif item.kind in ("Working", "ToolStarted") and state.phase == "WAITING":
+        state, more = reduce(state, LifecycleTransition(state.task_id, "RUNNING", ts=now))
+        rows += more
+    if item.kind in ("Working", "ToolStarted") and item.text:
+        state.summary = item.text
+        rows.append(_row(state, "working", item.text, now))
+    elif item.kind == "Thinking" and item.text:
+        rows.append(_row(state, "thinking", item.text, now))
+    elif item.kind == "Status" and item.text:
+        rows.append(_row(state, "notice", item.text, now))
+    # Heartbeat, ToolFinished, RuntimeStopped: liveness only. A provider that stops is not a
+    # failure; the scheduler decides FAILED, never an observation's absence.
+    return state, rows
+
+
+class ActivityStore:
+    """Snapshots under <workspace>/state/activity/<task_id>.json (atomic replace) and the row
+    projection through the one row writer. Restart-safe: the snapshot IS the task."""
+
+    def __init__(self, workspace: Path | None = None, project: Callable[[dict], None] | None = None):
+        self.ws = workspace or resolve_workspace()
+        self.dir = self.ws / "state" / "activity"
+        self.project = project if project is not None else self._default_project
+
+    def _default_project(self, row: dict) -> None:
+        append_row(row["line"], kind=row["kind"], room=row["room"], task=row["task"], done=row["done"],
+                   workspace=self.ws)
+
+    def path(self, task_id: str) -> Path:
+        return self.dir / f"{task_id}.json"
+
+    def load(self, task_id: str) -> TaskActivityState:
+        try:
+            d = json.loads(self.path(task_id).read_text(encoding="utf-8"))
+            return TaskActivityState(**{k: v for k, v in d.items() if k in TaskActivityState.__dataclass_fields__})
+        except (OSError, ValueError, TypeError):
+            return TaskActivityState(task_id=task_id)
+
+    def save(self, state: TaskActivityState) -> None:
+        self.dir.mkdir(parents=True, exist_ok=True)
+        p = self.path(state.task_id)
+        tmp = p.with_name(f".{p.name}.{os.getpid()}.tmp")
+        tmp.write_text(json.dumps(asdict(state), ensure_ascii=False), encoding="utf-8")
+        os.replace(tmp, p)
+
+    def apply(self, item: LifecycleTransition | RuntimeEvent) -> TaskActivityState:
+        """Load → reduce → save → project, under one lock per task so two emitters serialize."""
+        self.dir.mkdir(parents=True, exist_ok=True)
+        with open(self.dir / f".{item.task_id}.lock", "w") as lk:
+            fcntl.flock(lk, fcntl.LOCK_EX)
+            state = self.load(item.task_id)
+            state, rows = reduce(state, item)
+            self.save(state)
+        for row in rows:
+            self.project(row)
+        return state

--- a/src/activity_bus.py
+++ b/src/activity_bus.py
@@ -205,7 +205,8 @@ class ActivityStore:
 
     def _default_project(self, row: dict) -> None:
         append_row(row["line"], kind=row["kind"], room=row["room"], task=row["task"], done=row["done"],
-                   workspace=self.ws, pid=row.get("pid"), ts=row.get("ts"))
+                   workspace=self.ws, pid=row.get("pid"), ts=row.get("ts"),
+                   replay=int(row.get("attempts", 0)) > 1)
 
     def path(self, task_id: str) -> Path:
         return self.dir / f"{task_id}.json"
@@ -244,6 +245,9 @@ class ActivityStore:
         """Project every owed row in order; stop at the first failure and persist what is still owed."""
         while state.pending:
             row = state.pending[0]
+            # The attempt is recorded and saved BEFORE projecting, so a retry knows it is a replay.
+            row["attempts"] = int(row.get("attempts", 0)) + 1
+            self.save(state)
             try:
                 self.project(row)
             except Exception:  # noqa: BLE001 - the rows stay owed; the caller must not fail

--- a/src/activity_bus.py
+++ b/src/activity_bus.py
@@ -45,6 +45,7 @@ class TaskActivityState:
     phase: str = "RECEIVED"
     generation: int = 0  # bumps each time the task enters RUNNING: one per run
     seq: int = 0  # last runtime-event sequence applied, across sessions
+    emitted: int = 0
     message_event_id: str | None = None
     room: str | None = None
     sender: str | None = None
@@ -108,7 +109,11 @@ def _task_dict(state: TaskActivityState) -> dict:
 
 
 def _row(state: TaskActivityState, kind: str, line: str, ts: float, done: bool = False) -> dict:
-    return {"kind": kind, "line": line, "ts": ts, "room": state.room, "task": _task_dict(state), "done": done}
+    # The pid rides in the snapshot's pending list, so a replay projects the same identity again
+    # and the row writer applies it once.
+    state.emitted += 1
+    return {"kind": kind, "line": line, "ts": ts, "room": state.room, "task": _task_dict(state), "done": done,
+            "pid": f"{state.task_id}:{state.generation}:{state.emitted}"}
 
 
 _PHASE_ROW = {
@@ -200,7 +205,7 @@ class ActivityStore:
 
     def _default_project(self, row: dict) -> None:
         append_row(row["line"], kind=row["kind"], room=row["room"], task=row["task"], done=row["done"],
-                   workspace=self.ws)
+                   workspace=self.ws, pid=row.get("pid"))
 
     def path(self, task_id: str) -> Path:
         return self.dir / f"{task_id}.json"

--- a/src/activity_bus.py
+++ b/src/activity_bus.py
@@ -55,6 +55,7 @@ class TaskActivityState:
     last_activity_at: float | None = None
     summary: str = ""
     into: str | None = None  # a consolidated reply: the holder message's event id
+    pending: list[dict] = field(default_factory=list)  # rows reduced but not yet projected
     applied: list[str] = field(default_factory=list)
     sessions: dict[str, int] = field(default_factory=dict)
     telemetry: int = 0
@@ -219,13 +220,29 @@ class ActivityStore:
         os.replace(tmp, p)
 
     def apply(self, item: LifecycleTransition | RuntimeEvent) -> TaskActivityState:
-        """Load → reduce → save → project, under one lock per task so two emitters serialize."""
+        """Load → drain → reduce → save (rows pending) → project → save (drained), all under one lock
+        per task, so two emitters serialize their rows as well as their transitions. A projection
+        that fails leaves its rows pending in the snapshot; the next apply on that task drains them
+        first, so a row is projected exactly once, later, never lost and never twice."""
         self.dir.mkdir(parents=True, exist_ok=True)
         with open(self.dir / f".{item.task_id}.lock", "w") as lk:
             fcntl.flock(lk, fcntl.LOCK_EX)
             state = self.load(item.task_id)
+            self._drain(state)
             state, rows = reduce(state, item)
-            self.save(state)
-        for row in rows:
-            self.project(row)
+            state.pending = list(state.pending) + rows
+            self.save(state)  # the transition is committed with its rows still owed
+            self._drain(state)
         return state
+
+    def _drain(self, state: TaskActivityState) -> None:
+        """Project every owed row in order; stop at the first failure and persist what is still owed."""
+        while state.pending:
+            row = state.pending[0]
+            try:
+                self.project(row)
+            except Exception:  # noqa: BLE001 - the rows stay owed; the caller must not fail
+                self.save(state)
+                return
+            state.pending = state.pending[1:]
+            self.save(state)

--- a/src/activity_rows.py
+++ b/src/activity_rows.py
@@ -110,6 +110,24 @@ def _ack_close(workspace: Path | None, task_id: str) -> None:
         pass
 
 
+def _pid_in_archive(workspace: Path | None, pid: str, ts: float) -> bool:
+    """A landed row whose acknowledgement never landed: once rotated, its only memory is the archive
+    day file its own timestamp names (rotate() files by the row's ts)."""
+    live = log_path(workspace)
+    for name in (f"{live.stem}.archive.{day_of(ts)}.jsonl", f"{live.stem}.archive.jsonl"):
+        if _pid_in_log(live.with_name(name), pid):
+            return True
+    return False
+
+
+def _oldest_live_ts(path: Path) -> float | None:
+    try:
+        first = path.read_text(encoding="utf-8").split("\n", 1)[0]
+        return float(json.loads(first).get("ts")) if first.strip() else None
+    except (OSError, ValueError, TypeError):
+        return None
+
+
 def _pid_in_log(path: Path, pid: str) -> bool:
     try:
         return any(json.loads(l).get("pid") == pid for l in path.read_text(encoding="utf-8").splitlines() if l.strip())
@@ -119,12 +137,12 @@ def _pid_in_log(path: Path, pid: str) -> bool:
 
 def append(line: str, *, kind: str, room: str | None, task: dict | None = None,
            done: bool = False, workspace: Path | None = None, live_rows: int | None = None,
-           pid: str | None = None) -> dict:
+           pid: str | None = None, ts: float | None = None) -> dict:
     """`pid` is the row's stable projection identity: a replay after a partial write (row appended,
     index or summary not) is applied exactly once, each half checking what already landed."""
     if kind not in KINDS:
         raise ValueError(f"kind must be one of {KINDS}")
-    rec: dict = {"ts": time.time(), "line": line.strip(), "kind": kind}
+    rec: dict = {"ts": ts if ts is not None else time.time(), "line": line.strip(), "kind": kind}
     if pid:
         rec["pid"] = pid
     if room:
@@ -142,7 +160,9 @@ def append(line: str, *, kind: str, room: str | None, task: dict | None = None,
         task_id = task.get("id") if isinstance(task, dict) and isinstance(task.get("id"), str) else None
         acked = bool(pid and task_id and (_pid_acked(workspace, task_id, pid)
                                           or (done and _pid_in_log(summaries_path(workspace), pid))))
-        if not (pid and (acked or _pid_in_log(path, pid))):
+        oldest = _oldest_live_ts(path) if pid and not acked else None
+        rotated = oldest is not None and rec["ts"] < oldest and _pid_in_archive(workspace, pid, rec["ts"])
+        if not (pid and (acked or rotated or _pid_in_log(path, pid))):
             with open(path, "a", encoding="utf-8") as f:
                 f.write(json.dumps(rec, ensure_ascii=False) + "\n")
             if pid and task_id:

--- a/src/activity_rows.py
+++ b/src/activity_rows.py
@@ -82,11 +82,23 @@ def default_room(workspace: Path | None = None) -> str | None:
     return d.get("channel_id") if d.get("channel") == "ag2space" else None
 
 
+def _pid_in_log(path: Path, pid: str) -> bool:
+    try:
+        return any(json.loads(l).get("pid") == pid for l in path.read_text(encoding="utf-8").splitlines() if l.strip())
+    except (OSError, ValueError):
+        return False
+
+
 def append(line: str, *, kind: str, room: str | None, task: dict | None = None,
-           done: bool = False, workspace: Path | None = None, live_rows: int | None = None) -> dict:
+           done: bool = False, workspace: Path | None = None, live_rows: int | None = None,
+           pid: str | None = None) -> dict:
+    """`pid` is the row's stable projection identity: a replay after a partial write (row appended,
+    index or summary not) is applied exactly once, each half checking what already landed."""
     if kind not in KINDS:
         raise ValueError(f"kind must be one of {KINDS}")
     rec: dict = {"ts": time.time(), "line": line.strip(), "kind": kind}
+    if pid:
+        rec["pid"] = pid
     if room:
         rec["room"] = room
     if task:
@@ -99,13 +111,16 @@ def append(line: str, *, kind: str, room: str | None, task: dict | None = None,
     # an inode that a concurrent rotation replaces.
     with open(path.with_suffix(".lock"), "w") as lk:
         fcntl.flock(lk, fcntl.LOCK_EX)
-        with open(path, "a", encoding="utf-8") as f:
-            f.write(json.dumps(rec, ensure_ascii=False) + "\n")
+        if not (pid and _pid_in_log(path, pid)):
+            with open(path, "a", encoding="utf-8") as f:
+                f.write(json.dumps(rec, ensure_ascii=False) + "\n")
         if task and isinstance(task.get("id"), str):
             ip = index_path(workspace)
             idx = _load_index(ip)
             e = idx.get(task["id"]) or {"started": rec["ts"], "rows": 0, "task": task, "room": room}
-            e["rows"] = int(e.get("rows", 0)) + 1
+            if not (pid and e.get("last_pid") == pid):
+                e["rows"] = int(e.get("rows", 0)) + 1
+                e["last_pid"] = pid
             e["started"] = min(float(e.get("started", rec["ts"])), rec["ts"])
             e["task"] = dict(e.get("task") or {}, **task)
             if room:
@@ -129,7 +144,11 @@ def summarize(done_rec: dict, entry: dict, workspace: Path | None = None) -> dic
                "days": day_range(started, done_rec["ts"]), "line": done_rec["line"], "task": done_rec["task"]}
     if done_rec.get("room"):
         summary["room"] = done_rec["room"]
+    if done_rec.get("pid"):
+        summary["pid"] = done_rec["pid"]
     sp = summaries_path(workspace)
+    if done_rec.get("pid") and sp.exists() and _pid_in_log(sp, done_rec["pid"]):
+        return summary  # this done row's summary already landed: a replay writes nothing
     with open(sp, "a", encoding="utf-8") as f:
         f.write(json.dumps(summary, ensure_ascii=False) + "\n")
     return summary

--- a/src/activity_rows.py
+++ b/src/activity_rows.py
@@ -82,26 +82,30 @@ def default_room(workspace: Path | None = None) -> str | None:
     return d.get("channel_id") if d.get("channel") == "ag2space" else None
 
 
-def acks_path(workspace: Path | None = None) -> Path:
-    """Projection ids the writer has applied, one per line: the sink's acknowledgement, kept apart
-    from the rotating live log so a replay after rotation is still recognised."""
+def acks_dir(workspace: Path | None = None) -> Path:
+    """Per task, the projection ids the writer has applied — the sink's acknowledgement, kept apart
+    from the rotating live log and per task so unrelated traffic can never evict an owed row's ack."""
     return log_path(workspace).with_name("agent-activity.acks")
 
 
-def _pid_acked(path: Path, pid: str) -> bool:
+def _pid_acked(workspace: Path | None, task_id: str, pid: str) -> bool:
     try:
-        return pid in path.read_text(encoding="utf-8").split("\n")
+        return pid in (acks_dir(workspace) / task_id).read_text(encoding="utf-8").split("\n")
     except OSError:
         return False
 
 
-def _ack(path: Path, pid: str, keep: int = 5000) -> None:
-    with open(path, "a", encoding="utf-8") as f:
+def _ack(workspace: Path | None, task_id: str, pid: str) -> None:
+    d = acks_dir(workspace)
+    d.mkdir(parents=True, exist_ok=True)
+    with open(d / task_id, "a", encoding="utf-8") as f:
         f.write(pid + "\n")
+
+
+def _ack_close(workspace: Path | None, task_id: str) -> None:
+    """The task is done: its summary carries the done pid, so the per-task file can go."""
     try:
-        lines = path.read_text(encoding="utf-8").split("\n")
-        if len(lines) > keep + 1000:
-            path.write_text("\n".join(lines[-keep:]) + "\n", encoding="utf-8")
+        (acks_dir(workspace) / task_id).unlink()
     except OSError:
         pass
 
@@ -135,11 +139,14 @@ def append(line: str, *, kind: str, room: str | None, task: dict | None = None,
     # an inode that a concurrent rotation replaces.
     with open(path.with_suffix(".lock"), "w") as lk:
         fcntl.flock(lk, fcntl.LOCK_EX)
-        if not (pid and (_pid_acked(acks_path(workspace), pid) or _pid_in_log(path, pid))):
+        task_id = task.get("id") if isinstance(task, dict) and isinstance(task.get("id"), str) else None
+        acked = bool(pid and task_id and (_pid_acked(workspace, task_id, pid)
+                                          or (done and _pid_in_log(summaries_path(workspace), pid))))
+        if not (pid and (acked or _pid_in_log(path, pid))):
             with open(path, "a", encoding="utf-8") as f:
                 f.write(json.dumps(rec, ensure_ascii=False) + "\n")
-            if pid:
-                _ack(acks_path(workspace), pid)
+            if pid and task_id:
+                _ack(workspace, task_id, pid)
         if task and isinstance(task.get("id"), str):
             ip = index_path(workspace)
             idx = _load_index(ip)
@@ -154,6 +161,7 @@ def append(line: str, *, kind: str, room: str | None, task: dict | None = None,
             if done:
                 idx.pop(task["id"], None)
                 summarize(rec, e, workspace)
+                _ack_close(workspace, task["id"])
             else:
                 idx[task["id"]] = e
             _save_index(ip, idx)

--- a/src/activity_rows.py
+++ b/src/activity_rows.py
@@ -130,7 +130,7 @@ def _pid_in_log(path: Path, pid: str) -> bool:
 
 def append(line: str, *, kind: str, room: str | None, task: dict | None = None,
            done: bool = False, workspace: Path | None = None, live_rows: int | None = None,
-           pid: str | None = None, ts: float | None = None) -> dict:
+           pid: str | None = None, ts: float | None = None, replay: bool = False) -> dict:
     """`pid` is the row's stable projection identity: a replay after a partial write (row appended,
     index or summary not) is applied exactly once, each half checking what already landed."""
     if kind not in KINDS:
@@ -153,9 +153,9 @@ def append(line: str, *, kind: str, room: str | None, task: dict | None = None,
         task_id = task.get("id") if isinstance(task, dict) and isinstance(task.get("id"), str) else None
         acked = bool(pid and task_id and (_pid_acked(workspace, task_id, pid)
                                           or (done and _pid_in_log(summaries_path(workspace), pid))))
-        # No ordering heuristic: an unacknowledged row absent from the live log is looked up in the
-        # archive file its own timestamp names — exact, and a fresh row only pays for a small read.
-        landed = bool(pid) and (acked or _pid_in_log(path, pid) or _pid_in_archive(workspace, pid, rec["ts"]))
+        # Only a replay (the bus retrying an owed row) consults the archive: exact for recovery, and a
+        # fresh row never reads the day file under the lock.
+        landed = bool(pid) and (acked or _pid_in_log(path, pid) or (replay and _pid_in_archive(workspace, pid, rec["ts"])))
         if not landed:
             with open(path, "a", encoding="utf-8") as f:
                 f.write(json.dumps(rec, ensure_ascii=False) + "\n")

--- a/src/activity_rows.py
+++ b/src/activity_rows.py
@@ -82,6 +82,30 @@ def default_room(workspace: Path | None = None) -> str | None:
     return d.get("channel_id") if d.get("channel") == "ag2space" else None
 
 
+def acks_path(workspace: Path | None = None) -> Path:
+    """Projection ids the writer has applied, one per line: the sink's acknowledgement, kept apart
+    from the rotating live log so a replay after rotation is still recognised."""
+    return log_path(workspace).with_name("agent-activity.acks")
+
+
+def _pid_acked(path: Path, pid: str) -> bool:
+    try:
+        return pid in path.read_text(encoding="utf-8").split("\n")
+    except OSError:
+        return False
+
+
+def _ack(path: Path, pid: str, keep: int = 5000) -> None:
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(pid + "\n")
+    try:
+        lines = path.read_text(encoding="utf-8").split("\n")
+        if len(lines) > keep + 1000:
+            path.write_text("\n".join(lines[-keep:]) + "\n", encoding="utf-8")
+    except OSError:
+        pass
+
+
 def _pid_in_log(path: Path, pid: str) -> bool:
     try:
         return any(json.loads(l).get("pid") == pid for l in path.read_text(encoding="utf-8").splitlines() if l.strip())
@@ -111,9 +135,11 @@ def append(line: str, *, kind: str, room: str | None, task: dict | None = None,
     # an inode that a concurrent rotation replaces.
     with open(path.with_suffix(".lock"), "w") as lk:
         fcntl.flock(lk, fcntl.LOCK_EX)
-        if not (pid and _pid_in_log(path, pid)):
+        if not (pid and (_pid_acked(acks_path(workspace), pid) or _pid_in_log(path, pid))):
             with open(path, "a", encoding="utf-8") as f:
                 f.write(json.dumps(rec, ensure_ascii=False) + "\n")
+            if pid:
+                _ack(acks_path(workspace), pid)
         if task and isinstance(task.get("id"), str):
             ip = index_path(workspace)
             idx = _load_index(ip)

--- a/src/activity_rows.py
+++ b/src/activity_rows.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""The agent-activity row writer: one JSON row per line at <workspace>/state/agent-activity.jsonl,
+the live window the desktop renders, its per-day archive, the per-task index that keeps a summary
+exact after rotation, and the summary left at done.
+
+One owner: the agent-activity skill's CLI and the activity bus both write through here, so the
+lock, the rotation, the index and the summary cannot drift between them. Row shape is the contract
+the client reads: {"ts", "room", "line", "kind", "task": {"id","from","text","event","into"}, "done"}.
+"""
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import time
+from pathlib import Path
+
+from workspace_default import resolve_workspace
+
+KINDS = ("processing", "thinking", "working", "notice", "done")
+TEXT_MAX = 160
+LIVE_ROWS = 400
+
+
+def log_path(workspace: Path | None = None) -> Path:
+    return (workspace or resolve_workspace()) / "state" / "agent-activity.jsonl"
+
+
+def summaries_path(workspace: Path | None = None) -> Path:
+    """One line per finished task: what the folded card shows after the task's rows have left the
+    live log. Never rotated; ~200 bytes a task."""
+    return (workspace or resolve_workspace()) / "state" / "agent-activity.summaries.jsonl"
+
+
+def day_of(ts: float) -> str:
+    return time.strftime("%Y-%m-%d", time.gmtime(ts))
+
+
+def index_path(workspace: Path | None = None) -> Path:
+    """Per open task: {task, room, started, rows, days}. Updated on every append under the writer
+    lock, so a summary is exact after any rotation; an entry leaves when its task is summarized."""
+    return (workspace or resolve_workspace()) / "state" / "agent-activity.index.json"
+
+
+def _load_index(path: Path) -> dict:
+    try:
+        d = json.loads(path.read_text(encoding="utf-8"))
+        return d if isinstance(d, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def _save_index(path: Path, d: dict) -> None:
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    tmp.write_text(json.dumps(d, ensure_ascii=False), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def day_range(start_ts: float, end_ts: float) -> list[str]:
+    """Every UTC day from start to end inclusive: the complete list of archive files that can hold
+    a row of the span, never just its two ends."""
+    out, t = [], start_ts
+    while day_of(t) <= day_of(end_ts):
+        out.append(day_of(t))
+        t += 86400
+    return out
+
+
+def open_task_index(workspace: Path | None = None) -> dict:
+    """The tasks the index still holds open: what the hook falls back to when a task's rows have
+    rotated out of the live log but its result now exists."""
+    return _load_index(index_path(workspace))
+
+
+def default_room(workspace: Path | None = None) -> str | None:
+    """The room of the owner's latest AG2 Space message; a row with no room shows only in the dock."""
+    p = (workspace or resolve_workspace()) / "state" / "last-owner-activity.json"
+    try:
+        d = json.loads(p.read_text())
+    except (OSError, ValueError):
+        return None
+    return d.get("channel_id") if d.get("channel") == "ag2space" else None
+
+
+def append(line: str, *, kind: str, room: str | None, task: dict | None = None,
+           done: bool = False, workspace: Path | None = None, live_rows: int | None = None) -> dict:
+    if kind not in KINDS:
+        raise ValueError(f"kind must be one of {KINDS}")
+    rec: dict = {"ts": time.time(), "line": line.strip(), "kind": kind}
+    if room:
+        rec["room"] = room
+    if task:
+        rec["task"] = task
+    if done:
+        rec["done"] = True
+    path = log_path(workspace)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # One lock for the append AND the rotation; the log is opened only under it, so no writer holds
+    # an inode that a concurrent rotation replaces.
+    with open(path.with_suffix(".lock"), "w") as lk:
+        fcntl.flock(lk, fcntl.LOCK_EX)
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(rec, ensure_ascii=False) + "\n")
+        if task and isinstance(task.get("id"), str):
+            ip = index_path(workspace)
+            idx = _load_index(ip)
+            e = idx.get(task["id"]) or {"started": rec["ts"], "rows": 0, "task": task, "room": room}
+            e["rows"] = int(e.get("rows", 0)) + 1
+            e["started"] = min(float(e.get("started", rec["ts"])), rec["ts"])
+            e["task"] = dict(e.get("task") or {}, **task)
+            if room:
+                e["room"] = room
+            if done:
+                idx.pop(task["id"], None)
+                summarize(rec, e, workspace)
+            else:
+                idx[task["id"]] = e
+            _save_index(ip, idx)
+        rotate(path, live_rows if live_rows is not None else LIVE_ROWS)
+    return rec
+
+
+def summarize(done_rec: dict, entry: dict, workspace: Path | None = None) -> dict:
+    """Append the task's durable summary from the index entry — exact whether or not its rows have
+    rotated out — with `days` as every UTC day of the span, the complete archive fetch list.
+    Called with the writer lock held."""
+    started = float(entry.get("started", done_rec["ts"]))
+    summary = {"ts": done_rec["ts"], "started": started, "rows": max(int(entry.get("rows", 1)), 1),
+               "days": day_range(started, done_rec["ts"]), "line": done_rec["line"], "task": done_rec["task"]}
+    if done_rec.get("room"):
+        summary["room"] = done_rec["room"]
+    sp = summaries_path(workspace)
+    with open(sp, "a", encoding="utf-8") as f:
+        f.write(json.dumps(summary, ensure_ascii=False) + "\n")
+    return summary
+
+
+def rotate(path: Path, keep: int = LIVE_ROWS) -> None:
+    """The live file keeps the newest `keep` rows; older rows move to <name>.archive.jsonl, so every
+    reader that re-parses the live file per event stays bounded. Called with the writer lock held."""
+    try:
+        rows = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return
+    if len(rows) <= keep:
+        return
+    # One archive file per UTC day of the row's own timestamp, so a reader expanding an old card
+    # fetches one small immutable file, not the whole history; a torn row goes to the undated file.
+    by_day: dict[str, list[str]] = {}
+    for line in rows[:-keep]:
+        try:
+            ts = json.loads(line).get("ts")
+            day = day_of(ts) if isinstance(ts, (int, float)) else None
+        except (ValueError, AttributeError):
+            day = None
+        by_day.setdefault(day, []).append(line)
+    for day, lines in by_day.items():
+        name = f"{path.stem}.archive.{day}.jsonl" if day else f"{path.stem}.archive.jsonl"
+        with open(path.with_name(name), "a", encoding="utf-8") as arch:
+            arch.write("\n".join(lines) + "\n")
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    tmp.write_text("\n".join(rows[-keep:]) + "\n", encoding="utf-8")
+    os.replace(tmp, path)

--- a/src/activity_rows.py
+++ b/src/activity_rows.py
@@ -120,13 +120,6 @@ def _pid_in_archive(workspace: Path | None, pid: str, ts: float) -> bool:
     return False
 
 
-def _oldest_live_ts(path: Path) -> float | None:
-    try:
-        first = path.read_text(encoding="utf-8").split("\n", 1)[0]
-        return float(json.loads(first).get("ts")) if first.strip() else None
-    except (OSError, ValueError, TypeError):
-        return None
-
 
 def _pid_in_log(path: Path, pid: str) -> bool:
     try:
@@ -160,9 +153,10 @@ def append(line: str, *, kind: str, room: str | None, task: dict | None = None,
         task_id = task.get("id") if isinstance(task, dict) and isinstance(task.get("id"), str) else None
         acked = bool(pid and task_id and (_pid_acked(workspace, task_id, pid)
                                           or (done and _pid_in_log(summaries_path(workspace), pid))))
-        oldest = _oldest_live_ts(path) if pid and not acked else None
-        rotated = oldest is not None and rec["ts"] < oldest and _pid_in_archive(workspace, pid, rec["ts"])
-        if not (pid and (acked or rotated or _pid_in_log(path, pid))):
+        # No ordering heuristic: an unacknowledged row absent from the live log is looked up in the
+        # archive file its own timestamp names — exact, and a fresh row only pays for a small read.
+        landed = bool(pid) and (acked or _pid_in_log(path, pid) or _pid_in_archive(workspace, pid, rec["ts"]))
+        if not landed:
             with open(path, "a", encoding="utf-8") as f:
                 f.write(json.dumps(rec, ensure_ascii=False) + "\n")
             if pid and task_id:

--- a/tests/activity-bus.test.py
+++ b/tests/activity-bus.test.py
@@ -287,6 +287,24 @@ class IdempotentProjection(unittest.TestCase):
             sums = [json.loads(l) for l in card.summaries_path(ws).read_text().splitlines()]
             self.assertEqual([x["rows"] for x in sums], [2], f"fault={fault}: the summary counts two rows, once")
 
+    def test_an_archived_unacked_row_is_found_whatever_the_live_windows_order(self):
+        # yixuan's residual: after a replayed old-ts row lands in the live log, any "older than the
+        # window" reading lies. The lookup must not depend on live order at all.
+        import activity_rows
+        t = {"id": "task-h1"}
+        with unittest.mock.patch.object(activity_rows, "_ack", lambda w, tid, pid: None):  # the ack never lands
+            card.append("picked up", kind="processing", room="!r:s", task=t, workspace=self.ws, pid="task-h1:1:1", ts=1_757_000_000.0)
+        for i in range(card.LIVE_ROWS + 1):
+            card.append(f"noise {i}", kind="notice", room=None, workspace=self.ws)
+        self.assertNotIn("task-h1", card.log_path(self.ws).read_text(), "precondition: the victim is archived")
+        # a replayed row with an ancient event ts now sits in the live window, both older and newer rows around it
+        card.append("old replay", kind="notice", room=None, task={"id": "task-o"}, workspace=self.ws, pid="task-o:1:1", ts=1.0)
+        card.append("picked up", kind="processing", room="!r:s", task=t, workspace=self.ws, pid="task-h1:1:1", ts=1_757_000_000.0)
+        history = "".join(p.read_text() for p in (self.ws / "state").glob("agent-activity*.jsonl") if "summaries" not in p.name)
+        self.assertEqual(history.count('"pid": "task-h1:1:1"'), 1, "found in the archive; not appended again")
+        card.append("fresh", kind="notice", room=None, task=t, workspace=self.ws, pid="task-h1:1:9")
+        self.assertEqual(card.log_path(self.ws).read_text().count('"pid": "task-h1:1:9"'), 1, "control: a new pid appends once")
+
     def test_a_replay_of_a_landed_row_leaves_the_index_count_exact(self):
         # The other half: index saved, then the drained snapshot save lost (a crash) — the same pid
         # projected again must not count the row twice.

--- a/tests/activity-bus.test.py
+++ b/tests/activity-bus.test.py
@@ -128,6 +128,34 @@ class Acceptance(unittest.TestCase):
         summary = json.loads(card.summaries_path(self.ws).read_text().splitlines()[-1])
         self.assertEqual((summary["task"]["id"], summary["rows"], summary["line"]), ("t5", 3, "replied"))
 
+    def test_a_failed_projection_is_retried_later_and_projected_exactly_once(self):
+        # Reviewer's case: the snapshot advanced but the row was lost when projecting raised.
+        projected = []
+        calls = {"n": 0}
+        def flaky(row):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise OSError("disk full")
+            projected.append(row["line"])
+        store = ActivityStore(self.ws, project=flaky)
+        st = store.apply(T("t7", "RUNNING", ts=1, message_event_id="$m"))
+        self.assertEqual((st.phase, projected, len(st.pending)), ("RUNNING", [], 1), "committed, row still owed")
+        st = store.apply(T("t7", "COMPLETED", ts=2))
+        self.assertEqual((st.phase, projected, st.pending), ("COMPLETED", ["picked up", "replied"], []))
+        # a restart with a healthy projector drains what an earlier process left owed
+        store.project = flaky
+        calls["n"] = 0; projected.clear()
+        st = store.apply(T("t8", "RUNNING", ts=1)); self.assertEqual(len(st.pending), 1)
+        fresh = ActivityStore(self.ws, project=lambda r: projected.append(r["line"]))
+        st = fresh.apply(E("t8", "S1", 1, "Heartbeat", ts=2))
+        self.assertEqual((projected, st.pending), (["picked up"], []), "exactly once, on the next apply")
+
+    def test_rows_are_projected_inside_the_task_lock(self):
+        import inspect
+        src = inspect.getsource(bus.ActivityStore.apply)
+        self.assertLess(src.index("self._drain(state)", src.index("self.save(state)")), src.index("return state"))
+        self.assertNotIn("\n        for row in rows:", src, "no projection after the lock block")
+
     def test_a_consolidated_completion_names_the_holder(self):
         st = self.store.apply(T("t6", "RUNNING", ts=1, message_event_id="$m"))
         st = self.store.apply(T("t6", "COMPLETED", ts=2, into="$holder"))

--- a/tests/activity-bus.test.py
+++ b/tests/activity-bus.test.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""The owner's acceptance tests for the activity bus (2026-09-06): the card stays truthful with no
+hook at all, a dead provider is not a failure, replays never regress a phase, and a restart
+reconstructs the run. Plus the state machine itself and the two dedup keys."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SRC = os.path.join(_HERE, "..", "src")
+sys.path.insert(0, _SRC)
+import activity_bus as bus  # noqa: E402
+from activity_bus import ActivityStore, LifecycleTransition as T, RuntimeEvent as E, TaskActivityState, reduce  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location("card", os.path.join(_HERE, "..", "skills", "agent-activity", "scripts", "activity.py"))
+card = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(card)
+
+
+def phases(rows):
+    return [(r["kind"], r["line"]) for r in rows]
+
+
+class StateMachine(unittest.TestCase):
+    def test_the_valid_transitions_and_only_those(self):
+        s = TaskActivityState("t")
+        for to in ("QUEUED", "RUNNING", "WAITING", "RUNNING", "COMPLETED"):
+            s, _ = reduce(s, T("t", to, ts=1))
+            self.assertEqual(s.phase, to)
+        self.assertEqual(s.generation, 2, "each entry into RUNNING is a generation")
+        s, rows = reduce(s, T("t", "RUNNING", ts=2))
+        self.assertEqual((s.phase, rows, s.telemetry), ("COMPLETED", [], 1), "a terminal phase is sticky")
+        s2, rows = reduce(TaskActivityState("u"), T("u", "WAITING", ts=1))
+        self.assertEqual((s2.phase, rows), ("RECEIVED", []), "RECEIVED cannot jump to WAITING")
+
+    def test_lifecycle_dedup_is_by_task_generation_from_to(self):
+        s = TaskActivityState("t")
+        s, r1 = reduce(s, T("t", "RUNNING", from_phase="RECEIVED", generation=0, ts=1))
+        s, r2 = reduce(s, T("t", "RUNNING", from_phase="RECEIVED", generation=0, ts=1))
+        self.assertEqual((len(r1), len(r2), s.generation), (1, 0, 1))
+        # RUNNING → WAITING → RUNNING again is legitimate: a new generation, a new row
+        s, _ = reduce(s, T("t", "WAITING", ts=2))
+        s, r3 = reduce(s, T("t", "RUNNING", ts=3))
+        self.assertEqual((len(r3), s.generation), (1, 2))
+
+    def test_runtime_dedup_is_by_session_and_seq(self):
+        s = TaskActivityState("t", phase="RUNNING", generation=1)
+        s, r1 = reduce(s, E("t", "S1", 1, "Working", text="Bash: tests", ts=1))
+        s, r2 = reduce(s, E("t", "S1", 1, "Working", text="Bash: tests", ts=1))  # duplicate
+        s, r3 = reduce(s, E("t", "S1", 3, "Working", text="Edit: x", ts=3))
+        s, r4 = reduce(s, E("t", "S1", 2, "Working", text="late", ts=2))  # out of order: dropped
+        self.assertEqual((len(r1), len(r2), len(r3), len(r4), s.seq), (1, 0, 1, 0, 3))
+        s, r5 = reduce(s, E("t", "S2", 1, "Working", text="other session", ts=4))
+        self.assertEqual(len(r5), 1, "a second session has its own sequence")
+
+
+class Acceptance(unittest.TestCase):
+    def setUp(self):
+        self.ws = Path(tempfile.mkdtemp())
+        (self.ws / "state").mkdir()
+        self.rows = []
+        self.store = ActivityStore(self.ws, project=self.rows.append)
+
+    def test_1_delete_every_hook_and_the_lifecycle_alone_is_truthful(self):
+        # No RuntimeEvent at all: the scheduler's transitions carry the card from start to finish.
+        self.store.apply(T("t1", "QUEUED", ts=1, message_event_id="$m", room="!r:s", sender="@q:s", text="Review PR"))
+        self.store.apply(T("t1", "RUNNING", ts=2))
+        st = self.store.apply(T("t1", "COMPLETED", ts=3))
+        self.assertEqual(phases(self.rows), [("notice", "queued"), ("processing", "picked up"), ("done", "replied")])
+        self.assertTrue(all(r["task"]["event"] == "$m" and r["room"] == "!r:s" for r in self.rows), "every row mounts under the message")
+        self.assertEqual((st.phase, st.generation, st.started_at), ("COMPLETED", 1, 1))
+
+    def test_2_a_provider_that_dies_halfway_leaves_the_task_running_not_failed(self):
+        self.store.apply(T("t2", "RUNNING", ts=1, message_event_id="$m"))
+        self.store.apply(E("t2", "S1", 1, "Working", text="Bash: build", ts=2))
+        st = self.store.apply(E("t2", "S1", 2, "RuntimeStopped", ts=3))
+        self.assertEqual(st.phase, "RUNNING", "an observation's absence is not a failure")
+        self.assertEqual(phases(self.rows)[-1], ("working", "Bash: build"))
+        st = self.store.apply(E("t2", "S1", 3, "Heartbeat", ts=4))
+        self.assertEqual((st.phase, st.last_activity_at), ("RUNNING", 4), "heartbeats keep it alive without a row")
+        self.assertEqual(len(self.rows), 2)
+
+    def test_3_duplicate_and_out_of_order_events_never_regress_the_phase(self):
+        self.store.apply(T("t3", "RUNNING", ts=1))
+        self.store.apply(E("t3", "S1", 5, "InteractionRequired", text="pick one", ts=2))
+        self.assertEqual(self.store.load("t3").phase, "WAITING")
+        self.store.apply(E("t3", "S1", 6, "Working", text="Edit: y", ts=3))
+        self.assertEqual(self.store.load("t3").phase, "RUNNING")
+        # a replay of the old InteractionRequired (seq 5) must not put it back into WAITING
+        self.store.apply(E("t3", "S1", 5, "InteractionRequired", text="pick one", ts=2))
+        st = self.store.apply(T("t3", "COMPLETED", ts=4))
+        self.assertEqual(st.phase, "COMPLETED")
+        st = self.store.apply(E("t3", "S1", 7, "Working", text="late hook", ts=5))
+        self.assertEqual((st.phase, st.telemetry), ("COMPLETED", 1), "a late event is telemetry, never a reopen")
+        first = json.dumps(bus.asdict(st), sort_keys=True)
+        st = self.store.apply(E("t3", "S1", 7, "Working", text="late hook", ts=5))
+        self.assertEqual(json.dumps(bus.asdict(st), sort_keys=True), first, "deterministic under replay")
+
+    def test_4_restart_during_running_reconstructs_the_task_without_a_second_run(self):
+        self.store.apply(T("t4", "QUEUED", ts=1, message_event_id="$m", room="!r:s"))
+        self.store.apply(E("t4", "S1", 1, "RuntimeStarted", ts=2))
+        self.store.apply(E("t4", "S1", 2, "Working", text="Read: file", ts=3))
+        before = self.store.load("t4")
+        # "restart": a fresh store over the same workspace knows the same run
+        fresh_rows = []
+        fresh = ActivityStore(self.ws, project=fresh_rows.append)
+        after = fresh.load("t4")
+        self.assertEqual((after.phase, after.generation, after.seq, after.message_event_id), ("RUNNING", 1, 2, "$m"))
+        self.assertEqual(bus.asdict(after), bus.asdict(before))
+        st = fresh.apply(E("t4", "S1", 3, "RuntimeStarted", ts=4))  # the resumed provider announces itself again
+        self.assertEqual((st.phase, st.generation, fresh_rows), ("RUNNING", 1, []), "no second run, no second row")
+
+    def test_5_the_default_projection_is_the_real_row_writer_and_leaves_a_summary(self):
+        real = ActivityStore(self.ws)
+        real.apply(T("t5", "QUEUED", ts=1, message_event_id="$m", room="!r:s", sender="@q:s", text="hi"))
+        real.apply(T("t5", "RUNNING", ts=2))
+        real.apply(T("t5", "COMPLETED", ts=3))
+        rows = [json.loads(l) for l in card.log_path(self.ws).read_text().splitlines()]
+        self.assertEqual([(r["kind"], r["line"], r.get("done", False)) for r in rows],
+                         [("notice", "queued", False), ("processing", "picked up", False), ("done", "replied", True)])
+        self.assertTrue(all(r["task"]["event"] == "$m" for r in rows))
+        summary = json.loads(card.summaries_path(self.ws).read_text().splitlines()[-1])
+        self.assertEqual((summary["task"]["id"], summary["rows"], summary["line"]), ("t5", 3, "replied"))
+
+    def test_a_consolidated_completion_names_the_holder(self):
+        st = self.store.apply(T("t6", "RUNNING", ts=1, message_event_id="$m"))
+        st = self.store.apply(T("t6", "COMPLETED", ts=2, into="$holder"))
+        self.assertEqual((self.rows[-1]["line"], self.rows[-1]["task"]["into"]), ("consolidated", "$holder"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/activity-bus.test.py
+++ b/tests/activity-bus.test.py
@@ -198,6 +198,31 @@ class IdempotentProjection(unittest.TestCase):
         self.assertEqual([(x["task"]["id"], x["rows"]) for x in sums], [("task-i1", 2)], "one summary, exact")
         self.assertNotIn("task-i1", card.open_task_index(self.ws))
 
+    def test_a_replay_after_rotation_is_still_applied_once(self):
+        # Reviewer's case: the owed row rotates into the day archive before recovery. The writer's
+        # acknowledgement ledger, not the rotating live log, is what recognises the replay.
+        import activity_rows
+        store = ActivityStore(self.ws)
+        store.apply(T("task-i3", "RUNNING", ts=1, message_event_id="$m"))
+        real = activity_rows._save_index; calls = {"n": 0}
+        def flaky(ip, idx):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise OSError("index disk full")
+            real(ip, idx)
+        with unittest.mock.patch.object(activity_rows, "_save_index", flaky):
+            store.apply(T("task-i3", "COMPLETED", ts=2))
+        for i in range(card.LIVE_ROWS + 1):
+            card.append(f"noise {i}", kind="notice", room=None, workspace=self.ws)
+        live = card.log_path(self.ws).read_text()
+        self.assertNotIn("task-i3", live, "precondition: the task's rows rotated into the archive")
+        fresh = ActivityStore(self.ws)
+        fresh.apply(T("task-i3", "COMPLETED", ts=2))  # the public entry point performs the recovery
+        history = "".join(p.read_text() for p in (self.ws / "state").glob("agent-activity*.jsonl") if "summaries" not in p.name)
+        self.assertEqual(history.count('"pid": "task-i3:1:2"'), 1, "the done row appears once across live + archive")
+        self.assertEqual(len(fresh.load("task-i3").pending), 0)
+        self.assertEqual(len(card.summaries_path(self.ws).read_text().splitlines()), 1)
+
     def test_a_replay_of_a_landed_row_leaves_the_index_count_exact(self):
         # The other half: index saved, then the drained snapshot save lost (a crash) — the same pid
         # projected again must not count the row twice.

--- a/tests/activity-bus.test.py
+++ b/tests/activity-bus.test.py
@@ -299,11 +299,36 @@ class IdempotentProjection(unittest.TestCase):
         self.assertNotIn("task-h1", card.log_path(self.ws).read_text(), "precondition: the victim is archived")
         # a replayed row with an ancient event ts now sits in the live window, both older and newer rows around it
         card.append("old replay", kind="notice", room=None, task={"id": "task-o"}, workspace=self.ws, pid="task-o:1:1", ts=1.0)
-        card.append("picked up", kind="processing", room="!r:s", task=t, workspace=self.ws, pid="task-h1:1:1", ts=1_757_000_000.0)
+        card.append("picked up", kind="processing", room="!r:s", task=t, workspace=self.ws, pid="task-h1:1:1", ts=1_757_000_000.0, replay=True)
         history = "".join(p.read_text() for p in (self.ws / "state").glob("agent-activity*.jsonl") if "summaries" not in p.name)
         self.assertEqual(history.count('"pid": "task-h1:1:1"'), 1, "found in the archive; not appended again")
         card.append("fresh", kind="notice", room=None, task=t, workspace=self.ws, pid="task-h1:1:9")
         self.assertEqual(card.log_path(self.ws).read_text().count('"pid": "task-h1:1:9"'), 1, "control: a new pid appends once")
+
+    def test_a_fresh_row_never_reads_the_archive(self):
+        # Bounded cost: the archive is consulted only on a replay. Fresh bus rows and hook rows pay
+        # the live-log read they always paid, and nothing more, however large the day file grows.
+        import activity_rows
+        calls = {"n": 0}; real = activity_rows._pid_in_archive
+        def counting(ws, pid, ts):
+            calls["n"] += 1
+            return real(ws, pid, ts)
+        with unittest.mock.patch.object(activity_rows, "_pid_in_archive", counting):
+            store = ActivityStore(self.ws)
+            for i in range(200):
+                store.apply(T(f"task-p{i}", "RUNNING", ts=1 + i, message_event_id="$m"))
+            for i in range(50):
+                card.append(f"noise {i}", kind="notice", room=None, task={"id": f"task-n{i}"}, workspace=self.ws, pid=f"n:{i}")
+            self.assertEqual(calls["n"], 0, "no fresh row reads the archive")
+            with unittest.mock.patch.object(activity_rows, "_ack", lambda w, tid, pid: (_ for _ in ()).throw(OSError("ack disk full"))):
+                store.apply(T("task-q1", "RUNNING", ts=400, message_event_id="$m"))  # landed, ack lost, row owed
+            for i in range(card.LIVE_ROWS + 1):
+                card.append(f"more {i}", kind="notice", room=None, task={"id": f"task-m{i}"}, workspace=self.ws, pid=f"m:{i}")
+            self.assertEqual(calls["n"], 0, "rotation traffic does not read the archive either")
+            ActivityStore(self.ws).apply(T("task-q1", "COMPLETED", ts=401))  # the replay of the owed row
+            self.assertEqual(calls["n"], 1, "exactly the replay consulted the archive")
+            rows = [json.loads(l) for p in (self.ws / "state").glob("agent-activity*.jsonl") if "summaries" not in p.name for l in p.read_text().splitlines() if "task-q1" in l]
+            self.assertEqual(sorted(r["line"] for r in rows), ["picked up", "replied"], "found in the archive: applied once")
 
     def test_a_replay_of_a_landed_row_leaves_the_index_count_exact(self):
         # The other half: index saved, then the drained snapshot save lost (a crash) — the same pid

--- a/tests/activity-bus.test.py
+++ b/tests/activity-bus.test.py
@@ -10,6 +10,7 @@ import os
 import sys
 import tempfile
 import unittest
+import unittest.mock
 from pathlib import Path
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
@@ -160,6 +161,55 @@ class Acceptance(unittest.TestCase):
         st = self.store.apply(T("t6", "RUNNING", ts=1, message_event_id="$m"))
         st = self.store.apply(T("t6", "COMPLETED", ts=2, into="$holder"))
         self.assertEqual((self.rows[-1]["line"], self.rows[-1]["task"]["into"]), ("consolidated", "$holder"))
+
+
+class IdempotentProjection(unittest.TestCase):
+    """Reviewer's case: the real row writer appends the row, then raises while saving its index. The
+    row stays owed; the replay must not publish it twice, and the summary must land exactly once."""
+
+    def setUp(self):
+        self.ws = Path(tempfile.mkdtemp()); (self.ws / "state").mkdir()
+
+    def rows(self):
+        return [json.loads(l)["line"] for l in card.log_path(self.ws).read_text().splitlines()]
+
+    def test_a_failure_after_the_append_is_replayed_exactly_once(self):
+        import activity_rows
+        store = ActivityStore(self.ws)
+        store.apply(T("task-i1", "RUNNING", ts=1, message_event_id="$m"))
+        self.assertEqual(self.rows(), ["picked up"])
+        real = activity_rows._save_index
+        calls = {"n": 0}
+        def flaky(ip, idx):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise OSError("index disk full")  # AFTER the log append and the summary write
+            real(ip, idx)
+        with unittest.mock.patch.object(activity_rows, "_save_index", flaky):
+            st = store.apply(T("task-i1", "COMPLETED", ts=2))
+        self.assertEqual((st.phase, len(st.pending)), ("COMPLETED", 1), "committed, row still owed")
+        self.assertEqual(self.rows(), ["picked up", "replied"], "the row DID land before the failure")
+        self.assertTrue(all("pid" in json.loads(l) for l in card.log_path(self.ws).read_text().splitlines()))
+        fresh = ActivityStore(self.ws)  # a restart: the drain replays the owed row
+        fresh._drain(fresh.load("task-i1"))
+        self.assertEqual(self.rows(), ["picked up", "replied"], "replayed, not duplicated")
+        self.assertEqual(len(fresh.load("task-i1").pending), 0)
+        sums = [json.loads(l) for l in card.summaries_path(self.ws).read_text().splitlines()]
+        self.assertEqual([(x["task"]["id"], x["rows"]) for x in sums], [("task-i1", 2)], "one summary, exact")
+        self.assertNotIn("task-i1", card.open_task_index(self.ws))
+
+    def test_a_replay_of_a_landed_row_leaves_the_index_count_exact(self):
+        # The other half: index saved, then the drained snapshot save lost (a crash) — the same pid
+        # projected again must not count the row twice.
+        t = {"id": "task-i2"}
+        card.append("picked up", kind="processing", room="!r:s", task=t, workspace=self.ws, pid="task-i2:1:1")
+        card.append("picked up", kind="processing", room="!r:s", task=t, workspace=self.ws, pid="task-i2:1:1")
+        self.assertEqual(self.rows(), ["picked up"])
+        self.assertEqual(card.open_task_index(self.ws)["task-i2"]["rows"], 1)
+        card.append("replied", kind="done", room="!r:s", task=t, done=True, workspace=self.ws, pid="task-i2:1:2")
+        card.append("replied", kind="done", room="!r:s", task=t, done=True, workspace=self.ws, pid="task-i2:1:2")
+        self.assertEqual(len(card.summaries_path(self.ws).read_text().splitlines()), 1, "one summary")
+        self.assertEqual(self.rows(), ["picked up", "replied"])
 
 
 if __name__ == "__main__":

--- a/tests/activity-bus.test.py
+++ b/tests/activity-bus.test.py
@@ -223,6 +223,42 @@ class IdempotentProjection(unittest.TestCase):
         self.assertEqual(len(fresh.load("task-i3").pending), 0)
         self.assertEqual(len(card.summaries_path(self.ws).read_text().splitlines()), 1)
 
+    def test_unrelated_pid_bearing_traffic_never_evicts_an_owed_rows_ack(self):
+        # yixuan's finding: the filler must carry pids of OTHER tasks, the memory a global ledger
+        # would evict. Per-task acknowledgement cannot be evicted by anyone else's rows.
+        import activity_rows
+        store = ActivityStore(self.ws)
+        store.apply(T("task-i4", "RUNNING", ts=1, message_event_id="$m"))
+        real = activity_rows._save_index; calls = {"n": 0}
+        def flaky(ip, idx):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise OSError("index disk full")
+            real(ip, idx)
+        with unittest.mock.patch.object(activity_rows, "_save_index", flaky):
+            store.apply(T("task-i4", "COMPLETED", ts=2))
+        for i in range(6100):
+            card.append(f"noise {i}", kind="notice", room=None, task={"id": f"task-n{i % 50}"}, workspace=self.ws, pid=f"pid-noise-{i}")
+        self.assertNotIn("task-i4", card.log_path(self.ws).read_text(), "precondition: rotated out")
+        fresh = ActivityStore(self.ws)
+        fresh.apply(T("task-i4", "COMPLETED", ts=2))
+        history = "".join(p.read_text() for p in (self.ws / "state").glob("agent-activity*.jsonl") if "summaries" not in p.name)
+        self.assertEqual(history.count('"pid": "task-i4:1:2"'), 1, "still exactly once after 6100 pid-bearing rows")
+        self.assertEqual(len(fresh.load("task-i4").pending), 0)
+        # positive control: a brand-new pid still appends exactly one row
+        card.append("fresh", kind="notice", room=None, task={"id": "task-i4"}, workspace=self.ws, pid="task-i4:1:99")
+        self.assertEqual(card.log_path(self.ws).read_text().count('"pid": "task-i4:1:99"'), 1)
+
+    def test_a_closed_task_leaves_no_ack_file_behind(self):
+        import activity_rows
+        t = {"id": "task-i5"}
+        card.append("picked up", kind="processing", room="!r:s", task=t, workspace=self.ws, pid="task-i5:1:1")
+        self.assertTrue((activity_rows.acks_dir(self.ws) / "task-i5").exists())
+        card.append("replied", kind="done", room="!r:s", task=t, done=True, workspace=self.ws, pid="task-i5:1:2")
+        self.assertFalse((activity_rows.acks_dir(self.ws) / "task-i5").exists(), "the summary carries the done pid; the file goes")
+        card.append("replied", kind="done", room="!r:s", task=t, done=True, workspace=self.ws, pid="task-i5:1:2")
+        self.assertEqual(len(card.summaries_path(self.ws).read_text().splitlines()), 1, "a replayed done row is still one summary")
+
     def test_a_replay_of_a_landed_row_leaves_the_index_count_exact(self):
         # The other half: index saved, then the drained snapshot save lost (a crash) — the same pid
         # projected again must not count the row twice.

--- a/tests/activity-bus.test.py
+++ b/tests/activity-bus.test.py
@@ -259,6 +259,34 @@ class IdempotentProjection(unittest.TestCase):
         card.append("replied", kind="done", room="!r:s", task=t, done=True, workspace=self.ws, pid="task-i5:1:2")
         self.assertEqual(len(card.summaries_path(self.ws).read_text().splitlines()), 1, "a replayed done row is still one summary")
 
+    def test_a_row_whose_ack_never_landed_is_still_found_after_rotation(self):
+        # The log append completes, then _ack raises: once the row rotates no memory of it remains, so
+        # the replay must find it in the archive day file its own (event, not replay) timestamp names.
+        import activity_rows
+        for fault in (False, True):
+            ws = Path(tempfile.mkdtemp()); (ws / "state").mkdir()
+            real = activity_rows._ack; calls = {"n": 0}
+            def flaky(w, tid, pid):
+                calls["n"] += 1
+                if fault and calls["n"] == 1:
+                    raise OSError("ack disk full")  # AFTER the log append
+                real(w, tid, pid)
+            store = ActivityStore(ws)
+            with unittest.mock.patch.object(activity_rows, "_ack", flaky):
+                st = store.apply(T("task-g1", "RUNNING", ts=1_757_000_000.0, message_event_id="$m"))
+            self.assertEqual(len(st.pending), 1 if fault else 0, "a faulted ack leaves the row owed")
+            for i in range(card.LIVE_ROWS + 1):
+                card.append(f"noise {i}", kind="notice", room=None, workspace=ws)
+            self.assertNotIn("task-g1", card.log_path(ws).read_text(), "precondition: rotated out")
+            fresh = ActivityStore(ws); fresh.apply(T("task-g1", "COMPLETED", ts=1_757_000_002.0))
+            history = [json.loads(l) for p in (ws / "state").glob("agent-activity*.jsonl") if "summaries" not in p.name for l in p.read_text().splitlines()]
+            mine = [r for r in history if r.get("task", {}).get("id") == "task-g1"]
+            self.assertEqual([r["line"] for r in sorted(mine, key=lambda r: r["ts"])], ["picked up", "replied"], f"fault={fault}")
+            self.assertEqual([r["ts"] for r in sorted(mine, key=lambda r: r["ts"])], [1_757_000_000.0, 1_757_000_002.0], "event timestamps, not a replay clock")
+            self.assertEqual(len(fresh.load("task-g1").pending), 0)
+            sums = [json.loads(l) for l in card.summaries_path(ws).read_text().splitlines()]
+            self.assertEqual([x["rows"] for x in sums], [2], f"fault={fault}: the summary counts two rows, once")
+
     def test_a_replay_of_a_landed_row_leaves_the_index_count_exact(self):
         # The other half: index saved, then the drained snapshot save lost (a crash) — the same pid
         # projected again must not count the row twice.


### PR DESCRIPTION
**Stacked on #3982 → #3981** (merge in that order; this branch contains both). Child-only diff: `src/activity_bus.py`, `src/activity_rows.py`, `skills/agent-activity/scripts/activity.py`, `tests/activity-bus.test.py`, `docs/src-map.md`. **Part 1 of the owner's PR 2**: the bus and its state machine; part 2 wires the scheduler's six emit points (watcher, pick-up, HITL requirement, result drain, terminal failure, cancel) through it.

> ActivityCard is the UI projection of a durable TaskRun state machine; runtime instrumentation only enriches that state machine with observations. — the owner's definition, 2026-09-06, and this module's first line.

## What
- **Two vocabularies, never one enum.** `TaskPhase`: RECEIVED → QUEUED → RUNNING ↔ WAITING → COMPLETED | FAILED | CANCELLED, encoded as a transition table, terminal phases sticky. `RuntimeEvent`: Status, Thinking, Working, ToolStarted, ToolFinished, InteractionRequired, Heartbeat, RuntimeStarted, RuntimeStopped. Only `reduce()` turns an observation into a phase (InteractionRequired → WAITING; Working/RuntimeStarted → RUNNING). A provider stopping is never a failure; a late event after a terminal phase is telemetry and cannot reopen the task.
- **State is the source of truth.** `TaskActivityState` {task_id, message_event_id, room, sender, text, activity_session_id, worker, generation, phase, seq, started_at, last_activity_at, summary, into} — the same shape a server snapshot will carry, so C syncs this record rather than re-deriving state from rows. Rows and the snapshot file are projections of it.
- **Dedup by key, not by "a row of this phase exists".** Lifecycle by (task_id, generation, from_phase, to_phase) — generation bumps on each entry into RUNNING, so RUNNING ↔ WAITING loops are legitimate; runtime events by (activity_session_id, seq), out-of-order and duplicates dropped deterministically.
- **`ActivityStore`**: snapshot per task under `state/activity/<task_id>.json` (atomic replace), `apply()` = load → reduce → save → project under one lock per task. Default projection is the real row writer, so the client keeps rendering unchanged.
- **One row writer.** `append/rotate/summarize` move from the skill to `src/activity_rows.py`; the skill's CLI keeps its names and its 37 tests unchanged. Core no longer needs to import a skill to write a row.

## Evidence
```
tests/activity-bus.test.py      Ran 9 tests in 0.012s OK
tests/agent-activity.test.py    Ran 37 tests in 0.332s OK   (unchanged from #3982)
```
The owner's acceptance tests, each a test: (1) delete every hook → lifecycle alone yields queued → picked up → replied, every row under the message; (2) provider dies halfway → RUNNING, degrades to heartbeat, no false FAILED; (3) duplicate and out-of-order events → phase never regresses, state byte-identical under replay; (4) restart during RUNNING → a fresh store reconstructs the run, a re-announced provider adds no second run and no row; (5) the default projection is the real writer and leaves the summary.

Mutation controls (tests kept, restored after):
- seq check removed → `FAILED (failures=2)` (test 3 and the seq-dedup test)
- RuntimeStopped treated as FAILED → `FAILED (failures=1)` (test 2)
- terminal stickiness needs BOTH guards removed to break (COMPLETED→RUNNING added to the table AND the TERMINAL clause dropped) → FAILED (failures=1) FAIL: test_the_valid_transitions_and_only_those ; either alone is covered by the other, stated here so the control is not mistaken for coverage.

`scripts/review-checks.sh --diff`: PASS. `docs/src-map.md` regenerated.

## Worst case
Nothing calls the bus yet (part 2 wires it), so runtime behaviour is unchanged; the writer move is a pure relocation with the skill's suite as the control. Additive to the hooks by construction: hook rows keep flowing through the same writer; the bus dedups its own transitions by key and never by the presence of a hook's row.

— sutando-qingyun-air
