### PR TITLE
fix(warn-already-triaged): the gate never searched the build log

### DIFF
--- a/skills/proactive-loop/scripts/warn-already-triaged.py
+++ b/skills/proactive-loop/scripts/warn-already-triaged.py
@@ -28,11 +28,16 @@ def parking_files():
     warn whose decision is settled is written there rather than to a file that
     waits on a human. Omitting it reported those as untriaged, which is the one
     verdict that invites re-deriving a decision already made.
+
+    The build log is the third kind and the largest: the other files record what
+    a pass DECIDED, it records what a pass FOUND. A re-derivation collides with
+    the finding, so a corpus of decisions is blind to exactly this class.
     """
     sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3] / "src"))
-    from util_paths import memory_dir, personal_path
+    from util_paths import memory_dir, personal_path, shared_personal_path
     files = [p for p in (personal_path("pending-questions.md"),
-                         personal_path("current-track.md")) if p.exists()]
+                         personal_path("current-track.md"),
+                         shared_personal_path("build_log.md")) if p.exists()]
     mem = memory_dir()
     if mem.is_dir():
         files.extend(sorted(p for p in mem.glob("*.md") if p.is_file()))
@@ -43,7 +48,8 @@ def display(path):
     """`memory/<name>` for a memory file, bare name otherwise.
 
     A pending question waits on a human; a memory records a decision already
-    taken. The reader must be able to tell which one a hit is.
+    taken; `build_log.md` records a measurement nobody has to act on. The reader
+    must be able to tell which one a hit is.
     """
     return f"memory/{path.name}" if path.parent.name == "memory" else path.name
 

--- a/tests/proactive-loop-warn-already-triaged.test.py
+++ b/tests/proactive-loop-warn-already-triaged.test.py
@@ -12,6 +12,7 @@ import io
 import os
 import contextlib
 import tempfile
+import sys
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -321,6 +322,75 @@ class MemoryIsPartOfTheCorpus(unittest.TestCase):
         self.assertEqual(reads.count(str(f)), 1, f"read {reads.count(str(f))}x")
 
 
+
+class BuildLogIsPartOfTheCorpus(unittest.TestCase):
+    """The per-host files record what a pass DECIDED; the build log records what
+    a pass FOUND. A re-derivation collides with the finding, so a corpus of
+    decisions is blind to exactly the class this gate exists to catch.
+
+    These patch the resolver rather than the environment on purpose: pointing
+    SUTANDO_MEMORY_DIR at a directory holding build_log.md lets the memory glob
+    pick the file up, so the suite still passes with the build log removed from
+    parking_files() -- a control that certifies nothing.
+    """
+
+    def _corpus(self, build_log_text):
+        d = Path(tempfile.mkdtemp())
+        bl = d / "build_log.md"
+        bl.write_text(build_log_text)
+        mem = d / "memory"
+        mem.mkdir()
+        (mem / "unrelated.md").write_text("## nothing to do with it\n")
+        return bl, mem
+
+    @contextlib.contextmanager
+    def _resolved(self, bl, mem):
+        # parking_files() puts src/ on sys.path when it runs; do it here too so
+        # the patch targets the same module object the function will import.
+        sys.path.insert(0, str(SCRIPTS.parents[2] / "src"))
+        import util_paths
+        fake = lambda name, workspace=None: bl if name == "build_log.md" else Path("/nonexistent-xyz") / name
+        with mock.patch.object(util_paths, "shared_personal_path", side_effect=fake), \
+             mock.patch.dict(os.environ, {"SUTANDO_MEMORY_DIR": str(mem)}):
+            yield
+
+    def test_the_build_log_joins_the_parking_corpus(self):
+        bl, mem = self._corpus("### zzz-subject measured and closed\n")
+        with self._resolved(bl, mem):
+            names = [f.name for f in wat.parking_files()]
+        self.assertIn("build_log.md", names)
+
+    def test_a_finding_recorded_only_in_the_build_log_is_not_called_untriaged(self):
+        # Without the build log this material is in no searched file, so the
+        # verdict is NONE FOUND -> exit 0, which the loop reads as a green light.
+        bl, mem = self._corpus("### zzz-subject measured and closed\n")
+        with self._resolved(bl, mem):
+            verdict, out = _report("", "the `zzz-subject` needs investigating", wat.parking_files())
+        self.assertEqual(verdict, "parked")
+        self.assertNotIn("NONE FOUND", out)
+
+    def test_the_hit_names_the_build_log_and_is_not_labelled_as_memory(self):
+        bl, mem = self._corpus("### zzz-subject measured and closed\n")
+        with self._resolved(bl, mem):
+            _, out = _report("", "the `zzz-subject` needs investigating", wat.parking_files())
+        self.assertIn("build_log.md", out)
+        self.assertNotIn("memory/build_log.md", out)
+
+    def test_absent_material_still_reports_untriaged_with_the_build_log_present(self):
+        # Green-on-purpose: the real corpus is 2 MB, so it must not match everything.
+        bl, mem = self._corpus("### something entirely else\n")
+        with self._resolved(bl, mem):
+            verdict, out = _report("", "the `zzz-subject` needs investigating", wat.parking_files())
+        self.assertEqual(verdict, "untriaged")
+        self.assertIn("NONE FOUND", out)
+
+    def test_a_missing_build_log_degrades_rather_than_raising(self):
+        d = Path(tempfile.mkdtemp())
+        mem = d / "memory"
+        mem.mkdir()
+        with self._resolved(d / "build_log.md", mem):
+            files = wat.parking_files()
+        self.assertTrue(all(f.exists() for f in files))
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## The defect

`parking_files()` searches the two per-host files and every core-memory file. Those record what a
pass **DECIDED**. `build_log.md` records what a pass **FOUND** — and a re-derivation collides with
the *finding*, not the decision, so the corpus was structurally blind to the exact class this gate
exists to catch.

`skills/proactive-loop/SKILL.md` already carries the measurement, in bold, as step 3's own rule:

> **`build_log.md` IS THE THIRD FILE AND IT IS NOT OPTIONAL** — the two parking files hold what a
> pass DECIDED; the build log holds what a pass FOUND.

The tool the same file mandates (step 3.4) was never widened to match. So a claim whose prior
coverage lives only in the build log returns `NONE FOUND` → **exit 0**, which the loop reads as
*"genuinely untriaged → proceed"*.

## Before / after — real corpus, same command

Claim: ``the `health-monitor` cron looks like it has never been triaged here``

**At the parent commit `c3ac6b96`:**
```
searching 1 parking file(s) for this claim's nouns

  NONE FOUND this claim                — no heading, no body mention; genuinely
             untriaged, OR every token missed (try one from the warn text)
exit=0
```

**At `1a75d122` (this branch):**
```
searching 2 parking file(s) for this claim's nouns

  CANDIDATES this claim                (1) — verify the CONDITION matches, not just the probe
             via 'health-monitor' -> build_log.md:79  ### 2026-07-15 proactive pass — health-monitor no-op (crons re-registered this boot)
exit=1
```

## How large is the blind spot

Population **derived from the file**, not hand-picked: every entity the shared `ENT` regex extracts
from the last 400 `###` headings of a live 2.24 MB / 30,010-line `build_log.md`, checked against the
full post-#3963 parking set (pending-questions + current-track + 105 memory files).

```
population                                   580 distinct entities
not findable in the parking set              465  (80%)
negative control ('zzz-token-written-nowhere')  parking 0 / build_log 0
```

Every one of those 465 is a subject the build log names in a heading and the gate calls untriaged.
The sample skews to PR numbers (`#3753` — 15 build_log mentions, 0 elsewhere), which #3958 just made
tokenizable, so the gate now extracts them and then searches the one corpus that has them.

## Why `shared_personal_path`

Its own docstring names this file: *"Resolve a shared-private path (notes, build_log, etc.)"*. Using
it keeps the build log on the same override chain as every other workspace read, rather than joining
a second path convention.

## Cost

One extra read per run — `lines_of()` already caches per file:

```
build_log.md   2.24 MB, 30,010 lines
  read_text     3 ms
  splitlines    3 ms
  scan, 8 tokens  15 ms
```

## Tests

5 added (34 → 39). Mutation verified: removing `shared_personal_path("build_log.md")` from
`parking_files()` → **`FAILED (failures=3)`**; restored → **`OK`** (39).

⚠ The first draft of these tests pointed `SUTANDO_MEMORY_DIR` at a directory *containing*
`build_log.md`. That passed with the fix removed — `memory_dir()` globs `*.md`, so the memory branch
smuggled the file in and the control certified nothing. The committed version patches
`shared_personal_path` and keeps the memory dir a separate subdirectory; that is what makes the
mutation red. The green-on-purpose test (`test_absent_material_still_reports_untriaged...`) is there
because widening a corpus to 2 MB must not make everything read as parked.

`scripts/review-checks.sh` (diff piped): `PASS (hardcoded-paths + root-artifacts + prose-cap clean)`,
re-run against the exact pushed HEAD.

## Scope

Single concern. No behaviour change to `tokens()`, `report()`, or either exit-code contract; the only
change is which files are searched, plus one docstring line in `display()` naming the third kind of
hit so a reader can tell a measurement from a decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
