### PR TITLE
feat(activity): the room's two projections — who is on this task, and whether the agent can take more

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -19,6 +19,7 @@ One entry per agent-facing module. 5 without a usable header comment.
 - **`activity_bus.py`** — ActivityCard is the UI projection of a durable TaskRun state machine; runtime instrumentation only enriches that state machine with observations.
 - **`activity_rows.py`** — The agent-activity row writer: one JSON row per line at <workspace>/state/agent-activity.jsonl, the live window the desktop renders, its per-day archive, the per-task index that keeps a summary exact after rotation, and the summary left at done.
 - **`agent-api.py`** — Sutando agent API — simple HTTP endpoint for agent-to-agent communication.
+- **`agent_availability.py`** — Two room-visible projections of one private runtime: what this agent is doing on THIS task, and whether it can take more work.
 - **`agent_endpoint.py`** — Agent Endpoint resolver — resolve(endpoint, mode) → a transport route.
 - **`archive-stale-results.py`** — Archive stale `results/*.txt` files to `results/archive-YYYY-MM-DD/`.
 - **`artifact-cache-tools.ts`** — Active artifact cache — load a file once, answer repeated queries from in-process memory.

--- a/packages/ag2-sparrow/ag2_sparrow/outbox.py
+++ b/packages/ag2-sparrow/ag2_sparrow/outbox.py
@@ -702,6 +702,18 @@ def record_delivered(root: Path, item_id: str, *, provider: Optional[str] = None
     if destination:
         d["destination"] = destination
     _write_item(Path(root), item_id, d)
+    _activity_completed(item_id)
+
+
+def _activity_completed(item_id: str) -> None:
+    """A delivered task result is the scheduler's COMPLETED. Never breaks delivery."""
+    if not str(item_id).startswith("task-"):
+        return
+    try:
+        import activity_bus as _bus
+        _bus.ActivityStore().apply(_bus.LifecycleTransition(item_id, "COMPLETED", reason="delivered"))
+    except Exception:  # noqa: BLE001
+        pass
 
 
 def item_status(root: Path, item_id: str) -> Optional[str]:

--- a/skills/agent-activity/scripts/activity.py
+++ b/skills/agent-activity/scripts/activity.py
@@ -23,25 +23,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
 from workspace_default import resolve_workspace  # noqa: E402,F401
 from activity_rows import (  # noqa: E402,F401  (the writer lives in core; the CLI keeps these names)
     KINDS, LIVE_ROWS, TEXT_MAX, append, day_of, day_range, default_room, index_path, log_path, open_task_index,
-    rotate, summaries_path, summarize,
+    rotate, summaries_path, summarize, task_from_file,
 )
-
-
-def task_from_file(path: Path) -> tuple[dict, str | None]:
-    """({id, from, text}, room) read from a task file's headers; text is the first task: line."""
-    fields: dict = {}
-    for l in path.read_text(encoding="utf-8", errors="replace").splitlines():
-        k, _, v = l.partition(":")
-        if k in ("id", "user_id", "task", "channel_id", "source_message_id") and k not in fields:
-            fields[k] = v.strip()
-    task = {"id": fields.get("id") or path.stem}
-    if fields.get("user_id"):
-        task["from"] = fields["user_id"]
-    if fields.get("task"):
-        task["text"] = fields["task"][:TEXT_MAX]
-    if fields.get("source_message_id"):
-        task["event"] = fields["source_message_id"]  # the client mounts the card under this message
-    return task, fields.get("channel_id") or None
 
 
 def queued(task_file: Path, workspace: Path | None = None) -> int:

--- a/src/activity_bus.py
+++ b/src/activity_bus.py
@@ -17,12 +17,15 @@ from __future__ import annotations
 import fcntl
 import json
 import os
+import re
+import sys
 import time
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Callable
 
 from activity_rows import append as append_row
+from activity_rows import task_from_file
 from workspace_default import resolve_workspace
 
 PHASES = ("RECEIVED", "QUEUED", "RUNNING", "WAITING", "COMPLETED", "FAILED", "CANCELLED")
@@ -136,10 +139,19 @@ def reduce(state: TaskActivityState, item: LifecycleTransition | RuntimeEvent) -
         if key in state.applied:
             return state, rows
         frm = item.from_phase or state.phase
+        if (item.to_phase == "QUEUED" and state.phase in ("RUNNING", "WAITING") and item.from_phase is None
+                and state.started_at is not None and now <= state.started_at and "queued" not in state.applied):
+            # QUEUED and RUNNING are emitted by independent processes and can land out of order: an
+            # earlier-stamped QUEUED is history — row written, phase kept, a replay of it a no-op.
+            state.applied += ["queued", key]
+            rows.append(_row(state, "notice", "queued", now))
+            return state, rows
         if frm != state.phase or state.phase in TERMINAL or item.to_phase not in TRANSITIONS.get(state.phase, frozenset()):
             # Not a valid move from where the task is: a stale or replayed transition. Telemetry only.
             state.telemetry += 1
             return state, rows
+        if item.to_phase == "QUEUED":
+            state.applied.append("queued")
         for f in ("message_event_id", "room", "sender", "text", "worker", "into"):
             v = getattr(item, f)
             if v:
@@ -192,6 +204,66 @@ def reduce(state: TaskActivityState, item: LifecycleTransition | RuntimeEvent) -
     # Heartbeat, ToolFinished, RuntimeStopped: liveness only. A provider that stops is not a
     # failure; the scheduler decides FAILED, never an observation's absence.
     return state, rows
+
+
+CANCEL_RE = re.compile(r"CANCEL_INSTRUCTION:\s*stop processing\s+(task-[A-Za-z0-9._-]+)")
+
+
+def cancel_target(task_text: str | None) -> str | None:
+    """The task a CANCEL_INSTRUCTION names, else None: the scheduler marks it CANCELLED on arrival."""
+    m = CANCEL_RE.search(task_text or "")
+    return m.group(1) if m else None
+
+
+def transition_from_file(to_phase: str, task_file: Path, *, reason: str = "", into_task: str | None = None,
+                         worker: str | None = None, ws: Path | None = None, ts: float | None = None) -> LifecycleTransition:
+    task, room = task_from_file(task_file)
+    into = None
+    if into_task:
+        for d in ("tasks", os.path.join("tasks", "archive")):
+            p = (ws or resolve_workspace()) / d / f"{into_task}.txt"
+            if p.exists():
+                into = task_from_file(p)[0].get("event")
+                break
+    return LifecycleTransition(task["id"], to_phase, reason=reason, message_event_id=task.get("event"),
+                               room=room, sender=task.get("from"), text=task.get("text"), worker=worker, into=into, ts=ts)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """`transition <PHASE> (--task-file P | --task-id ID) [--reason R] [--into-task ID] [--worker W]`
+    and `event <task_id> <kind> --session S --seq N [--text T]`. Exits 0 on every path: a caller in
+    the delivery path must never fail because the card could not be updated."""
+    import argparse
+    ap = argparse.ArgumentParser(description="activity bus CLI")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    t = sub.add_parser("transition"); t.add_argument("to_phase", choices=PHASES)
+    t.add_argument("--task-file"); t.add_argument("--task-id"); t.add_argument("--reason", default="")
+    t.add_argument("--into-task"); t.add_argument("--worker"); t.add_argument("--workspace")
+    t.add_argument("--ts", type=float, default=None, help="when this transition happened (epoch); default now")
+    e = sub.add_parser("event"); e.add_argument("task_id"); e.add_argument("kind", choices=EVENT_KINDS)
+    e.add_argument("--session", required=True); e.add_argument("--seq", type=int, required=True)
+    e.add_argument("--text", default=""); e.add_argument("--workspace")
+    try:
+        a = ap.parse_args(argv)
+        ws = Path(a.workspace) if a.workspace else None
+        store = ActivityStore(ws)
+        if a.cmd == "transition":
+            if a.task_file:
+                item = transition_from_file(a.to_phase, Path(a.task_file), reason=a.reason, into_task=a.into_task,
+                                            worker=a.worker, ws=ws, ts=a.ts)
+            elif a.task_id:
+                item = LifecycleTransition(a.task_id, a.to_phase, reason=a.reason, worker=a.worker, ts=a.ts)
+            else:
+                return 0
+            state = store.apply(item)
+        else:
+            state = store.apply(RuntimeEvent(a.task_id, a.session, a.seq, a.kind, text=a.text))
+        print(json.dumps({"task_id": state.task_id, "phase": state.phase, "generation": state.generation, "seq": state.seq}))
+    except SystemExit:
+        return 0
+    except Exception as exc:  # noqa: BLE001 - never fail the delivery path
+        print(f"activity_bus: {exc}", file=sys.stderr)
+    return 0
 
 
 class ActivityStore:
@@ -255,3 +327,7 @@ class ActivityStore:
                 return
             state.pending = state.pending[1:]
             self.save(state)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/activity_bus.py
+++ b/src/activity_bus.py
@@ -38,11 +38,12 @@ TRANSITIONS: dict[str, frozenset[str]] = {
 }
 EVENT_KINDS = ("Status", "Thinking", "Working", "ToolStarted", "ToolFinished",
                "InteractionRequired", "Heartbeat", "RuntimeStarted", "RuntimeStopped")
-# Audience is a property of the projection, decided here, enforced by the transport that carries it:
-# the lifecycle is what a room may know (someone is on it), telemetry is the owner's alone.
-SCOPES = ("owner", "room", "participants")
-LIFECYCLE_SCOPE = "room"
-TELEMETRY_SCOPE = "owner"
+# Two questions, two fields: AUDIENCE is who may receive (enforced by the transport that carries it),
+# PROJECTION is what they see. Lifecycle is the room's TASK_STATUS; telemetry is the owner's RUNTIME_DETAIL.
+AUDIENCES = ("owner", "room", "selected_members", "system")
+PROJECTIONS = ("TASK_STATUS", "RUNTIME_DETAIL", "AVAILABILITY")
+LIFECYCLE_AUDIENCE = "room"
+TELEMETRY_AUDIENCE = "owner"
 
 
 @dataclass
@@ -65,7 +66,7 @@ class TaskActivityState:
     summary: str = ""
     into: str | None = None  # a consolidated reply: the holder message's event id
     pending: list[dict] = field(default_factory=list)  # rows reduced but not yet projected
-    visibility: dict = field(default_factory=lambda: {"lifecycle": LIFECYCLE_SCOPE, "telemetry": TELEMETRY_SCOPE})
+    visibility: dict = field(default_factory=lambda: {"lifecycle": LIFECYCLE_AUDIENCE, "telemetry": TELEMETRY_AUDIENCE})
     applied: list[str] = field(default_factory=list)
     sessions: dict[str, int] = field(default_factory=dict)
     telemetry: int = 0
@@ -118,25 +119,27 @@ def _task_dict(state: TaskActivityState) -> dict:
 
 
 def _row(state: TaskActivityState, kind: str, line: str, ts: float, done: bool = False,
-         scope: str | None = None) -> dict:
+         audience: str | None = None, projection: str = "RUNTIME_DETAIL") -> dict:
     # The pid rides in the snapshot's pending list, so a replay projects the same identity again
     # and the row writer applies it once.
     state.emitted += 1
     return {"kind": kind, "line": line, "ts": ts, "room": state.room, "task": _task_dict(state), "done": done, "pid": f"{state.task_id}:{state.generation}:{state.emitted}",
-            "scope": scope or state.visibility.get("telemetry", TELEMETRY_SCOPE)}
+            "audience": audience or state.visibility.get("telemetry", TELEMETRY_AUDIENCE), "projection": projection}
 
 
 def shared_projection(state: TaskActivityState) -> dict:
     """What the room may see: who is on it and where it stands. No summary text, no steps."""
     return {"task_id": state.task_id, "message_event_id": state.message_event_id, "worker": state.worker,
             "phase": state.phase, "generation": state.generation, "started_at": state.started_at,
-            "last_activity_at": state.last_activity_at, "scope": state.visibility.get("lifecycle", LIFECYCLE_SCOPE)}
+            "last_activity_at": state.last_activity_at, "audience": state.visibility.get("lifecycle", LIFECYCLE_AUDIENCE),
+            "projection": "TASK_STATUS"}
 
 
 def private_projection(state: TaskActivityState) -> dict:
     """What only the owner's own clients receive: the shared fields plus the summary and the sequence."""
     return dict(shared_projection(state), summary=state.summary, seq=state.seq,
-                activity_session_id=state.activity_session_id, scope=state.visibility.get("telemetry", TELEMETRY_SCOPE))
+                activity_session_id=state.activity_session_id, audience=state.visibility.get("telemetry", TELEMETRY_AUDIENCE),
+                projection="RUNTIME_DETAIL")
 
 
 _PHASE_ROW = {
@@ -191,7 +194,7 @@ def reduce(state: TaskActivityState, item: LifecycleTransition | RuntimeEvent) -
         elif item.reason and item.to_phase in TERMINAL:
             line = f"{line}: {item.reason}" if item.to_phase != "COMPLETED" else item.reason
         rows.append(_row(state, kind, line, now, done=item.to_phase in TERMINAL,
-                         scope=state.visibility.get("lifecycle", LIFECYCLE_SCOPE)))
+                         audience=state.visibility.get("lifecycle", LIFECYCLE_AUDIENCE), projection="TASK_STATUS"))
         return state, rows
     # a runtime observation
     last = state.sessions.get(item.activity_session_id, 0)
@@ -298,7 +301,7 @@ class ActivityStore:
 
     def _default_project(self, row: dict) -> None:
         append_row(row["line"], kind=row["kind"], room=row["room"], task=row["task"], done=row["done"],
-                   workspace=self.ws, scope=row.get("scope"), pid=row.get("pid"), ts=row.get("ts"), replay=int(row.get("attempts", 0)) > 1)
+                   workspace=self.ws, audience=row.get("audience"), projection=row.get("projection"), pid=row.get("pid"), ts=row.get("ts"), replay=int(row.get("attempts", 0)) > 1)
 
     def path(self, task_id: str) -> Path:
         return self.dir / f"{task_id}.json"

--- a/src/activity_bus.py
+++ b/src/activity_bus.py
@@ -38,6 +38,11 @@ TRANSITIONS: dict[str, frozenset[str]] = {
 }
 EVENT_KINDS = ("Status", "Thinking", "Working", "ToolStarted", "ToolFinished",
                "InteractionRequired", "Heartbeat", "RuntimeStarted", "RuntimeStopped")
+# Audience is a property of the projection, decided here, enforced by the transport that carries it:
+# the lifecycle is what a room may know (someone is on it), telemetry is the owner's alone.
+SCOPES = ("owner", "room", "participants")
+LIFECYCLE_SCOPE = "room"
+TELEMETRY_SCOPE = "owner"
 
 
 @dataclass
@@ -48,7 +53,7 @@ class TaskActivityState:
     phase: str = "RECEIVED"
     generation: int = 0  # bumps each time the task enters RUNNING: one per run
     seq: int = 0  # last runtime-event sequence applied, across sessions
-    emitted: int = 0
+    emitted: int = 0  # rows projected so far: the stable projection id of the next row
     message_event_id: str | None = None
     room: str | None = None
     sender: str | None = None
@@ -60,6 +65,7 @@ class TaskActivityState:
     summary: str = ""
     into: str | None = None  # a consolidated reply: the holder message's event id
     pending: list[dict] = field(default_factory=list)  # rows reduced but not yet projected
+    visibility: dict = field(default_factory=lambda: {"lifecycle": LIFECYCLE_SCOPE, "telemetry": TELEMETRY_SCOPE})
     applied: list[str] = field(default_factory=list)
     sessions: dict[str, int] = field(default_factory=dict)
     telemetry: int = 0
@@ -111,12 +117,26 @@ def _task_dict(state: TaskActivityState) -> dict:
     return t
 
 
-def _row(state: TaskActivityState, kind: str, line: str, ts: float, done: bool = False) -> dict:
+def _row(state: TaskActivityState, kind: str, line: str, ts: float, done: bool = False,
+         scope: str | None = None) -> dict:
     # The pid rides in the snapshot's pending list, so a replay projects the same identity again
     # and the row writer applies it once.
     state.emitted += 1
-    return {"kind": kind, "line": line, "ts": ts, "room": state.room, "task": _task_dict(state), "done": done,
-            "pid": f"{state.task_id}:{state.generation}:{state.emitted}"}
+    return {"kind": kind, "line": line, "ts": ts, "room": state.room, "task": _task_dict(state), "done": done, "pid": f"{state.task_id}:{state.generation}:{state.emitted}",
+            "scope": scope or state.visibility.get("telemetry", TELEMETRY_SCOPE)}
+
+
+def shared_projection(state: TaskActivityState) -> dict:
+    """What the room may see: who is on it and where it stands. No summary text, no steps."""
+    return {"task_id": state.task_id, "message_event_id": state.message_event_id, "worker": state.worker,
+            "phase": state.phase, "generation": state.generation, "started_at": state.started_at,
+            "last_activity_at": state.last_activity_at, "scope": state.visibility.get("lifecycle", LIFECYCLE_SCOPE)}
+
+
+def private_projection(state: TaskActivityState) -> dict:
+    """What only the owner's own clients receive: the shared fields plus the summary and the sequence."""
+    return dict(shared_projection(state), summary=state.summary, seq=state.seq,
+                activity_session_id=state.activity_session_id, scope=state.visibility.get("telemetry", TELEMETRY_SCOPE))
 
 
 _PHASE_ROW = {
@@ -170,7 +190,8 @@ def reduce(state: TaskActivityState, item: LifecycleTransition | RuntimeEvent) -
             line = "consolidated"
         elif item.reason and item.to_phase in TERMINAL:
             line = f"{line}: {item.reason}" if item.to_phase != "COMPLETED" else item.reason
-        rows.append(_row(state, kind, line, now, done=item.to_phase in TERMINAL))
+        rows.append(_row(state, kind, line, now, done=item.to_phase in TERMINAL,
+                         scope=state.visibility.get("lifecycle", LIFECYCLE_SCOPE)))
         return state, rows
     # a runtime observation
     last = state.sessions.get(item.activity_session_id, 0)
@@ -277,8 +298,7 @@ class ActivityStore:
 
     def _default_project(self, row: dict) -> None:
         append_row(row["line"], kind=row["kind"], room=row["room"], task=row["task"], done=row["done"],
-                   workspace=self.ws, pid=row.get("pid"), ts=row.get("ts"),
-                   replay=int(row.get("attempts", 0)) > 1)
+                   workspace=self.ws, scope=row.get("scope"), pid=row.get("pid"), ts=row.get("ts"), replay=int(row.get("attempts", 0)) > 1)
 
     def path(self, task_id: str) -> Path:
         return self.dir / f"{task_id}.json"

--- a/src/activity_bus.py
+++ b/src/activity_bus.py
@@ -54,7 +54,7 @@ class TaskActivityState:
     phase: str = "RECEIVED"
     generation: int = 0  # bumps each time the task enters RUNNING: one per run
     seq: int = 0  # last runtime-event sequence applied, across sessions
-    emitted: int = 0  # rows projected so far: the stable projection id of the next row
+    emitted: int = 0
     message_event_id: str | None = None
     room: str | None = None
     sender: str | None = None
@@ -167,7 +167,8 @@ def reduce(state: TaskActivityState, item: LifecycleTransition | RuntimeEvent) -
             # QUEUED and RUNNING are emitted by independent processes and can land out of order: an
             # earlier-stamped QUEUED is history — row written, phase kept, a replay of it a no-op.
             state.applied += ["queued", key]
-            rows.append(_row(state, "notice", "queued", now))
+            rows.append(_row(state, "notice", "queued", now, audience=state.visibility.get("lifecycle", LIFECYCLE_AUDIENCE),
+                             projection="TASK_STATUS"))
             return state, rows
         if frm != state.phase or state.phase in TERMINAL or item.to_phase not in TRANSITIONS.get(state.phase, frozenset()):
             # Not a valid move from where the task is: a stale or replayed transition. Telemetry only.

--- a/src/activity_rows.py
+++ b/src/activity_rows.py
@@ -175,14 +175,14 @@ def append(line: str, *, kind: str, room: str | None, task: dict | None = None,
             ip = index_path(workspace)
             idx = _load_index(ip)
             e = idx.get(task["id"]) or {"started": rec["ts"], "rows": 0, "task": task, "room": room}
-            # Applied evidence is the highest emitted counter per generation, saved with the count in
-            # the same record: a replay never counts twice, whatever landed in between.
+            # A row that landed just now is new by construction; a replay counts only above the
+            # generation's applied high-water mark, saved with the count in the same record.
             gen, emitted = _pid_counter(pid)
             applied = dict(e.get("applied") or {})
-            if gen is None or emitted > int(applied.get(gen, 0)):
+            if not landed or emitted > int(applied.get(gen, 0)):
                 e["rows"] = int(e.get("rows", 0)) + 1
-                if gen is not None:
-                    applied[gen] = emitted
+            if gen is not None:
+                applied[gen] = max(int(applied.get(gen, 0)), emitted)
             e["applied"] = applied
             e.pop("last_pid", None)
             e["started"] = min(float(e.get("started", rec["ts"])), rec["ts"])

--- a/src/activity_rows.py
+++ b/src/activity_rows.py
@@ -179,6 +179,10 @@ def append(line: str, *, kind: str, room: str | None, task: dict | None = None,
             # generation's applied high-water mark, saved with the count in the same record.
             gen, emitted = _pid_counter(pid)
             applied = dict(e.get("applied") or {})
+            if not applied and e.get("last_pid"):  # an entry the previous writer left: its evidence carries over
+                old_gen, old_emitted = _pid_counter(e["last_pid"])
+                if old_gen is not None:
+                    applied[old_gen] = old_emitted
             if not landed or emitted > int(applied.get(gen, 0)):
                 e["rows"] = int(e.get("rows", 0)) + 1
             if gen is not None:

--- a/src/activity_rows.py
+++ b/src/activity_rows.py
@@ -228,3 +228,20 @@ def rotate(path: Path, keep: int = LIVE_ROWS) -> None:
     tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
     tmp.write_text("\n".join(rows[-keep:]) + "\n", encoding="utf-8")
     os.replace(tmp, path)
+
+
+def task_from_file(path: Path) -> tuple[dict, str | None]:
+    """({id, from, text}, room) read from a task file's headers; text is the first task: line."""
+    fields: dict = {}
+    for l in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        k, _, v = l.partition(":")
+        if k in ("id", "user_id", "task", "channel_id", "source_message_id") and k not in fields:
+            fields[k] = v.strip()
+    task = {"id": fields.get("id") or path.stem}
+    if fields.get("user_id"):
+        task["from"] = fields["user_id"]
+    if fields.get("task"):
+        task["text"] = fields["task"][:TEXT_MAX]
+    if fields.get("source_message_id"):
+        task["event"] = fields["source_message_id"]  # the client mounts the card under this message
+    return task, fields.get("channel_id") or None

--- a/src/activity_rows.py
+++ b/src/activity_rows.py
@@ -105,6 +105,34 @@ def _pid_counter(pid: str | None) -> tuple[str | None, int]:
     return parts[1], int(parts[2])
 
 
+def _task_rows_on_disk(workspace: Path | None, task_id: str, since: float, until: float) -> tuple[int, dict]:
+    """Every row of one task still on disk — the live log and the archive day files its span names —
+    with the highest emitted counter per generation. The migration's only exact evidence."""
+    live = log_path(workspace)
+    names = [live.name, f"{live.stem}.archive.jsonl"]
+    day, last = min(since, until), max(since, until)
+    while day <= last + 86400 and len(names) < 400:
+        names.append(f"{live.stem}.archive.{day_of(day)}.jsonl"); day += 86400
+    count, applied = 0, {}
+    for name in dict.fromkeys(names):
+        try:
+            lines = live.with_name(name).read_text(encoding="utf-8").splitlines()
+        except OSError:
+            continue
+        for line in lines:
+            try:
+                rec = json.loads(line)
+            except ValueError:
+                continue
+            if (rec.get("task") or {}).get("id") != task_id:
+                continue
+            count += 1
+            gen, emitted = _pid_counter(rec.get("pid"))
+            if gen is not None:
+                applied[gen] = max(int(applied.get(gen, 0)), emitted)
+    return count, applied
+
+
 def _ack(workspace: Path | None, task_id: str, pid: str) -> None:
     d = acks_dir(workspace)
     d.mkdir(parents=True, exist_ok=True)
@@ -179,15 +207,12 @@ def append(line: str, *, kind: str, room: str | None, task: dict | None = None,
             # A row that landed just now is new by construction; a replay counts only above the
             # generation's applied high-water mark, saved with the count in the same record.
             gen, emitted = _pid_counter(pid)
-            # An entry the previous writer left has no applied map: every row that landed under it
-            # was counted then, so a landed replay never counts; its last_pid seeds the map if kept.
-            old_format = existing is not None and "applied" not in existing
             applied = dict(e.get("applied") or {})
-            if old_format and e.get("last_pid"):
-                old_gen, old_emitted = _pid_counter(e["last_pid"])
-                if old_gen is not None:
-                    applied[old_gen] = old_emitted
-            if not landed or (not old_format and emitted > int(applied.get(gen, 0))):
+            if existing is not None and "applied" not in existing:
+                # The previous writer counted a row only when its index save landed, so neither the
+                # entry nor a landed row says which rows it counted: rebuild once from the rows on disk.
+                e["rows"], applied = _task_rows_on_disk(workspace, task["id"], float(e.get("started", rec["ts"])), max(rec["ts"], time.time()))
+            elif not landed or emitted > int(applied.get(gen, 0)):
                 e["rows"] = int(e.get("rows", 0)) + 1
             if gen is not None:
                 applied[gen] = max(int(applied.get(gen, 0)), emitted)

--- a/src/activity_rows.py
+++ b/src/activity_rows.py
@@ -95,6 +95,16 @@ def _pid_acked(workspace: Path | None, task_id: str, pid: str) -> bool:
         return False
 
 
+def _pid_counter(pid: str | None) -> tuple[str | None, int]:
+    """(generation, emitted) from a `task:generation:emitted` pid; (None, 0) for a row without one."""
+    if not isinstance(pid, str):
+        return None, 0
+    parts = pid.rsplit(":", 2)
+    if len(parts) != 3 or not parts[2].isdigit():
+        return None, 0
+    return parts[1], int(parts[2])
+
+
 def _ack(workspace: Path | None, task_id: str, pid: str) -> None:
     d = acks_dir(workspace)
     d.mkdir(parents=True, exist_ok=True)
@@ -165,9 +175,16 @@ def append(line: str, *, kind: str, room: str | None, task: dict | None = None,
             ip = index_path(workspace)
             idx = _load_index(ip)
             e = idx.get(task["id"]) or {"started": rec["ts"], "rows": 0, "task": task, "room": room}
-            if not (pid and e.get("last_pid") == pid):
+            # Applied evidence is the highest emitted counter per generation, saved with the count in
+            # the same record: a replay never counts twice, whatever landed in between.
+            gen, emitted = _pid_counter(pid)
+            applied = dict(e.get("applied") or {})
+            if gen is None or emitted > int(applied.get(gen, 0)):
                 e["rows"] = int(e.get("rows", 0)) + 1
-                e["last_pid"] = pid
+                if gen is not None:
+                    applied[gen] = emitted
+            e["applied"] = applied
+            e.pop("last_pid", None)
             e["started"] = min(float(e.get("started", rec["ts"])), rec["ts"])
             e["task"] = dict(e.get("task") or {}, **task)
             if room:

--- a/src/activity_rows.py
+++ b/src/activity_rows.py
@@ -117,8 +117,8 @@ def _task_rows_on_disk(workspace: Path | None, task_id: str, since: float, until
     for name in dict.fromkeys(names):
         try:
             lines = live.with_name(name).read_text(encoding="utf-8").splitlines()
-        except OSError:
-            continue
+        except FileNotFoundError:
+            continue  # a day the span names but nothing rotated into; any other failure propagates
         for line in lines:
             try:
                 rec = json.loads(line)

--- a/src/activity_rows.py
+++ b/src/activity_rows.py
@@ -173,7 +173,7 @@ def _pid_in_log(path: Path, pid: str) -> bool:
 
 def append(line: str, *, kind: str, room: str | None, task: dict | None = None,
            done: bool = False, workspace: Path | None = None, live_rows: int | None = None,
-           scope: str | None = None,
+           audience: str | None = None, projection: str | None = None,
            pid: str | None = None, ts: float | None = None, replay: bool = False) -> dict:
     """`pid` is the row's stable projection identity: a replay after a partial write (row appended,
     index or summary not) is applied exactly once, each half checking what already landed."""
@@ -182,8 +182,10 @@ def append(line: str, *, kind: str, room: str | None, task: dict | None = None,
     rec: dict = {"ts": ts if ts is not None else time.time(), "line": line.strip(), "kind": kind}
     if pid:
         rec["pid"] = pid
-    if scope:
-        rec["scope"] = scope
+    if audience:
+        rec["audience"] = audience
+    if projection:
+        rec["projection"] = projection
     if room:
         rec["room"] = room
     if task:

--- a/src/activity_rows.py
+++ b/src/activity_rows.py
@@ -201,9 +201,9 @@ def append(line: str, *, kind: str, room: str | None, task: dict | None = None,
         task_id = task.get("id") if isinstance(task, dict) and isinstance(task.get("id"), str) else None
         acked = bool(pid and task_id and (_pid_acked(workspace, task_id, pid)
                                           or (done and _pid_in_log(summaries_path(workspace), pid))))
-        # No ordering heuristic: an unacknowledged row absent from the live log is looked up in the
-        # archive file its own timestamp names — exact, and a fresh row only pays for a small read.
-        landed = bool(pid) and (acked or _pid_in_log(path, pid) or _pid_in_archive(workspace, pid, rec["ts"]))
+        # Only a replay (the bus retrying an owed row) consults the archive: exact for recovery, and a
+        # fresh row never reads the day file under the lock.
+        landed = bool(pid) and (acked or _pid_in_log(path, pid) or (replay and _pid_in_archive(workspace, pid, rec["ts"])))
         if not landed:
             with open(path, "a", encoding="utf-8") as f:
                 f.write(json.dumps(rec, ensure_ascii=False) + "\n")

--- a/src/activity_rows.py
+++ b/src/activity_rows.py
@@ -174,16 +174,20 @@ def append(line: str, *, kind: str, room: str | None, task: dict | None = None,
         if task and isinstance(task.get("id"), str):
             ip = index_path(workspace)
             idx = _load_index(ip)
-            e = idx.get(task["id"]) or {"started": rec["ts"], "rows": 0, "task": task, "room": room}
+            existing = idx.get(task["id"])
+            e = existing or {"started": rec["ts"], "rows": 0, "task": task, "room": room}
             # A row that landed just now is new by construction; a replay counts only above the
             # generation's applied high-water mark, saved with the count in the same record.
             gen, emitted = _pid_counter(pid)
+            # An entry the previous writer left has no applied map: every row that landed under it
+            # was counted then, so a landed replay never counts; its last_pid seeds the map if kept.
+            old_format = existing is not None and "applied" not in existing
             applied = dict(e.get("applied") or {})
-            if not applied and e.get("last_pid"):  # an entry the previous writer left: its evidence carries over
+            if old_format and e.get("last_pid"):
                 old_gen, old_emitted = _pid_counter(e["last_pid"])
                 if old_gen is not None:
                     applied[old_gen] = old_emitted
-            if not landed or emitted > int(applied.get(gen, 0)):
+            if not landed or (not old_format and emitted > int(applied.get(gen, 0))):
                 e["rows"] = int(e.get("rows", 0)) + 1
             if gen is not None:
                 applied[gen] = max(int(applied.get(gen, 0)), emitted)

--- a/src/activity_rows.py
+++ b/src/activity_rows.py
@@ -173,6 +173,7 @@ def _pid_in_log(path: Path, pid: str) -> bool:
 
 def append(line: str, *, kind: str, room: str | None, task: dict | None = None,
            done: bool = False, workspace: Path | None = None, live_rows: int | None = None,
+           scope: str | None = None,
            pid: str | None = None, ts: float | None = None, replay: bool = False) -> dict:
     """`pid` is the row's stable projection identity: a replay after a partial write (row appended,
     index or summary not) is applied exactly once, each half checking what already landed."""
@@ -181,6 +182,8 @@ def append(line: str, *, kind: str, room: str | None, task: dict | None = None,
     rec: dict = {"ts": ts if ts is not None else time.time(), "line": line.strip(), "kind": kind}
     if pid:
         rec["pid"] = pid
+    if scope:
+        rec["scope"] = scope
     if room:
         rec["room"] = room
     if task:
@@ -196,9 +199,9 @@ def append(line: str, *, kind: str, room: str | None, task: dict | None = None,
         task_id = task.get("id") if isinstance(task, dict) and isinstance(task.get("id"), str) else None
         acked = bool(pid and task_id and (_pid_acked(workspace, task_id, pid)
                                           or (done and _pid_in_log(summaries_path(workspace), pid))))
-        # Only a replay (the bus retrying an owed row) consults the archive: exact for recovery, and a
-        # fresh row never reads the day file under the lock.
-        landed = bool(pid) and (acked or _pid_in_log(path, pid) or (replay and _pid_in_archive(workspace, pid, rec["ts"])))
+        # No ordering heuristic: an unacknowledged row absent from the live log is looked up in the
+        # archive file its own timestamp names — exact, and a fresh row only pays for a small read.
+        landed = bool(pid) and (acked or _pid_in_log(path, pid) or _pid_in_archive(workspace, pid, rec["ts"]))
         if not landed:
             with open(path, "a", encoding="utf-8") as f:
                 f.write(json.dumps(rec, ensure_ascii=False) + "\n")

--- a/src/activity_rows.py
+++ b/src/activity_rows.py
@@ -113,7 +113,7 @@ def _task_rows_on_disk(workspace: Path | None, task_id: str, since: float, until
     day, last = min(since, until), max(since, until)
     while day <= last + 86400 and len(names) < 400:
         names.append(f"{live.stem}.archive.{day_of(day)}.jsonl"); day += 86400
-    count, applied = 0, {}
+    count, applied, seen = 0, {}, set()
     for name in dict.fromkeys(names):
         try:
             lines = live.with_name(name).read_text(encoding="utf-8").splitlines()
@@ -126,8 +126,13 @@ def _task_rows_on_disk(workspace: Path | None, task_id: str, since: float, until
                 continue
             if (rec.get("task") or {}).get("id") != task_id:
                 continue
+            pid = rec.get("pid")
+            if pid is not None:
+                if pid in seen:
+                    continue  # an interrupted rotation leaves a row in the live log AND the archive
+                seen.add(pid)
             count += 1
-            gen, emitted = _pid_counter(rec.get("pid"))
+            gen, emitted = _pid_counter(pid)
             if gen is not None:
                 applied[gen] = max(int(applied.get(gen, 0)), emitted)
     return count, applied

--- a/src/agent_availability.py
+++ b/src/agent_availability.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Two room-visible projections of one private runtime: what this agent is doing on THIS task, and
+whether it can take more work. Neither says why it is busy.
+
+The room availability contract is deliberately narrow — available | busy_accepting |
+busy_unavailable | offline | unknown — computed here from the private canonical numbers
+(active runs, capacity, queue depth, runtime health, accepting flag) that never leave the owner's
+side. A member sees "Busy · not accepting work", never "reviewing the acquisition documents" or
+"3 of 4 runs". Agents consume the same projection: a second agent asked for help can see the first
+is on it and offer to work independently instead of doubling up.
+"""
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from workspace_default import resolve_workspace
+
+AVAILABILITY = ("available", "busy_accepting", "busy_unavailable", "offline", "unknown")
+ACTIVE_PHASES = frozenset({"RUNNING", "WAITING"})
+HEARTBEAT_MAX_AGE_S = 90.0  # matches the core liveness rule: younger than ~90 s is alive
+
+
+@dataclass
+class AgentRuntimeState:
+    """Private, canonical. Change the scheduler and only this changes; the room contract holds."""
+
+    active_runs: int = 0
+    max_concurrency: int = 1
+    queue_depth: int = 0
+    runtime_healthy: bool | None = None  # None = nothing readable
+    accepting_work: bool = True
+
+
+def availability(state: AgentRuntimeState) -> str:
+    """The narrow room-visible value. Never derived from 'has a running task' alone: a concurrent
+    agent with 2 of 4 runs active is busy_accepting, not busy."""
+    if state.runtime_healthy is None:
+        return "unknown"
+    if not state.runtime_healthy:
+        return "offline"
+    if not state.accepting_work:
+        return "busy_unavailable"
+    if state.active_runs <= 0 and state.queue_depth <= 0:
+        return "available"
+    if state.active_runs < max(state.max_concurrency, 1):
+        return "busy_accepting"
+    return "busy_unavailable"
+
+
+def availability_projection(state: AgentRuntimeState, worker: str | None = None) -> dict:
+    """What the room may see. No counts, no reasons, no queue contents."""
+    return {"worker": worker, "availability": availability(state), "scope": "room", "ts": time.time()}
+
+
+def task_projection(snapshot: dict, now: float | None = None) -> dict:
+    """What the room may see about one task: who is on it, where it stands, since when. Built from
+    the bus's shared projection; carries no summary and no steps."""
+    started = snapshot.get("started_at")
+    now = now if now is not None else time.time()
+    return {"task_id": snapshot.get("task_id"), "message_event_id": snapshot.get("message_event_id"),
+            "worker": snapshot.get("worker"), "phase": snapshot.get("phase"),
+            "since_s": (max(0.0, now - started) if isinstance(started, (int, float)) else None),
+            "scope": "room"}
+
+
+def read_runtime_state(workspace: Path | None = None, host: str | None = None,
+                       max_concurrency: int = 1, now: float | None = None) -> AgentRuntimeState:
+    """The private numbers from what the engine already writes: task snapshots under state/activity
+    (active runs), the tasks/ directory (queue depth), and the core heartbeat (health)."""
+    ws = workspace or resolve_workspace()
+    now = now if now is not None else time.time()
+    active = 0
+    for p in (ws / "state" / "activity").glob("task-*.json"):
+        try:
+            if json.loads(p.read_text(encoding="utf-8")).get("phase") in ACTIVE_PHASES:
+                active += 1
+        except (OSError, ValueError):
+            continue
+    queue = sum(1 for p in (ws / "tasks").glob("task-*.txt") if not p.name.startswith("task-cron-")) if (ws / "tasks").exists() else 0
+    healthy: bool | None = None
+    cores = ws / "state" / "cores"
+    beats = list(cores.glob(f"{host}.alive")) if host else list(cores.glob("*.alive")) if cores.exists() else []
+    if beats:
+        healthy = any(now - b.stat().st_mtime < HEARTBEAT_MAX_AGE_S for b in beats)
+    return AgentRuntimeState(active_runs=active, max_concurrency=max_concurrency, queue_depth=queue,
+                             runtime_healthy=healthy, accepting_work=True)

--- a/src/agent_availability.py
+++ b/src/agent_availability.py
@@ -19,6 +19,12 @@ from pathlib import Path
 from workspace_default import resolve_workspace
 
 AVAILABILITY = ("available", "busy_accepting", "busy_unavailable", "offline", "unknown")
+# What a room policy may turn each true value into: the same, something less available, or
+# unknown. Never more available, never a different known fact (offline is a fact, not a level).
+NARROWING = {"available": frozenset({"available", "busy_accepting", "busy_unavailable", "unknown"}),
+             "busy_accepting": frozenset({"busy_accepting", "busy_unavailable", "unknown"}),
+             "busy_unavailable": frozenset({"busy_unavailable", "unknown"}),
+             "offline": frozenset({"offline", "unknown"}), "unknown": frozenset({"unknown"})}
 ACTIVE_PHASES = frozenset({"RUNNING", "WAITING"})
 HEARTBEAT_MAX_AGE_S = 90.0  # matches the core liveness rule: younger than ~90 s is alive
 
@@ -58,7 +64,7 @@ def availability_projection(state: AgentRuntimeState, worker: str | None = None,
     value = availability(state)
     if room_policy is not None:
         narrowed = room_policy(room_id, value)
-        if narrowed in AVAILABILITY:
+        if narrowed in NARROWING[value]:  # a policy may only say less; anything else is ignored
             value = narrowed
     return {"worker": worker, "room": room_id, "availability": value, "audience": "room",
             "projection": "AVAILABILITY", "ts": time.time()}
@@ -72,7 +78,7 @@ def task_projection(snapshot: dict, now: float | None = None) -> dict:
     return {"task_id": snapshot.get("task_id"), "message_event_id": snapshot.get("message_event_id"),
             "worker": snapshot.get("worker"), "phase": snapshot.get("phase"),
             "since_s": (max(0.0, now - started) if isinstance(started, (int, float)) else None),
-            "audience": "room", "projection": "TASK_STATUS"}
+            "audience": snapshot.get("audience") or "room", "projection": "TASK_STATUS"}
 
 
 def this_host() -> str:

--- a/src/agent_availability.py
+++ b/src/agent_availability.py
@@ -50,9 +50,18 @@ def availability(state: AgentRuntimeState) -> str:
     return "busy_unavailable"
 
 
-def availability_projection(state: AgentRuntimeState, worker: str | None = None) -> dict:
-    """What the room may see. No counts, no reasons, no queue contents."""
-    return {"worker": worker, "availability": availability(state), "scope": "room", "ts": time.time()}
+def availability_projection(state: AgentRuntimeState, worker: str | None = None, room_id: str | None = None,
+                            room_policy=None) -> dict:
+    """What THIS room may see. No counts, no reasons, no queue contents. The canonical state is global;
+    `room_policy(room_id, value) -> value` lets a room learn less (never more), so a member of one
+    room cannot infer what the agent does in another."""
+    value = availability(state)
+    if room_policy is not None:
+        narrowed = room_policy(room_id, value)
+        if narrowed in AVAILABILITY:
+            value = narrowed
+    return {"worker": worker, "room": room_id, "availability": value, "audience": "room",
+            "projection": "AVAILABILITY", "ts": time.time()}
 
 
 def task_projection(snapshot: dict, now: float | None = None) -> dict:
@@ -63,7 +72,7 @@ def task_projection(snapshot: dict, now: float | None = None) -> dict:
     return {"task_id": snapshot.get("task_id"), "message_event_id": snapshot.get("message_event_id"),
             "worker": snapshot.get("worker"), "phase": snapshot.get("phase"),
             "since_s": (max(0.0, now - started) if isinstance(started, (int, float)) else None),
-            "scope": "room"}
+            "audience": "room", "projection": "TASK_STATUS"}
 
 
 def read_runtime_state(workspace: Path | None = None, host: str | None = None,

--- a/src/agent_availability.py
+++ b/src/agent_availability.py
@@ -94,18 +94,21 @@ def this_host() -> str:
         return platform.node().split(".")[0]
 
 
-def _heartbeat_started_at(path: Path) -> float | None:
-    """When this host's heartbeat writer started: a snapshot written before it belongs to an earlier life."""
+def _session_started_at(ws: Path) -> float | None:
+    """When this core session's task watcher started: it dispatches every task that gets a snapshot and
+    dies with the session, so its pid file's mtime is the session boundary (the heartbeat writer is not)."""
     try:
-        v = json.loads(path.read_text(encoding="utf-8")).get("started_at")
-        return float(v) if isinstance(v, (int, float)) else None
-    except (OSError, ValueError, TypeError):
+        return (ws / "state" / "watch-tasks-stream.pid").stat().st_mtime
+    except OSError:
         return None
 
 
-def snapshot_is_live(written_at: float, now: float, core_started_at: float | None) -> bool:
-    """A RUNNING snapshot counts as work only while a live core could still be writing it."""
-    if core_started_at is not None and written_at < core_started_at:
+def snapshot_is_live(written_at: float, now: float, task_file_present: bool, session_started_at: float | None) -> bool:
+    """A RUNNING snapshot counts as work while its task is still in the queue; once the task file is gone,
+    only a run of this session, still within a live run's event cadence, can be finishing it."""
+    if task_file_present:
+        return True
+    if session_started_at is not None and written_at < session_started_at:
         return False
     return now - written_at <= ACTIVE_SNAPSHOT_MAX_AGE_S
 
@@ -117,13 +120,13 @@ def read_runtime_state(workspace: Path | None = None, host: str | None = None,
     ws = workspace or resolve_workspace()
     host = host or this_host()
     now = now if now is not None else time.time()
-    beat = ws / "state" / "cores" / f"{host}.alive"
-    core_started_at = _heartbeat_started_at(beat) if beat.exists() else None
+    session_started_at = _session_started_at(ws)
     active = 0
     for p in (ws / "state" / "activity").glob("task-*.json"):
         try:
             phase = json.loads(p.read_text(encoding="utf-8")).get("phase")
-            if phase in ACTIVE_PHASES and snapshot_is_live(p.stat().st_mtime, now, core_started_at):
+            task_file_present = (ws / "tasks" / f"{p.stem}.txt").exists()
+            if phase in ACTIVE_PHASES and snapshot_is_live(p.stat().st_mtime, now, task_file_present, session_started_at):
                 active += 1
         except (OSError, ValueError):
             continue

--- a/src/agent_availability.py
+++ b/src/agent_availability.py
@@ -27,6 +27,8 @@ NARROWING = {"available": frozenset({"available", "busy_accepting", "busy_unavai
              "offline": frozenset({"offline", "unknown"}), "unknown": frozenset({"unknown"})}
 ACTIVE_PHASES = frozenset({"RUNNING", "WAITING"})
 HEARTBEAT_MAX_AGE_S = 90.0  # matches the core liveness rule: younger than ~90 s is alive
+# A live run keeps writing its snapshot (events, transitions); one silent this long is a leftover.
+ACTIVE_SNAPSHOT_MAX_AGE_S = 1800.0
 
 
 @dataclass
@@ -92,6 +94,22 @@ def this_host() -> str:
         return platform.node().split(".")[0]
 
 
+def _heartbeat_started_at(path: Path) -> float | None:
+    """When this host's heartbeat writer started: a snapshot written before it belongs to an earlier life."""
+    try:
+        v = json.loads(path.read_text(encoding="utf-8")).get("started_at")
+        return float(v) if isinstance(v, (int, float)) else None
+    except (OSError, ValueError, TypeError):
+        return None
+
+
+def snapshot_is_live(written_at: float, now: float, core_started_at: float | None) -> bool:
+    """A RUNNING snapshot counts as work only while a live core could still be writing it."""
+    if core_started_at is not None and written_at < core_started_at:
+        return False
+    return now - written_at <= ACTIVE_SNAPSHOT_MAX_AGE_S
+
+
 def read_runtime_state(workspace: Path | None = None, host: str | None = None,
                        max_concurrency: int = 1, now: float | None = None) -> AgentRuntimeState:
     """The private numbers from what the engine already writes: task snapshots under state/activity
@@ -99,10 +117,13 @@ def read_runtime_state(workspace: Path | None = None, host: str | None = None,
     ws = workspace or resolve_workspace()
     host = host or this_host()
     now = now if now is not None else time.time()
+    beat = ws / "state" / "cores" / f"{host}.alive"
+    core_started_at = _heartbeat_started_at(beat) if beat.exists() else None
     active = 0
     for p in (ws / "state" / "activity").glob("task-*.json"):
         try:
-            if json.loads(p.read_text(encoding="utf-8")).get("phase") in ACTIVE_PHASES:
+            phase = json.loads(p.read_text(encoding="utf-8")).get("phase")
+            if phase in ACTIVE_PHASES and snapshot_is_live(p.stat().st_mtime, now, core_started_at):
                 active += 1
         except (OSError, ValueError):
             continue
@@ -112,5 +133,6 @@ def read_runtime_state(workspace: Path | None = None, host: str | None = None,
     beats = [cores / f"{host}.alive"] if (cores / f"{host}.alive").exists() else []
     if beats:
         healthy = any(now - b.stat().st_mtime < HEARTBEAT_MAX_AGE_S for b in beats)
+    # accepting_work: the scheduler's pause control sets it later; this reader never does.
     return AgentRuntimeState(active_runs=active, max_concurrency=max_concurrency, queue_depth=queue,
                              runtime_healthy=healthy, accepting_work=True)

--- a/src/agent_availability.py
+++ b/src/agent_availability.py
@@ -75,11 +75,23 @@ def task_projection(snapshot: dict, now: float | None = None) -> dict:
             "audience": "room", "projection": "TASK_STATUS"}
 
 
+def this_host() -> str:
+    """The label the heartbeat writes under, via the one resolver core_heartbeat uses; never a glob.
+    state/cores/ is synced across hosts, so any other choice lets a peer answer for this agent."""
+    try:
+        from util_paths import _host_label
+        return _host_label()
+    except Exception:  # noqa: BLE001
+        import platform
+        return platform.node().split(".")[0]
+
+
 def read_runtime_state(workspace: Path | None = None, host: str | None = None,
                        max_concurrency: int = 1, now: float | None = None) -> AgentRuntimeState:
     """The private numbers from what the engine already writes: task snapshots under state/activity
-    (active runs), the tasks/ directory (queue depth), and the core heartbeat (health)."""
+    (active runs), the tasks/ directory (queue depth), and THIS host's core heartbeat (health)."""
     ws = workspace or resolve_workspace()
+    host = host or this_host()
     now = now if now is not None else time.time()
     active = 0
     for p in (ws / "state" / "activity").glob("task-*.json"):
@@ -91,7 +103,7 @@ def read_runtime_state(workspace: Path | None = None, host: str | None = None,
     queue = sum(1 for p in (ws / "tasks").glob("task-*.txt") if not p.name.startswith("task-cron-")) if (ws / "tasks").exists() else 0
     healthy: bool | None = None
     cores = ws / "state" / "cores"
-    beats = list(cores.glob(f"{host}.alive")) if host else list(cores.glob("*.alive")) if cores.exists() else []
+    beats = [cores / f"{host}.alive"] if (cores / f"{host}.alive").exists() else []
     if beats:
         healthy = any(now - b.stat().st_mtime < HEARTBEAT_MAX_AGE_S for b in beats)
     return AgentRuntimeState(active_runs=active, max_concurrency=max_concurrency, queue_depth=queue,

--- a/src/hitl/manager.py
+++ b/src/hitl/manager.py
@@ -44,6 +44,19 @@ AUTH_KIND = "auth"
 ID_RE = re.compile(r"^hitl_[A-Za-z0-9_-]+$")
 
 
+def _activity(task_ids, to_phase: str, reason: str) -> None:
+    """A requirement is the scheduler's WAITING; its end is RUNNING again. Never breaks HITL."""
+    if not task_ids:
+        return
+    try:
+        import activity_bus as _bus
+        store = _bus.ActivityStore()
+        for tid in task_ids:
+            store.apply(_bus.LifecycleTransition(tid, to_phase, reason=reason))
+    except Exception:  # noqa: BLE001
+        pass
+
+
 def default_store(workspace: Optional[Path] = None) -> Path:
     """Where every hitl component on a host keeps requirements: the hook driver
     writes here, the supervisor projects from here. One store, one card."""
@@ -171,7 +184,9 @@ class HitlManager:
                 req.decided_by = POLICY_DECIDER
                 req.transition(STATUS_IN_PROGRESS)
             self.store.save(req)
-            return req
+        if req.decided_by != POLICY_DECIDER and req.status not in TERMINAL_STATUSES:
+            _activity(req.blocked_task_ids, "WAITING", req.kind)  # policy-answered: nobody is waiting
+        return req
 
     def active(self) -> List[HumanRequirement]:
         return [r for r in self.store.all() if r.status not in TERMINAL_STATUSES]
@@ -219,7 +234,8 @@ class HitlManager:
                 return []
             req.transition(status)
             self.store.save(req)
-            return list(req.blocked_task_ids)
+        _activity(req.blocked_task_ids, "RUNNING", status)
+        return list(req.blocked_task_ids)
 
     def link_blocked_task(self, req_id: str, task_id: str) -> None:
         with self.store.locked():

--- a/src/outbox.py
+++ b/src/outbox.py
@@ -702,6 +702,18 @@ def record_delivered(root: Path, item_id: str, *, provider: Optional[str] = None
     if destination:
         d["destination"] = destination
     _write_item(Path(root), item_id, d)
+    _activity_completed(item_id)
+
+
+def _activity_completed(item_id: str) -> None:
+    """A delivered task result is the scheduler's COMPLETED. Never breaks delivery."""
+    if not str(item_id).startswith("task-"):
+        return
+    try:
+        import activity_bus as _bus
+        _bus.ActivityStore().apply(_bus.LifecycleTransition(item_id, "COMPLETED", reason="delivered"))
+    except Exception:  # noqa: BLE001
+        pass
 
 
 def item_status(root: Path, item_id: str) -> Optional[str]:

--- a/src/task-emit.sh
+++ b/src/task-emit.sh
@@ -41,6 +41,14 @@ emit_task_file() {
 
 # The handler-failed fallback, NOT a shutdown emit: it runs in normal drain on
 # real stdout, so it must not borrow the shutdown emitter's fd 9.
+# The watcher's ordinary dispatch: QUEUED was marked once by dispatch_task; here the live core is told
+# (the printf failing means stdout is gone and the watcher exits, as before) and RUNNING follows.
+emit_dispatch_task_file() {
+	local filename="$1"
+	printf 'TASK_FILE: %s\n' "$filename" || exit 0
+	activity_transition RUNNING "$filename"
+}
+
 emit_fallback_task_file() {
 	local filename="$1"
 	queued_activity_row "$filename"

--- a/src/task-emit.sh
+++ b/src/task-emit.sh
@@ -8,20 +8,33 @@
 # The message reached this device: a `queued` row for the room's card, before any turn has the task.
 # Fire-and-forget through the skill's own writer (which decides whether the file names a room);
 # it must never delay or fail the emit, and it is inert when TASKS_DIR is unset (tests, probes).
-queued_activity_row() {
-	local filename="$1"
+# The scheduler owns the task's lifecycle: QUEUED when the file lands, RUNNING once a live core was
+# told, CANCELLED for the task a CANCEL_INSTRUCTION names. Through the activity bus (state, then rows),
+# fire-and-forget: it can neither delay nor fail the emit, and it is inert when TASKS_DIR is unset.
+activity_transition() {
+	local to="$1" filename="$2"
 	[ -n "${TASKS_DIR:-}" ] && [ -f "$TASKS_DIR/$filename" ] || return 0
-	local writer="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/skills/agent-activity/scripts/activity.py"
-	[ -f "$writer" ] || return 0
-	# The watcher's resolved interpreter, never PATH's: a configured python that works while PATH's
-	# does not would otherwise deliver the task and silently write no row.
-	( "${SUTANDO_PY_BIN:-python3}" "$writer" queued --task-file "$TASKS_DIR/$filename" >/dev/null 2>&1 & ) 2>/dev/null || true
+	local bus="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/activity_bus.py"
+	[ -f "$bus" ] || return 0
+	# Stamped now, so a QUEUED that lands after its RUNNING is reconciled by time, not dropped.
+	( "${SUTANDO_PY_BIN:-python3}" "$bus" transition "$to" --task-file "$TASKS_DIR/$filename" --ts "$(date +%s)" >/dev/null 2>&1 & ) 2>/dev/null || true
 	return 0
 }
+activity_cancel_target() {
+	local filename="$1" target
+	[ -n "${TASKS_DIR:-}" ] && [ -f "$TASKS_DIR/$filename" ] || return 0
+	local bus="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/activity_bus.py"
+	[ -f "$bus" ] || return 0
+	target="$(grep -oE 'CANCEL_INSTRUCTION:[[:space:]]*stop processing[[:space:]]+task-[A-Za-z0-9._-]+' "$TASKS_DIR/$filename" 2>/dev/null | grep -oE 'task-[A-Za-z0-9._-]+$' | head -1)"
+	[ -n "$target" ] || return 0
+	( "${SUTANDO_PY_BIN:-python3}" "$bus" transition CANCELLED --task-id "$target" --reason "cancel requested" >/dev/null 2>&1 & ) 2>/dev/null || true
+	return 0
+}
+queued_activity_row() { activity_transition QUEUED "$1"; activity_cancel_target "$1"; }
 emit_task_file() {
 	local filename="$1"
 	queued_activity_row "$filename"
-	printf 'TASK_FILE: %s\n' "$filename" >&9 && return 0
+	printf 'TASK_FILE: %s\n' "$filename" >&9 && { activity_transition RUNNING "$filename"; return 0; }
 	echo "watch-tasks-stream: FAILED to emit TASK_FILE for $filename on fd 9 (rc=$?); the task file is written but the live core was not told" >&2
 	return 0
 }
@@ -31,7 +44,7 @@ emit_task_file() {
 emit_fallback_task_file() {
 	local filename="$1"
 	queued_activity_row "$filename"
-	printf 'TASK_FILE: %s\n' "$filename" && return 0
+	printf 'TASK_FILE: %s\n' "$filename" && { activity_transition RUNNING "$filename"; return 0; }
 	echo "watch-tasks-stream: FAILED to emit TASK_FILE for $filename on stdout after a handler fallback (rc=$?); the fallback file is written but the live core was not told" >&2
 	return 0
 }

--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -193,6 +193,8 @@ publish_terminal_failure() {
   # Reading then mutating a path a provider can still claim has no safe ordering.
   if ln "$temporary" "$result" 2>/dev/null; then
     rc=0
+    # The scheduler's FAILED: the task ends here, whatever a provider observed.
+    ( "${SUTANDO_PY_BIN:-python3}" "$__SCRIPT_DIR/activity_bus.py" transition FAILED --task-file "$TASKS_DIR/$filename" --reason "$reason" >/dev/null 2>&1 & ) 2>/dev/null || true
   elif handler_result_exists "$filename"; then
     rc=0
   else

--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -342,6 +342,7 @@ drain_dispatch_queue() {
       "$WATCH_RUNTIME_DIR/events" \
       "$(basename "$marker")" &
     printf '%s\n' "$!" > "$worker_receipt"
+    activity_transition RUNNING "$(basename "$marker")"  # a launched handler is the task's pickup
     running_count=$((running_count + 1))
   done
   shopt -u nullglob

--- a/src/watch-tasks-stream.sh
+++ b/src/watch-tasks-stream.sh
@@ -372,8 +372,9 @@ queue_handler_task() {
 dispatch_task() {
   local task_path="$1" rc filename
   filename="$(basename "$task_path")"
+  queued_activity_row "$filename"
   if [ -z "$DISPATCH_DIR" ]; then
-    printf 'TASK_FILE: %s\n' "$filename" || exit 0
+    emit_dispatch_task_file "$filename"
     return
   fi
   "$SUTANDO_TASK_EVENT_HANDLER" \
@@ -386,10 +387,10 @@ dispatch_task() {
   rc=$?
   if [ "$rc" -eq 0 ]; then
     if [ -f "$FALLBACKS_DIR/$filename" ]; then
-      printf 'TASK_FILE: %s\n' "$filename" || exit 0
+      emit_dispatch_task_file "$filename"
       return
     fi
-    queue_handler_task "$task_path" "fallback" || printf 'TASK_FILE: %s\n' "$filename" || exit 0
+    queue_handler_task "$task_path" "fallback" || emit_dispatch_task_file "$filename"
   elif [ "$rc" -eq 4 ]; then
     # A required handler is a security boundary. Remove any legacy fallback
     # receipt and never make this task visible to the unrestricted live core.
@@ -398,10 +399,10 @@ dispatch_task() {
       publish_terminal_failure "$filename" "could not be queued" || true
     fi
   elif [ "$rc" -eq 3 ]; then
-    printf 'TASK_FILE: %s\n' "$filename" || exit 0
+    emit_dispatch_task_file "$filename"
   else
     echo "watch-tasks-stream: optional task handler probe failed for $filename (exit $rc); falling back to live core" >&2
-    printf 'TASK_FILE: %s\n' "$filename" || exit 0
+    emit_dispatch_task_file "$filename"
   fi
 }
 

--- a/tests/activity-bus.test.py
+++ b/tests/activity-bus.test.py
@@ -506,33 +506,37 @@ class IdempotentProjection(unittest.TestCase):
         self.assertEqual(len(card.summaries_path(self.ws).read_text().splitlines()), 1, "one summary")
         self.assertEqual(self.rows(), ["picked up", "replied"])
 class Visibility(unittest.TestCase):
-    """Audience is decided in the bus: lifecycle rows are the room's, observations are the owner's,
-    and the two projections of one TaskRun carry only what their audience may see."""
+    """Two fields, two questions: audience is who may receive, projection is what they see. Lifecycle
+    rows are the room's TASK_STATUS, observations are the owner's RUNTIME_DETAIL."""
 
-    def test_lifecycle_rows_are_room_scoped_and_observations_owner_scoped(self):
+    def test_lifecycle_rows_are_the_rooms_task_status_and_observations_the_owners_detail(self):
         s = TaskActivityState("t")
         s, r1 = reduce(s, T("t", "RUNNING", ts=1, message_event_id="$m"))
         s, r2 = reduce(s, E("t", "S1", 1, "Thinking", text="checking", ts=2))
         s, r3 = reduce(s, E("t", "S1", 2, "InteractionRequired", text="pick one", ts=3))
-        self.assertEqual([r["scope"] for r in r1 + r2], ["room", "owner"])
-        self.assertEqual([r["scope"] for r in r3], ["room"], "the WAITING transition an observation caused is still lifecycle")
+        self.assertEqual([(r["audience"], r["projection"]) for r in r1 + r2],
+                         [("room", "TASK_STATUS"), ("owner", "RUNTIME_DETAIL")])
+        self.assertEqual([(r["audience"], r["projection"]) for r in r3], [("room", "TASK_STATUS")],
+                         "the WAITING transition an observation caused is still lifecycle")
 
     def test_the_shared_projection_carries_no_summary_and_the_private_one_does(self):
         s = TaskActivityState("t")
         s, _ = reduce(s, T("t", "RUNNING", ts=1, message_event_id="$m", worker="air"))
         s, _ = reduce(s, E("t", "S1", 1, "Working", text="Running tests", ts=2))
         shared, private = bus.shared_projection(s), bus.private_projection(s)
-        self.assertEqual((shared["phase"], shared["worker"], shared["scope"]), ("RUNNING", "air", "room"))
+        self.assertEqual((shared["phase"], shared["worker"], shared["audience"], shared["projection"]),
+                         ("RUNNING", "air", "room", "TASK_STATUS"))
         self.assertNotIn("summary", shared)
-        self.assertEqual((private["summary"], private["seq"], private["scope"]), ("Running tests", 1, "owner"))
+        self.assertEqual((private["summary"], private["seq"], private["audience"], private["projection"]),
+                         ("Running tests", 1, "owner", "RUNTIME_DETAIL"))
 
-    def test_the_writer_persists_the_scope_on_the_row(self):
+    def test_the_writer_persists_audience_and_projection_on_the_row(self):
         ws = Path(tempfile.mkdtemp()); (ws / "state").mkdir()
         ActivityStore(ws).apply(T("t", "QUEUED", ts=1, room="!r:s", message_event_id="$m"))
         row = json.loads(card.log_path(ws).read_text().splitlines()[-1])
-        self.assertEqual(row["scope"], "room")
+        self.assertEqual((row["audience"], row["projection"]), ("room", "TASK_STATUS"))
         rec = card.append("x", kind="working", room=None, workspace=ws)
-        self.assertNotIn("scope", rec, "a row with no stated audience carries none: the client's rule applies")
+        self.assertNotIn("audience", rec, "a row with no stated audience carries none: the client's rule applies")
 
 
 class Wiring(unittest.TestCase):

--- a/tests/activity-bus.test.py
+++ b/tests/activity-bus.test.py
@@ -409,6 +409,35 @@ class IdempotentProjection(unittest.TestCase):
             sums = [json.loads(l) for l in card.summaries_path(ws).read_text().splitlines()]
             self.assertEqual([x["rows"] for x in sums], [3], f"rotate={rotate}: pickup + waiting + replied, the lost count restored")
 
+    def test_recovery_across_the_format_change_counts_a_pid_rotated_twice_once(self):
+        # rotate() archives the oldest rows BEFORE replacing the live file: one failed replacement leaves
+        # them in both places and the next rotation archives them again; count identities, not copies.
+        import activity_rows
+        ws = Path(tempfile.mkdtemp()); (ws / "state").mkdir(); store = ActivityStore(ws)
+        store.apply(T("task-dup", "RUNNING", ts=1_757_000_000.0, message_event_id="$m"))
+        store.apply(T("task-dup", "WAITING", ts=1_757_000_001.0, reason="approval"))
+        live = card.log_path(ws); real = os.replace; faults = []
+        def fail_live_once(src, dst):
+            if not faults and Path(dst) == live:
+                faults.append(1); raise OSError("one live-log replacement fault")
+            return real(src, dst)
+        with unittest.mock.patch.object(activity_rows.os, "replace", fail_live_once):
+            for i in range(card.LIVE_ROWS + 1):
+                try:
+                    card.append(f"noise {i}", kind="notice", room=None, workspace=ws)
+                except OSError:
+                    pass  # the producer that hit the fault; the rows it archived stay archived
+        for i in range(card.LIVE_ROWS + 1):
+            card.append(f"more {i}", kind="notice", room=None, workspace=ws)
+        archived = [json.loads(l).get("pid") for p in live.parent.glob(f"{live.stem}.archive.*.jsonl") for l in p.read_text().splitlines()]
+        self.assertEqual((len(faults), archived.count("task-dup:1:1")), (1, 2), "precondition: the interrupted rotation archived the pickup twice")
+        ip = card.index_path(ws); idx = json.loads(ip.read_text()); e = idx["task-dup"]
+        self.assertEqual(e["rows"], 2); e.pop("applied"); e["last_pid"] = "task-dup:1:2"; ip.write_text(json.dumps(idx))  # the old format
+        fresh = ActivityStore(ws); fresh.apply(T("task-dup", "COMPLETED", ts=1_757_000_002.0))
+        self.assertEqual(len(fresh.load("task-dup").pending), 0)
+        sums = [json.loads(l) for l in card.summaries_path(ws).read_text().splitlines()]
+        self.assertEqual([x["rows"] for x in sums], [3], "pickup + waiting + replied: a pid archived twice counts once")
+
     def test_a_rebuild_that_cannot_read_an_archive_leaves_the_row_owed_and_the_old_index_intact(self):
         # The old writer counted two rotated rows; the rebuild's first archive read fails. Nothing may
         # be published on partial evidence: the row stays owed, the index stays old-format, a retry lands.

--- a/tests/activity-bus.test.py
+++ b/tests/activity-bus.test.py
@@ -342,6 +342,98 @@ class IdempotentProjection(unittest.TestCase):
         card.append("replied", kind="done", room="!r:s", task=t, done=True, workspace=self.ws, pid="task-i2:1:2")
         self.assertEqual(len(card.summaries_path(self.ws).read_text().splitlines()), 1, "one summary")
         self.assertEqual(self.rows(), ["picked up", "replied"])
+class Wiring(unittest.TestCase):
+    """The scheduler's emit points reach the bus: the CLI from shell, the manager and the outbox in-process."""
+
+    def setUp(self):
+        self.ws = Path(tempfile.mkdtemp())
+        (self.ws / "state").mkdir(); (self.ws / "tasks").mkdir()
+        (self.ws / "tasks" / "task-w1.txt").write_text(
+            "id: task-w1\nchannel_id: !r:s\nuser_id: @q:s\nsender_name: qingyun\ntask: Fix it\nsource_message_id: $m1\nsource: ag2space\n")
+
+    def rows(self):
+        return [json.loads(l) for l in card.log_path(self.ws).read_text().splitlines()]
+
+    def test_cli_transitions_from_a_task_file_carry_room_sender_text_and_event(self):
+        for to in ("QUEUED", "RUNNING"):
+            self.assertEqual(bus.main(["transition", to, "--task-file", str(self.ws / "tasks" / "task-w1.txt"), "--workspace", str(self.ws)]), 0)
+        st = ActivityStore(self.ws).load("task-w1")
+        self.assertEqual((st.phase, st.room, st.sender, st.text, st.message_event_id), ("RUNNING", "!r:s", "@q:s", "Fix it", "$m1"))
+        self.assertEqual([(r["kind"], r["line"], r["task"]["event"]) for r in self.rows()],
+                         [("notice", "queued", "$m1"), ("processing", "picked up", "$m1")])
+
+    def test_cli_never_fails_the_caller(self):
+        self.assertEqual(bus.main(["transition", "RUNNING", "--task-file", "/nonexistent/task-x.txt", "--workspace", str(self.ws)]), 0)
+        self.assertEqual(bus.main(["transition", "RUNNING", "--workspace", str(self.ws)]), 0)
+
+    def test_a_cancel_instruction_names_its_target(self):
+        self.assertEqual(bus.cancel_target("CANCEL_INSTRUCTION: stop processing task-abc12 if still in flight."), "task-abc12")
+        self.assertIsNone(bus.cancel_target("please cancel my subscription"))
+
+    def test_a_consolidated_completion_resolves_the_holder_event_from_its_task_file(self):
+        (self.ws / "tasks" / "task-h1.txt").write_text("id: task-h1\nchannel_id: !r:s\ntask: holder\nsource_message_id: $holder\n")
+        bus.main(["transition", "RUNNING", "--task-file", str(self.ws / "tasks" / "task-w1.txt"), "--workspace", str(self.ws)])
+        bus.main(["transition", "COMPLETED", "--task-file", str(self.ws / "tasks" / "task-w1.txt"), "--into-task", "task-h1", "--workspace", str(self.ws)])
+        self.assertEqual((self.rows()[-1]["line"], self.rows()[-1]["task"]["into"]), ("consolidated", "$holder"))
+
+    def test_a_queued_that_lands_after_its_running_is_history_not_a_regression(self):
+        # The emitter's QUEUED and RUNNING are independent processes: RUNNING (stamped later) can take
+        # the lock first. The earlier-stamped QUEUED still writes its row and never regresses the phase.
+        store = ActivityStore(self.ws)
+        st = store.apply(T("task-w1", "RUNNING", ts=10.0, message_event_id="$m1", room="!r:s"))
+        st = store.apply(T("task-w1", "QUEUED", ts=9.0))
+        self.assertEqual((st.phase, st.generation), ("RUNNING", 1))
+        self.assertEqual([(r["kind"], r["line"]) for r in self.rows()], [("processing", "picked up"), ("notice", "queued")])
+        st = store.apply(T("task-w1", "QUEUED", ts=9.0))  # replay: once
+        self.assertEqual(len(self.rows()), 2)
+        st = store.apply(T("task-w1", "QUEUED", ts=11.0))  # a later QUEUED is a replay by key: no row, no regression
+        self.assertEqual((st.phase, len(self.rows())), ("RUNNING", 2))
+
+    def test_the_hitl_manager_stays_silent_for_a_policy_answered_requirement(self):
+        import hitl.manager as hm
+        calls = []
+        class FakeStore:
+            def apply(self, item): calls.append((item.task_id, item.to_phase))
+        class Req:
+            blocked_task_ids = ["task-w1"]; kind = "permission"; status = "in_progress"; decided_by = hm.POLICY_DECIDER
+        with unittest.mock.patch.object(bus, "ActivityStore", lambda *a, **k: FakeStore()):
+            if Req.decided_by != hm.POLICY_DECIDER and Req.status not in hm.TERMINAL_STATUSES:
+                hm._activity(Req.blocked_task_ids, "WAITING", Req.kind)
+        self.assertEqual(calls, [], "policy answered it: nobody is waiting")
+        src = open(os.path.join(_SRC, "hitl", "manager.py")).read()
+        self.assertIn("if req.decided_by != POLICY_DECIDER and req.status not in TERMINAL_STATUSES:", src)
+
+    def test_the_emitter_and_the_watcher_route_through_the_bus(self):
+        emit = open(os.path.join(_SRC, "task-emit.sh")).read()
+        watcher = open(os.path.join(_SRC, "watch-tasks-stream.sh")).read()
+        for phase in ("QUEUED", "RUNNING", "CANCELLED"):
+            self.assertIn(phase, emit, f"task-emit.sh does not transition {phase}")
+        self.assertIn("activity_bus.py", emit)
+        self.assertIn("transition FAILED", watcher)
+        self.assertNotIn("( python3 ", emit + watcher, "the watcher's resolved interpreter, never PATH's python3")
+        self.assertIn("--ts", emit, "each transition is stamped so ordering survives independent processes")
+        self.assertNotIn("activity.py", emit, "the emitter must not write rows around the bus")
+
+    def test_the_hitl_manager_marks_waiting_and_running(self):
+        import hitl.manager as hm
+        calls = []
+        class FakeStore:
+            def apply(self, item): calls.append((item.task_id, item.to_phase, item.reason))
+        with unittest.mock.patch.object(bus, "ActivityStore", lambda *a, **k: FakeStore()):
+            hm._activity(["task-w1"], "WAITING", "selection")
+            hm._activity(["task-w1"], "RUNNING", "resolved")
+            hm._activity([], "WAITING", "none")
+        self.assertEqual(calls, [("task-w1", "WAITING", "selection"), ("task-w1", "RUNNING", "resolved")])
+
+    def test_the_outbox_marks_completed_for_task_results_only(self):
+        import outbox
+        calls = []
+        class FakeStore:
+            def apply(self, item): calls.append((item.task_id, item.to_phase))
+        with unittest.mock.patch.object(bus, "ActivityStore", lambda *a, **k: FakeStore()):
+            outbox._activity_completed("task-w1")
+            outbox._activity_completed("proactive-123")
+        self.assertEqual(calls, [("task-w1", "COMPLETED")])
 
 
 if __name__ == "__main__":

--- a/tests/activity-bus.test.py
+++ b/tests/activity-bus.test.py
@@ -305,6 +305,36 @@ class IdempotentProjection(unittest.TestCase):
         card.append("fresh", kind="notice", room=None, task=t, workspace=self.ws, pid="task-h1:1:9")
         self.assertEqual(card.log_path(self.ws).read_text().count('"pid": "task-h1:1:9"'), 1, "control: a new pid appends once")
 
+    def test_the_index_never_counts_a_replayed_pid_twice_whatever_landed_between(self):
+        # The drained-snapshot save fails once AFTER row, ack and index landed; a same-task hook row
+        # lands through the shared writer; the replay must not count the pickup again (4 arms).
+        import activity_rows
+        for fault, hook in ((False, False), (True, False), (False, True), (True, True)):
+            ws = Path(tempfile.mkdtemp()); (ws / "state").mkdir()
+            store = ActivityStore(ws); real_save = store.save; hit = {"n": 0}
+            def faulty_save(state):
+                if fault and not state.pending and hit["n"] == 0:
+                    hit["n"] += 1
+                    raise OSError("snapshot disk full")  # the drained snapshot never publishes
+                real_save(state)
+            store.save = faulty_save
+            if fault:
+                with self.assertRaises(OSError):
+                    store.apply(T("task-x1", "RUNNING", ts=1_757_000_000.0, message_event_id="$m"))
+                self.assertEqual(len(store.load("task-x1").pending), 1, "the pickup row is still owed")
+            else:
+                store.apply(T("task-x1", "RUNNING", ts=1_757_000_000.0, message_event_id="$m"))
+            if hook:
+                card.append("hook detail", kind="working", room="!r:s", task={"id": "task-x1"}, workspace=ws)
+            fresh = ActivityStore(ws); fresh.apply(T("task-x1", "COMPLETED", ts=1_757_000_002.0))
+            self.assertEqual(len(fresh.load("task-x1").pending), 0)
+            rows = [json.loads(l) for p in (ws / "state").glob("agent-activity*.jsonl") if "summaries" not in p.name for l in p.read_text().splitlines()]
+            mine = sorted((r for r in rows if r.get("task", {}).get("id") == "task-x1"), key=lambda r: r["ts"])
+            sums = [json.loads(l) for l in card.summaries_path(ws).read_text().splitlines()]
+            expect = 3 if hook else 2
+            self.assertEqual(len(mine), expect, f"fault={fault} hook={hook}: actual rows")
+            self.assertEqual([x["rows"] for x in sums], [expect], f"fault={fault} hook={hook}: the summary counts each row once")
+
     def test_a_fresh_row_never_reads_the_archive(self):
         # Bounded cost: the archive is consulted only on a replay. Fresh bus rows and hook rows pay
         # the live-log read they always paid, and nothing more, however large the day file grows.

--- a/tests/activity-bus.test.py
+++ b/tests/activity-bus.test.py
@@ -382,6 +382,33 @@ class IdempotentProjection(unittest.TestCase):
         sums = [json.loads(l) for l in card.summaries_path(self.ws).read_text().splitlines()]
         self.assertEqual([x["rows"] for x in sums], [3], "pickup + hook + replied; the replayed pickup counted once")
 
+    def test_recovery_across_the_format_change_adds_the_count_an_old_index_save_lost(self):
+        # The previous writer appended row + ack, then its index save failed: the entry (rows=1,
+        # last_pid=:1:1) does not include the owed WAITING row that is on disk. Both arms: rows live, rows rotated.
+        import activity_rows
+        for rotate in (False, True):
+            ws = Path(tempfile.mkdtemp()); (ws / "state").mkdir(); store = ActivityStore(ws)
+            store.apply(T("task-ix", "RUNNING", ts=1_757_000_000.0, message_event_id="$m"))
+            real = activity_rows._save_index; calls = []
+            def fail_once(path, data):
+                if not calls:
+                    calls.append(1)
+                    raise OSError("one index publication fault")
+                return real(path, data)
+            with unittest.mock.patch.object(activity_rows, "_save_index", fail_once):
+                store.apply(T("task-ix", "WAITING", ts=1_757_000_001.0, reason="approval"))
+            self.assertEqual(len(store.load("task-ix").pending), 1, "the WAITING row is owed; it landed with its ack")
+            ip = card.index_path(ws); idx = json.loads(ip.read_text()); e = idx["task-ix"]
+            self.assertEqual(e["rows"], 1); e.pop("applied"); e["last_pid"] = "task-ix:1:1"; ip.write_text(json.dumps(idx))  # the old format
+            if rotate:
+                for i in range(card.LIVE_ROWS + 1):
+                    card.append(f"noise {i}", kind="notice", room=None, workspace=ws)
+                self.assertNotIn("task-ix", card.log_path(ws).read_text(), "precondition: rotated into the day archive")
+            fresh = ActivityStore(ws); fresh.apply(T("task-ix", "COMPLETED", ts=1_757_000_002.0))
+            self.assertEqual(len(fresh.load("task-ix").pending), 0)
+            sums = [json.loads(l) for l in card.summaries_path(ws).read_text().splitlines()]
+            self.assertEqual([x["rows"] for x in sums], [3], f"rotate={rotate}: pickup + waiting + replied, the lost count restored")
+
     def test_a_fresh_row_never_reads_the_archive(self):
         # Bounded cost: the archive is consulted only on a replay. Fresh bus rows and hook rows pay
         # the live-log read they always paid, and nothing more, however large the day file grows.

--- a/tests/activity-bus.test.py
+++ b/tests/activity-bus.test.py
@@ -349,6 +349,22 @@ class IdempotentProjection(unittest.TestCase):
         sums = [json.loads(l) for l in card.summaries_path(self.ws).read_text().splitlines()]
         self.assertEqual([x["rows"] for x in sums], [3])
 
+    def test_recovery_across_the_index_format_change_counts_the_old_pickup_once(self):
+        # The previous writer left rows=1 and last_pid (no applied map) with the pickup row still
+        # owed; the new writer's replay must carry that evidence over, not count the pickup again.
+        store = ActivityStore(self.ws)
+        store.apply(T("task-up", "RUNNING", ts=1_757_000_000.0, message_event_id="$m"))  # row, ack, index landed
+        ip = card.index_path(self.ws); idx = json.loads(ip.read_text()); e = idx["task-up"]
+        self.assertEqual(e["rows"], 1); e.pop("applied"); e["last_pid"] = "task-up:1:1"  # the old format on disk
+        ip.write_text(json.dumps(idx))
+        st = store.load("task-up"); st.pending = [{"kind": "processing", "line": "picked up", "ts": 1_757_000_000.0, "room": "!r:s",
+                                                   "task": {"id": "task-up"}, "done": False, "pid": "task-up:1:1", "attempts": 1}]
+        store.save(st)  # the drained snapshot never published: the pickup is still owed
+        fresh = ActivityStore(self.ws); fresh.apply(T("task-up", "COMPLETED", ts=1_757_000_002.0))
+        self.assertEqual(len(fresh.load("task-up").pending), 0)
+        sums = [json.loads(l) for l in card.summaries_path(self.ws).read_text().splitlines()]
+        self.assertEqual([x["rows"] for x in sums], [2], "pickup + replied, the replayed pickup counted once")
+
     def test_a_fresh_row_never_reads_the_archive(self):
         # Bounded cost: the archive is consulted only on a replay. Fresh bus rows and hook rows pay
         # the live-log read they always paid, and nothing more, however large the day file grows.

--- a/tests/activity-bus.test.py
+++ b/tests/activity-bus.test.py
@@ -409,6 +409,36 @@ class IdempotentProjection(unittest.TestCase):
             sums = [json.loads(l) for l in card.summaries_path(ws).read_text().splitlines()]
             self.assertEqual([x["rows"] for x in sums], [3], f"rotate={rotate}: pickup + waiting + replied, the lost count restored")
 
+    def test_a_rebuild_that_cannot_read_an_archive_leaves_the_row_owed_and_the_old_index_intact(self):
+        # The old writer counted two rotated rows; the rebuild's first archive read fails. Nothing may
+        # be published on partial evidence: the row stays owed, the index stays old-format, a retry lands.
+        import activity_rows
+        ws = Path(tempfile.mkdtemp()); (ws / "state").mkdir(); store = ActivityStore(ws)
+        store.apply(T("task-ar", "RUNNING", ts=1_757_000_000.0, message_event_id="$m"))
+        store.apply(T("task-ar", "WAITING", ts=1_757_000_001.0, reason="approval"))
+        ip = card.index_path(ws); idx = json.loads(ip.read_text()); e = idx["task-ar"]
+        self.assertEqual(e["rows"], 2); e.pop("applied"); e["last_pid"] = "task-ar:1:2"; ip.write_text(json.dumps(idx))  # the old format
+        for i in range(card.LIVE_ROWS + 1):
+            card.append(f"noise {i}", kind="notice", room=None, workspace=ws)
+        self.assertNotIn("task-ar", card.log_path(ws).read_text(), "precondition: both rows rotated")
+        real = Path.read_text; hits = []
+        def faulty(self_, *a, **k):
+            if ".archive." in self_.name and self_.exists() and not hits:
+                hits.append(str(self_))
+                raise OSError("one transient archive read failure")
+            return real(self_, *a, **k)
+        fresh = ActivityStore(ws)
+        with unittest.mock.patch.object(Path, "read_text", faulty):
+            fresh.apply(T("task-ar", "COMPLETED", ts=1_757_000_002.0))
+        self.assertEqual(hits and len(hits), 1, "the fault fired once")
+        self.assertEqual(len(fresh.load("task-ar").pending), 1, "the done row stays owed")
+        self.assertFalse(card.summaries_path(ws).exists(), "nothing published on partial evidence")
+        idx = json.loads(ip.read_text()); self.assertEqual((idx["task-ar"]["rows"], "applied" in idx["task-ar"]), (2, False), "old index intact")
+        ActivityStore(ws).apply(T("task-ar", "COMPLETED", ts=1_757_000_002.0))  # the retry, archive readable
+        self.assertEqual(len(ActivityStore(ws).load("task-ar").pending), 0)
+        sums = [json.loads(l) for l in card.summaries_path(ws).read_text().splitlines()]
+        self.assertEqual([x["rows"] for x in sums], [3], "pickup + waiting + replied once the archive could be read")
+
     def test_a_fresh_row_never_reads_the_archive(self):
         # Bounded cost: the archive is consulted only on a replay. Fresh bus rows and hook rows pay
         # the live-log read they always paid, and nothing more, however large the day file grows.

--- a/tests/activity-bus.test.py
+++ b/tests/activity-bus.test.py
@@ -365,6 +365,23 @@ class IdempotentProjection(unittest.TestCase):
         sums = [json.loads(l) for l in card.summaries_path(self.ws).read_text().splitlines()]
         self.assertEqual([x["rows"] for x in sums], [2], "pickup + replied, the replayed pickup counted once")
 
+    def test_recovery_across_the_format_change_survives_a_pidless_hook_that_nulled_last_pid(self):
+        # The previous writer counted pickup + hook (rows=2) and its slot reads None after the hook;
+        # the owed pickup's replay under the new writer must not count a third time.
+        store = ActivityStore(self.ws)
+        store.apply(T("task-up2", "RUNNING", ts=1_757_000_000.0, message_event_id="$m"))
+        card.append("hook detail", kind="working", room="!r:s", task={"id": "task-up2"}, workspace=self.ws)
+        ip = card.index_path(self.ws); idx = json.loads(ip.read_text()); e = idx["task-up2"]
+        self.assertEqual(e["rows"], 2); e.pop("applied"); e["last_pid"] = None  # the old format after a pidless row
+        ip.write_text(json.dumps(idx))
+        st = store.load("task-up2"); st.pending = [{"kind": "processing", "line": "picked up", "ts": 1_757_000_000.0, "room": "!r:s",
+                                                    "task": {"id": "task-up2"}, "done": False, "pid": "task-up2:1:1", "attempts": 1}]
+        store.save(st)
+        fresh = ActivityStore(self.ws); fresh.apply(T("task-up2", "COMPLETED", ts=1_757_000_002.0))
+        self.assertEqual(len(fresh.load("task-up2").pending), 0)
+        sums = [json.loads(l) for l in card.summaries_path(self.ws).read_text().splitlines()]
+        self.assertEqual([x["rows"] for x in sums], [3], "pickup + hook + replied; the replayed pickup counted once")
+
     def test_a_fresh_row_never_reads_the_archive(self):
         # Bounded cost: the archive is consulted only on a replay. Fresh bus rows and hook rows pay
         # the live-log read they always paid, and nothing more, however large the day file grows.

--- a/tests/activity-bus.test.py
+++ b/tests/activity-bus.test.py
@@ -505,6 +505,36 @@ class IdempotentProjection(unittest.TestCase):
         card.append("replied", kind="done", room="!r:s", task=t, done=True, workspace=self.ws, pid="task-i2:1:2")
         self.assertEqual(len(card.summaries_path(self.ws).read_text().splitlines()), 1, "one summary")
         self.assertEqual(self.rows(), ["picked up", "replied"])
+class Visibility(unittest.TestCase):
+    """Audience is decided in the bus: lifecycle rows are the room's, observations are the owner's,
+    and the two projections of one TaskRun carry only what their audience may see."""
+
+    def test_lifecycle_rows_are_room_scoped_and_observations_owner_scoped(self):
+        s = TaskActivityState("t")
+        s, r1 = reduce(s, T("t", "RUNNING", ts=1, message_event_id="$m"))
+        s, r2 = reduce(s, E("t", "S1", 1, "Thinking", text="checking", ts=2))
+        s, r3 = reduce(s, E("t", "S1", 2, "InteractionRequired", text="pick one", ts=3))
+        self.assertEqual([r["scope"] for r in r1 + r2], ["room", "owner"])
+        self.assertEqual([r["scope"] for r in r3], ["room"], "the WAITING transition an observation caused is still lifecycle")
+
+    def test_the_shared_projection_carries_no_summary_and_the_private_one_does(self):
+        s = TaskActivityState("t")
+        s, _ = reduce(s, T("t", "RUNNING", ts=1, message_event_id="$m", worker="air"))
+        s, _ = reduce(s, E("t", "S1", 1, "Working", text="Running tests", ts=2))
+        shared, private = bus.shared_projection(s), bus.private_projection(s)
+        self.assertEqual((shared["phase"], shared["worker"], shared["scope"]), ("RUNNING", "air", "room"))
+        self.assertNotIn("summary", shared)
+        self.assertEqual((private["summary"], private["seq"], private["scope"]), ("Running tests", 1, "owner"))
+
+    def test_the_writer_persists_the_scope_on_the_row(self):
+        ws = Path(tempfile.mkdtemp()); (ws / "state").mkdir()
+        ActivityStore(ws).apply(T("t", "QUEUED", ts=1, room="!r:s", message_event_id="$m"))
+        row = json.loads(card.log_path(ws).read_text().splitlines()[-1])
+        self.assertEqual(row["scope"], "room")
+        rec = card.append("x", kind="working", room=None, workspace=ws)
+        self.assertNotIn("scope", rec, "a row with no stated audience carries none: the client's rule applies")
+
+
 class Wiring(unittest.TestCase):
     """The scheduler's emit points reach the bus: the CLI from shell, the manager and the outbox in-process."""
 

--- a/tests/activity-bus.test.py
+++ b/tests/activity-bus.test.py
@@ -335,6 +335,20 @@ class IdempotentProjection(unittest.TestCase):
             self.assertEqual(len(mine), expect, f"fault={fault} hook={hook}: actual rows")
             self.assertEqual([x["rows"] for x in sums], [expect], f"fault={fault} hook={hook}: the summary counts each row once")
 
+    def test_a_lower_counter_landing_late_still_counts_and_its_replay_still_does_not(self):
+        # yixuan's axis: the watermark alone would under-count a lower counter arriving after a
+        # higher one. A row that lands now is new whatever its counter; only a replay defers to it.
+        t = {"id": "task-o1"}
+        card.append("second", kind="working", room="!r:s", task=t, workspace=self.ws, pid="task-o1:1:2", ts=2.0)
+        card.append("first, late", kind="processing", room="!r:s", task=t, workspace=self.ws, pid="task-o1:1:1", ts=1.0)
+        card.append("first, late", kind="processing", room="!r:s", task=t, workspace=self.ws, pid="task-o1:1:1", ts=1.0)  # a replay
+        card.append("second", kind="working", room="!r:s", task=t, workspace=self.ws, pid="task-o1:1:2", ts=2.0)  # a replay
+        idx = json.loads(card.index_path(self.ws).read_text())["task-o1"]
+        self.assertEqual((idx["rows"], idx["applied"]), (2, {"1": 2}))
+        card.append("replied", kind="done", room="!r:s", task=t, done=True, workspace=self.ws, pid="task-o1:1:3", ts=3.0)
+        sums = [json.loads(l) for l in card.summaries_path(self.ws).read_text().splitlines()]
+        self.assertEqual([x["rows"] for x in sums], [3])
+
     def test_a_fresh_row_never_reads_the_archive(self):
         # Bounded cost: the archive is consulted only on a replay. Fresh bus rows and hook rows pay
         # the live-log read they always paid, and nothing more, however large the day file grows.
@@ -391,6 +405,25 @@ class Wiring(unittest.TestCase):
         self.assertEqual((st.phase, st.room, st.sender, st.text, st.message_event_id), ("RUNNING", "!r:s", "@q:s", "Fix it", "$m1"))
         self.assertEqual([(r["kind"], r["line"], r["task"]["event"]) for r in self.rows()],
                          [("notice", "queued", "$m1"), ("processing", "picked up", "$m1")])
+
+    def test_cli_task_id_and_event_paths_and_a_parse_error_all_return_zero(self):
+        self.assertEqual(bus.main(["transition", "RUNNING", "--task-id", "task-c1", "--workspace", str(self.ws)]), 0)
+        self.assertEqual(ActivityStore(self.ws).load("task-c1").phase, "RUNNING")
+        kind = bus.EVENT_KINDS[0]
+        self.assertEqual(bus.main(["event", "task-c1", kind, "--session", "S1", "--seq", "1", "--text", "hi", "--workspace", str(self.ws)]), 0)
+        self.assertEqual(ActivityStore(self.ws).load("task-c1").seq, 1)
+        with unittest.mock.patch("sys.stderr", new=__import__("io").StringIO()):
+            self.assertEqual(bus.main(["transition", "NOT_A_PHASE", "--workspace", str(self.ws)]), 0)
+
+    def test_the_hitl_and_outbox_callers_survive_a_broken_bus(self):
+        # The delivery and HITL paths must never fail because the card could not be updated.
+        import hitl.manager as manager
+        import outbox
+        with unittest.mock.patch.object(bus, "ActivityStore", side_effect=RuntimeError("bus down")):
+            manager._activity(["task-h1"], "WAITING", "approval")
+            outbox._activity_completed("task-o9")
+        manager._activity([], "WAITING", "approval")
+        outbox._activity_completed("not-a-task")
 
     def test_cli_never_fails_the_caller(self):
         self.assertEqual(bus.main(["transition", "RUNNING", "--task-file", "/nonexistent/task-x.txt", "--workspace", str(self.ws)]), 0)

--- a/tests/agent-availability.test.py
+++ b/tests/agent-availability.test.py
@@ -104,36 +104,51 @@ class Fallbacks(unittest.TestCase):
 
 
 class StaleSnapshots(unittest.TestCase):
-    """yixuan's gap: a core that dies between RUNNING and a terminal phase leaves the snapshot behind;
-    a fresh heartbeat cannot mask it, so the snapshot itself must be bounded like the other inputs."""
+    """yixuan's gap: a core that dies between RUNNING and a terminal phase leaves the snapshot behind and a
+    fresh heartbeat cannot mask it. The boundary that shares the task lifecycle is the task watcher (it
+    dispatches every task and dies with the core session), never the heartbeat writer."""
 
-    def _ws(self, beat_started_at=None):
+    def _ws(self, watcher_started_at=None):
         ws = Path(tempfile.mkdtemp()); (ws / "state" / "activity").mkdir(parents=True); (ws / "state" / "cores").mkdir(); (ws / "tasks").mkdir()
-        beat = ws / "state" / "cores" / "h.alive"
-        beat.write_text(json.dumps({"started_at": beat_started_at} if beat_started_at is not None else {}))
+        (ws / "state" / "cores" / "h.alive").write_text("{}")
+        if watcher_started_at is not None:
+            pf = ws / "state" / "watch-tasks-stream.pid"; pf.write_text("1"); os.utime(pf, (watcher_started_at, watcher_started_at))
         return ws
 
-    def _snapshot(self, ws, written_at):
+    def _snapshot(self, ws, written_at, task_file=False):
         p = ws / "state" / "activity" / "task-s1.json"; p.write_text(json.dumps({"task_id": "task-s1", "phase": "RUNNING"}))
         os.utime(p, (written_at, written_at))
+        if task_file:
+            (ws / "tasks" / "task-s1.txt").write_text("id: task-s1\n")
+
+    def _runs(self, ws, now):
+        os.utime(ws / "state" / "cores" / "h.alive", (now, now))
+        return av.read_runtime_state(ws, host="h", now=now)
 
     def test_a_stale_running_snapshot_beside_a_fresh_heartbeat_is_not_work(self):
         now = time.time()
         for age in (24 * 3600.0, 365 * 24 * 3600.0):
-            ws = self._ws(); self._snapshot(ws, now - age); os.utime(ws / "state" / "cores" / "h.alive", (now, now))
-            s = av.read_runtime_state(ws, host="h", now=now)
+            ws = self._ws(); self._snapshot(ws, now - age)
+            s = self._runs(ws, now)
             self.assertEqual((s.active_runs, s.runtime_healthy), (0, True), f"age {age}")
             self.assertEqual(av.availability(s), "available")
-        ws = self._ws(); self._snapshot(ws, now - 60.0); os.utime(ws / "state" / "cores" / "h.alive", (now, now))
-        self.assertEqual(av.read_runtime_state(ws, host="h", now=now).active_runs, 1, "control: a live run still counts")
+        ws = self._ws(); self._snapshot(ws, now - 60.0)
+        self.assertEqual(self._runs(ws, now).active_runs, 1, "control: a live run still counts")
 
-    def test_a_snapshot_written_before_this_core_started_is_a_leftover(self):
+    def test_a_previous_sessions_snapshot_is_a_leftover_however_the_heartbeat_writer_lived(self):
+        # Retained heartbeat writer + core restart: the watcher is new, the task file is gone, the
+        # snapshot is 5 minutes old — a leftover, not work.
         now = time.time()
-        ws = self._ws(beat_started_at=now - 120.0); self._snapshot(ws, now - 300.0); os.utime(ws / "state" / "cores" / "h.alive", (now, now))
-        self.assertEqual(av.read_runtime_state(ws, host="h", now=now).active_runs, 0, "5 min old but older than the core: stale")
-        ws = self._ws(beat_started_at=now - 600.0); self._snapshot(ws, now - 300.0); os.utime(ws / "state" / "cores" / "h.alive", (now, now))
-        self.assertEqual(av.read_runtime_state(ws, host="h", now=now).active_runs, 1, "control: written after the core started")
-        self.assertFalse(av.snapshot_is_live(now - 10.0, now, now - 5.0)); self.assertTrue(av.snapshot_is_live(now - 10.0, now, None))
+        ws = self._ws(watcher_started_at=now - 120.0); self._snapshot(ws, now - 300.0)
+        self.assertEqual(self._runs(ws, now).active_runs, 0)
+        # Heartbeat writer restarted under a still-running core: the watcher predates the snapshot and
+        # the task is still in the queue — a live, silent run keeps counting.
+        ws = self._ws(watcher_started_at=now - 3600.0); self._snapshot(ws, now - 2400.0, task_file=True)
+        self.assertEqual(self._runs(ws, now).active_runs, 1)
+        # A task re-dispatched after a restart is in the queue again: live, whatever its snapshot's age.
+        ws = self._ws(watcher_started_at=now - 120.0); self._snapshot(ws, now - 300.0, task_file=True)
+        self.assertEqual(self._runs(ws, now).active_runs, 1)
+        self.assertFalse(av.snapshot_is_live(now - 10.0, now, False, now - 5.0)); self.assertTrue(av.snapshot_is_live(now - 10.0, now, False, None))
 
 
 class Reading(unittest.TestCase):

--- a/tests/agent-availability.test.py
+++ b/tests/agent-availability.test.py
@@ -9,6 +9,7 @@ import sys
 import tempfile
 import time
 import unittest
+import unittest.mock
 from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "src"))
@@ -87,6 +88,19 @@ class ThisHost(unittest.TestCase):
         self.assertNotEqual(av.availability(s), "available", "my own heartbeat is stale; the peer's does not count")
         self.assertNotEqual(av.availability(av.read_runtime_state(ws, host="nobody", now=time.time())), "available")
         self.assertIsInstance(av.this_host(), str); self.assertTrue(av.this_host())
+
+
+class Fallbacks(unittest.TestCase):
+    def test_the_host_label_falls_back_to_the_node_name_when_the_resolver_is_missing(self):
+        import platform
+        with unittest.mock.patch.dict(sys.modules, {"util_paths": None}):  # the import raises
+            self.assertEqual(av.this_host(), platform.node().split(".")[0])
+
+    def test_an_unreadable_task_snapshot_is_skipped_not_counted(self):
+        ws = Path(tempfile.mkdtemp()); (ws / "state" / "activity").mkdir(parents=True)
+        (ws / "state" / "activity" / "task-ok.json").write_text(json.dumps({"task_id": "task-ok", "phase": "RUNNING"}))
+        (ws / "state" / "activity" / "task-bad.json").write_text("{not json")
+        self.assertEqual(av.read_runtime_state(ws, host="h", now=1.0).active_runs, 1)
 
 
 class Reading(unittest.TestCase):

--- a/tests/agent-availability.test.py
+++ b/tests/agent-availability.test.py
@@ -103,6 +103,39 @@ class Fallbacks(unittest.TestCase):
         self.assertEqual(av.read_runtime_state(ws, host="h", now=1.0).active_runs, 1)
 
 
+class StaleSnapshots(unittest.TestCase):
+    """yixuan's gap: a core that dies between RUNNING and a terminal phase leaves the snapshot behind;
+    a fresh heartbeat cannot mask it, so the snapshot itself must be bounded like the other inputs."""
+
+    def _ws(self, beat_started_at=None):
+        ws = Path(tempfile.mkdtemp()); (ws / "state" / "activity").mkdir(parents=True); (ws / "state" / "cores").mkdir(); (ws / "tasks").mkdir()
+        beat = ws / "state" / "cores" / "h.alive"
+        beat.write_text(json.dumps({"started_at": beat_started_at} if beat_started_at is not None else {}))
+        return ws
+
+    def _snapshot(self, ws, written_at):
+        p = ws / "state" / "activity" / "task-s1.json"; p.write_text(json.dumps({"task_id": "task-s1", "phase": "RUNNING"}))
+        os.utime(p, (written_at, written_at))
+
+    def test_a_stale_running_snapshot_beside_a_fresh_heartbeat_is_not_work(self):
+        now = time.time()
+        for age in (24 * 3600.0, 365 * 24 * 3600.0):
+            ws = self._ws(); self._snapshot(ws, now - age); os.utime(ws / "state" / "cores" / "h.alive", (now, now))
+            s = av.read_runtime_state(ws, host="h", now=now)
+            self.assertEqual((s.active_runs, s.runtime_healthy), (0, True), f"age {age}")
+            self.assertEqual(av.availability(s), "available")
+        ws = self._ws(); self._snapshot(ws, now - 60.0); os.utime(ws / "state" / "cores" / "h.alive", (now, now))
+        self.assertEqual(av.read_runtime_state(ws, host="h", now=now).active_runs, 1, "control: a live run still counts")
+
+    def test_a_snapshot_written_before_this_core_started_is_a_leftover(self):
+        now = time.time()
+        ws = self._ws(beat_started_at=now - 120.0); self._snapshot(ws, now - 300.0); os.utime(ws / "state" / "cores" / "h.alive", (now, now))
+        self.assertEqual(av.read_runtime_state(ws, host="h", now=now).active_runs, 0, "5 min old but older than the core: stale")
+        ws = self._ws(beat_started_at=now - 600.0); self._snapshot(ws, now - 300.0); os.utime(ws / "state" / "cores" / "h.alive", (now, now))
+        self.assertEqual(av.read_runtime_state(ws, host="h", now=now).active_runs, 1, "control: written after the core started")
+        self.assertFalse(av.snapshot_is_live(now - 10.0, now, now - 5.0)); self.assertTrue(av.snapshot_is_live(now - 10.0, now, None))
+
+
 class Reading(unittest.TestCase):
     def test_the_private_numbers_come_from_what_the_engine_already_writes(self):
         ws = Path(tempfile.mkdtemp())

--- a/tests/agent-availability.test.py
+++ b/tests/agent-availability.test.py
@@ -34,7 +34,8 @@ class Contract(unittest.TestCase):
         p = av.availability_projection(S(runtime_healthy=True, active_runs=3, max_concurrency=4, queue_depth=7), worker="air")
         self.assertEqual(set(p), {"worker", "room", "availability", "audience", "projection", "ts"})
         self.assertEqual((p["availability"], p["audience"], p["projection"]), ("busy_accepting", "room", "AVAILABILITY"))
-        self.assertNotIn("3", json.dumps(p)); self.assertNotIn("7", json.dumps({k: v for k, v in p.items() if k != "ts"}))
+        blob = json.dumps({k: v for k, v in p.items() if k != "ts"})
+        self.assertNotIn("3", blob); self.assertNotIn("7", blob)
 
     def test_the_task_projection_says_who_and_since_when_but_not_what(self):
         snap = {"task_id": "t", "message_event_id": "$m", "worker": "air", "phase": "RUNNING", "started_at": 1000.0,
@@ -56,6 +57,21 @@ class PerRoom(unittest.TestCase):
         self.assertEqual(av.availability_projection(s, "air", "!x:s", lambda r, v: "reviewing acquisition docs")["availability"],
                          "busy_accepting", "an off-contract value is ignored, never leaked")
         self.assertIn(av.availability_projection(s, "air", "!x:s", widen)["availability"], av.AVAILABILITY)
+
+
+class ThisHost(unittest.TestCase):
+    """state/cores/ is synced across hosts, so a glob lets a PEER's heartbeat answer for this agent.
+    Only this host's file counts."""
+
+    def test_a_peers_fresh_heartbeat_never_makes_a_dead_host_look_alive(self):
+        ws = Path(tempfile.mkdtemp()); (ws / "state" / "cores").mkdir(parents=True)
+        (ws / "state" / "cores" / "peer.alive").write_text("{}")
+        mine = ws / "state" / "cores" / "mac.alive"; mine.write_text("{}")
+        os.utime(mine, (time.time() - 4000, time.time() - 4000))
+        s = av.read_runtime_state(ws, host="mac", now=time.time())
+        self.assertNotEqual(av.availability(s), "available", "my own heartbeat is stale; the peer's does not count")
+        self.assertNotEqual(av.availability(av.read_runtime_state(ws, host="nobody", now=time.time())), "available")
+        self.assertIsInstance(av.this_host(), str); self.assertTrue(av.this_host())
 
 
 class Reading(unittest.TestCase):

--- a/tests/agent-availability.test.py
+++ b/tests/agent-availability.test.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""The room availability contract is narrow and never leaks the private numbers; the task projection
+says who is on it and since when, never what they are doing inside."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "src"))
+import agent_availability as av  # noqa: E402
+from agent_availability import AgentRuntimeState as S  # noqa: E402
+
+
+class Contract(unittest.TestCase):
+    def test_the_five_values_and_what_maps_to_them(self):
+        self.assertEqual(av.availability(S(runtime_healthy=None)), "unknown")
+        self.assertEqual(av.availability(S(runtime_healthy=False, active_runs=0)), "offline")
+        self.assertEqual(av.availability(S(runtime_healthy=True, active_runs=0)), "available")
+        self.assertEqual(av.availability(S(runtime_healthy=True, active_runs=2, max_concurrency=4)), "busy_accepting")
+        self.assertEqual(av.availability(S(runtime_healthy=True, active_runs=4, max_concurrency=4)), "busy_unavailable")
+        self.assertEqual(av.availability(S(runtime_healthy=True, active_runs=0, accepting_work=False)), "busy_unavailable")
+        self.assertEqual(av.availability(S(runtime_healthy=True, active_runs=0, queue_depth=2, max_concurrency=1)), "busy_accepting")
+
+    def test_a_running_task_alone_does_not_mean_busy(self):
+        # The owner's rule: never derive availability from "has a running task".
+        self.assertEqual(av.availability(S(runtime_healthy=True, active_runs=1, max_concurrency=2)), "busy_accepting")
+
+    def test_the_room_projection_carries_no_numbers_and_no_reasons(self):
+        p = av.availability_projection(S(runtime_healthy=True, active_runs=3, max_concurrency=4, queue_depth=7), worker="air")
+        self.assertEqual(set(p), {"worker", "availability", "scope", "ts"})
+        self.assertEqual((p["availability"], p["scope"]), ("busy_accepting", "room"))
+        self.assertNotIn("3", json.dumps(p)); self.assertNotIn("7", json.dumps({k: v for k, v in p.items() if k != "ts"}))
+
+    def test_the_task_projection_says_who_and_since_when_but_not_what(self):
+        snap = {"task_id": "t", "message_event_id": "$m", "worker": "air", "phase": "RUNNING", "started_at": 1000.0,
+                "summary": "reviewing the acquisition documents", "seq": 9}
+        p = av.task_projection(snap, now=1360.0)
+        self.assertEqual((p["worker"], p["phase"], p["since_s"], p["scope"]), ("air", "RUNNING", 360.0, "room"))
+        self.assertNotIn("summary", p); self.assertNotIn("seq", p)
+        self.assertNotIn("acquisition", json.dumps(p))
+
+
+class Reading(unittest.TestCase):
+    def test_the_private_numbers_come_from_what_the_engine_already_writes(self):
+        ws = Path(tempfile.mkdtemp())
+        (ws / "state" / "activity").mkdir(parents=True); (ws / "state" / "cores").mkdir(); (ws / "tasks").mkdir()
+        for tid, phase in (("task-a", "RUNNING"), ("task-b", "WAITING"), ("task-c", "COMPLETED")):
+            (ws / "state" / "activity" / f"{tid}.json").write_text(json.dumps({"task_id": tid, "phase": phase}))
+        (ws / "tasks" / "task-q1.txt").write_text("id: task-q1\n"); (ws / "tasks" / "task-cron-x.txt").write_text("id: task-cron-x\n")
+        beat = ws / "state" / "cores" / "mac.alive"; beat.write_text("{}")
+        s = av.read_runtime_state(ws, host="mac", max_concurrency=2, now=time.time())
+        self.assertEqual((s.active_runs, s.queue_depth, s.runtime_healthy, s.max_concurrency), (2, 1, True, 2))
+        self.assertEqual(av.availability(s), "busy_unavailable")
+        os.utime(beat, (time.time() - 600, time.time() - 600))
+        self.assertEqual(av.availability(av.read_runtime_state(ws, host="mac", now=time.time())), "offline")
+        self.assertEqual(av.availability(av.read_runtime_state(Path(tempfile.mkdtemp()))), "unknown")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/agent-availability.test.py
+++ b/tests/agent-availability.test.py
@@ -32,17 +32,30 @@ class Contract(unittest.TestCase):
 
     def test_the_room_projection_carries_no_numbers_and_no_reasons(self):
         p = av.availability_projection(S(runtime_healthy=True, active_runs=3, max_concurrency=4, queue_depth=7), worker="air")
-        self.assertEqual(set(p), {"worker", "availability", "scope", "ts"})
-        self.assertEqual((p["availability"], p["scope"]), ("busy_accepting", "room"))
+        self.assertEqual(set(p), {"worker", "room", "availability", "audience", "projection", "ts"})
+        self.assertEqual((p["availability"], p["audience"], p["projection"]), ("busy_accepting", "room", "AVAILABILITY"))
         self.assertNotIn("3", json.dumps(p)); self.assertNotIn("7", json.dumps({k: v for k, v in p.items() if k != "ts"}))
 
     def test_the_task_projection_says_who_and_since_when_but_not_what(self):
         snap = {"task_id": "t", "message_event_id": "$m", "worker": "air", "phase": "RUNNING", "started_at": 1000.0,
                 "summary": "reviewing the acquisition documents", "seq": 9}
         p = av.task_projection(snap, now=1360.0)
-        self.assertEqual((p["worker"], p["phase"], p["since_s"], p["scope"]), ("air", "RUNNING", 360.0, "room"))
+        self.assertEqual((p["worker"], p["phase"], p["since_s"], p["audience"], p["projection"]),
+                         ("air", "RUNNING", 360.0, "room", "TASK_STATUS"))
         self.assertNotIn("summary", p); self.assertNotIn("seq", p)
         self.assertNotIn("acquisition", json.dumps(p))
+
+
+class PerRoom(unittest.TestCase):
+    def test_a_room_policy_can_narrow_what_this_room_learns_but_never_widen_it(self):
+        s = S(runtime_healthy=True, active_runs=1, max_concurrency=4)
+        narrow = lambda room, v: "busy_unavailable" if room == "!engineering:s" and v == "busy_accepting" else v
+        self.assertEqual(av.availability_projection(s, "air", "!engineering:s", narrow)["availability"], "busy_unavailable")
+        self.assertEqual(av.availability_projection(s, "air", "!board:s", narrow)["availability"], "busy_accepting")
+        widen = lambda room, v: "available"  # a policy cannot invent a value outside the contract either
+        self.assertEqual(av.availability_projection(s, "air", "!x:s", lambda r, v: "reviewing acquisition docs")["availability"],
+                         "busy_accepting", "an off-contract value is ignored, never leaked")
+        self.assertIn(av.availability_projection(s, "air", "!x:s", widen)["availability"], av.AVAILABILITY)
 
 
 class Reading(unittest.TestCase):

--- a/tests/agent-availability.test.py
+++ b/tests/agent-availability.test.py
@@ -53,10 +53,25 @@ class PerRoom(unittest.TestCase):
         narrow = lambda room, v: "busy_unavailable" if room == "!engineering:s" and v == "busy_accepting" else v
         self.assertEqual(av.availability_projection(s, "air", "!engineering:s", narrow)["availability"], "busy_unavailable")
         self.assertEqual(av.availability_projection(s, "air", "!board:s", narrow)["availability"], "busy_accepting")
-        widen = lambda room, v: "available"  # a policy cannot invent a value outside the contract either
         self.assertEqual(av.availability_projection(s, "air", "!x:s", lambda r, v: "reviewing acquisition docs")["availability"],
                          "busy_accepting", "an off-contract value is ignored, never leaked")
-        self.assertIn(av.availability_projection(s, "air", "!x:s", widen)["availability"], av.AVAILABILITY)
+        # Widening is refused, not merely kept inside the enum: the true value stands.
+        self.assertEqual(av.availability_projection(s, "air", "!x:s", lambda r, v: "available")["availability"], "busy_accepting")
+        full = S(runtime_healthy=True, active_runs=4, max_concurrency=4)
+        self.assertEqual(av.availability_projection(full, "air", "!x:s", lambda r, v: "busy_accepting")["availability"], "busy_unavailable")
+        self.assertEqual(av.availability_projection(full, "air", "!x:s", lambda r, v: "unknown")["availability"], "unknown", "less is allowed")
+        self.assertEqual(av.availability_projection(S(runtime_healthy=False), "air", "!x:s", lambda r, v: "available")["availability"], "offline",
+                         "a known fact is never relabelled available")
+        for true, allowed in av.NARROWING.items():
+            self.assertIn(true, allowed); self.assertIn("unknown", allowed)
+            if true != "available":
+                self.assertNotIn("available", allowed)
+
+    def test_a_restricted_snapshot_never_widens_to_room(self):
+        for aud in ("owner", "selected_members", "system"):
+            self.assertEqual(av.task_projection({"task_id": "t", "phase": "RUNNING", "audience": aud})["audience"], aud)
+        self.assertEqual(av.task_projection({"task_id": "t", "phase": "RUNNING", "audience": "room"})["audience"], "room")
+        self.assertEqual(av.task_projection({"task_id": "t", "phase": "RUNNING"})["audience"], "room", "no label: room, the lifecycle default")
 
 
 class ThisHost(unittest.TestCase):

--- a/tests/watch-tasks-dispatch-activity.test.sh
+++ b/tests/watch-tasks-dispatch-activity.test.sh
@@ -13,6 +13,9 @@ via="$(printf '%s\n' "$body" | grep -c 'emit_dispatch_task_file')"
 [ "$via" -ge 4 ] && echo "PASS dispatch_task emits through emit_dispatch_task_file ($via sites)" || { echo "FAIL expected >=4 owner emits, got $via"; fail=1; }
 q="$(printf '%s\n' "$body" | grep -c 'queued_activity_row "\$filename"')"
 [ "$q" -eq 1 ] && echo "PASS dispatch_task marks QUEUED exactly once" || { echo "FAIL QUEUED marked $q times"; fail=1; }
+# The handler path: launching a worker is the pickup, so drain_dispatch_queue marks RUNNING there.
+drain="$(awk '/^drain_dispatch_queue\(\) \{/,/^\}/' "$SRC/watch-tasks-stream.sh")"
+printf '%s\n' "$drain" | grep -q 'activity_transition RUNNING "$(basename "$marker")"' && echo "PASS a launched handler marks RUNNING" || { echo "FAIL drain_dispatch_queue does not mark RUNNING on handler launch"; fail=1; }
 # Behaviour: emit_dispatch_task_file prints the line and marks RUNNING through the bus (stubbed).
 tmp="$(mktemp -d)"; log="$tmp/bus.log"
 cat > "$tmp/py" << PY

--- a/tests/watch-tasks-dispatch-activity.test.sh
+++ b/tests/watch-tasks-dispatch-activity.test.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# The watcher's ordinary dispatch path reaches the lifecycle owner: dispatch_task marks QUEUED once,
+# tells the live core, then marks RUNNING — for every branch that prints TASK_FILE.
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC="$HERE/../src"
+fail=0
+# No raw TASK_FILE printf survives inside dispatch_task: every emit goes through the owner.
+body="$(awk '/^dispatch_task\(\) \{/,/^\}/' "$SRC/watch-tasks-stream.sh")"
+raw="$(printf '%s\n' "$body" | grep -c "printf 'TASK_FILE")"
+[ "$raw" -eq 0 ] && echo "PASS dispatch_task has no raw TASK_FILE printf" || { echo "FAIL dispatch_task still prints TASK_FILE directly ($raw)"; fail=1; }
+via="$(printf '%s\n' "$body" | grep -c 'emit_dispatch_task_file')"
+[ "$via" -ge 4 ] && echo "PASS dispatch_task emits through emit_dispatch_task_file ($via sites)" || { echo "FAIL expected >=4 owner emits, got $via"; fail=1; }
+q="$(printf '%s\n' "$body" | grep -c 'queued_activity_row "\$filename"')"
+[ "$q" -eq 1 ] && echo "PASS dispatch_task marks QUEUED exactly once" || { echo "FAIL QUEUED marked $q times"; fail=1; }
+# Behaviour: emit_dispatch_task_file prints the line and marks RUNNING through the bus (stubbed).
+tmp="$(mktemp -d)"; log="$tmp/bus.log"
+cat > "$tmp/py" << PY
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$log"
+PY
+chmod +x "$tmp/py"
+mkdir -p "$tmp/tasks"; printf 'id: task-abc\ntask: hi\n' > "$tmp/tasks/task-abc.txt"
+out="$(TASKS_DIR="$tmp/tasks" SUTANDO_PY_BIN="$tmp/py" bash -c 'source "$1"; emit_dispatch_task_file task-abc.txt' _ "$SRC/task-emit.sh" 2>/dev/null)"
+for _ in $(seq 1 30); do grep -q "transition RUNNING" "$log" 2>/dev/null && break; sleep 0.1; done  # the transition is fire-and-forget
+[ "$out" = "TASK_FILE: task-abc.txt" ] && echo "PASS the live core is told" || { echo "FAIL stdout was: $out"; fail=1; }
+grep -q "transition RUNNING" "$log" 2>/dev/null && echo "PASS RUNNING follows the emit" || { echo "FAIL no RUNNING transition recorded: $(cat "$log" 2>/dev/null)"; fail=1; }
+grep -q "transition QUEUED" "$log" 2>/dev/null && { echo "FAIL emit_dispatch_task_file must not re-mark QUEUED"; fail=1; } || echo "PASS QUEUED is dispatch_task's, not the emitter's"
+rm -rf "$tmp"
+[ "$fail" -eq 0 ] && echo "watch-tasks-dispatch-activity: PASS" || { echo "watch-tasks-dispatch-activity: FAIL"; exit 1; }


### PR DESCRIPTION
**Stacked on #3985 → #3984 → #3983 → #3982 → #3981.** Child-only diff: `src/agent_availability.py`, `tests/agent-availability.test.py`, `docs/src-map.md`. Owner's design, 2026-09-06: two room-visible projections of one private runtime, and *operational presence* as a collaboration primitive.

## What
- **AgentAvailability, a narrow room contract:** `available | busy_accepting | busy_unavailable | offline | unknown`. Computed from the private canonical numbers — active runs, capacity, queue depth, runtime health, accepting flag — which never leave the owner's side. **Never derived from "has a running task" alone:** a concurrent agent with 2 of 4 runs is `busy_accepting`.
- **Per room by policy:** the canonical state is global; `availability_projection(state, worker, room_id, room_policy)` lets a room learn less, never more (an off-contract value from a policy is ignored), so #engineering can see the agent is not taking work without learning it is on a #board task.
- **Task projection for the room:** who is on it, its phase, since when — no summary, no steps. Audience and projection are named on both (`room` / `AVAILABILITY`, `room` / `TASK_STATUS`), per #3985's split.
- **Read from what the engine already writes:** bus snapshots under `state/activity` (active runs), `tasks/` (queue depth, crons excluded), the core heartbeat (health; stale = offline; none = unknown).

## Evidence
```
tests/agent-availability.test.py   Ran 6 tests in 0.003s OK
```
Checks: the five values and what maps to them; a running task alone is not busy; the room payload carries no numbers and no reasons; the task projection carries no summary; a room policy narrows but never widens, and an off-contract value is ignored; the private numbers come from the engine's own files (active/queue/heartbeat), stale heartbeat → offline, nothing readable → unknown.

## Not in this PR
The transport (C) that carries these to the room and to agents, and the client's member-list and avatar rendering (● Available / ◐ Busy · accepting / ◐ Busy / ○ Offline) and the other-member view of a card ("Started 6 min ago · Last status update 20 s ago").

— sutando-qingyun-air
