### PR TITLE
fix(credential-proxy): decode a rejection body before recording it

### DIFF
--- a/skills/quota-tracker/scripts/credential-proxy.ts
+++ b/skills/quota-tracker/scripts/credential-proxy.ts
@@ -18,6 +18,7 @@ import { execFileSync } from 'node:child_process';
 import { writeFileSync, mkdirSync, readFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { createHash } from 'node:crypto';
+import { gunzipSync, inflateSync, brotliDecompressSync, zstdDecompressSync } from 'node:zlib';
 import { statusPath } from '../../../src/workspace_default.js';
 
 const PORT = 7846;
@@ -38,6 +39,27 @@ const QUOTA_FILE = statusPath('quota-state.json');
 // persisted in quota-state.json so health-check can page on a transient one.
 export const MAX_RECENT_REJECTIONS = 20;
 const REJECTION_SNIPPET_BYTES = 2048;
+
+const DECODERS: Record<string, (b: Buffer) => Buffer> = {
+	gzip: gunzipSync, 'x-gzip': gunzipSync, deflate: inflateSync,
+	br: brotliDecompressSync, zstd: zstdDecompressSync,
+};
+
+/** Decode a rejection body for reading. Upstream compresses whatever the client's
+ *  accept-encoding asked for, so the raw bytes are not text; a failure must say so
+ *  rather than emit mojibake that looks like a corrupt message from the API. */
+export function decodeRejectionBody(buf: Buffer, encoding?: string): string {
+	const enc = (encoding ?? '').trim().toLowerCase();
+	if (!enc || enc === 'identity') return buf.toString('utf8');
+	const decode = DECODERS[enc];
+	if (!decode) return `<undecodable body: ${buf.length} bytes, content-encoding: ${enc}>`;
+	try {
+		return decode(buf).toString('utf8');
+	} catch {
+		// Truncated at the snippet cap, or simply not what the header claimed.
+		return `<undecodable ${enc} body: ${buf.length} bytes>`;
+	}
+}
 
 // OAuth self-refresh. A namespaced CLAUDE_CONFIG_DIR uses a namespaced keychain
 // item (`Claude Code-credentials-<sha256(config-dir)[0..8]>`), while vanilla
@@ -316,6 +338,8 @@ export interface RejectionRecord {
 	model?: string;
 	user_agent?: string;
 	peer_port?: number;
+	// What the body arrived compressed as, so an undecodable snippet says why.
+	content_encoding?: string;
 }
 
 /** The `model` field of a JSON request body, or "" when absent or unparsable. */
@@ -578,12 +602,15 @@ export function createProxyServer(overrides: Partial<ProxyDeps> = {}) {
 								if (seen < REJECTION_SNIPPET_BYTES) { rejChunks.push(c); seen += c.length; }
 							});
 							upRes.on('end', () => {
-								const snippet = redactForLog(Buffer.concat(rejChunks).toString('utf8').slice(0, REJECTION_SNIPPET_BYTES));
+								const contentEncoding = String(upRes.headers['content-encoding'] ?? '');
+								// Redaction runs on the DECODED text: it cannot scrub a secret it cannot read.
+								const snippet = redactForLog(decodeRejectionBody(Buffer.concat(rejChunks), contentEncoding)).slice(0, REJECTION_SNIPPET_BYTES);
 								const model = requestModel(body);
 								console.error(`${ts()} [Proxy] rejected HTTP ${code} on ${req.url} model=${model || '?'} peer=${req.socket.remotePort ?? '?'}: ${snippet}`);
 								try {
 									deps.recordRejection({
 										ts: new Date(deps.now()).toISOString(), status: code, path: req.url ?? '', snippet,
+						content_encoding: contentEncoding || undefined,
 										model, user_agent: String(req.headers['user-agent'] ?? ''), peer_port: req.socket.remotePort,
 									});
 								} catch { /* best effort */ }

--- a/skills/quota-tracker/scripts/credential-proxy.ts
+++ b/skills/quota-tracker/scripts/credential-proxy.ts
@@ -18,7 +18,7 @@ import { execFileSync } from 'node:child_process';
 import { writeFileSync, mkdirSync, readFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { createHash } from 'node:crypto';
-import { gunzipSync, inflateSync, brotliDecompressSync, zstdDecompressSync } from 'node:zlib';
+import * as zlib from 'node:zlib';
 import { statusPath } from '../../../src/workspace_default.js';
 
 const PORT = 7846;
@@ -40,10 +40,21 @@ const QUOTA_FILE = statusPath('quota-state.json');
 export const MAX_RECENT_REJECTIONS = 20;
 const REJECTION_SNIPPET_BYTES = 2048;
 
-const DECODERS: Record<string, (b: Buffer) => Buffer> = {
-	gzip: gunzipSync, 'x-gzip': gunzipSync, deflate: inflateSync,
-	br: brotliDecompressSync, zstd: zstdDecompressSync,
-};
+type Zlib = Partial<Record<string, unknown>>;
+
+/** Built from the zlib namespace so an export missing on the supported Node floor is
+ *  simply absent from the map. zstd landed in 22.15.0; package.json allows 22.5.0. */
+export function buildDecoders(z: Zlib): Record<string, (b: Buffer) => Buffer> {
+	const out: Record<string, (b: Buffer) => Buffer> = {};
+	const add = (name: string, fn: unknown) => {
+		if (typeof fn === 'function') out[name] = fn as (b: Buffer) => Buffer;
+	};
+	add('gzip', z.gunzipSync); add('x-gzip', z.gunzipSync); add('deflate', z.inflateSync);
+	add('br', z.brotliDecompressSync); add('zstd', z.zstdDecompressSync);
+	return out;
+}
+
+const DECODERS = buildDecoders(zlib as Zlib);
 
 /** Decode a rejection body for reading. Upstream compresses whatever the client's
  *  accept-encoding asked for, so the raw bytes are not text; a failure must say so

--- a/tests/credential-proxy-rejection-ledger.test.ts
+++ b/tests/credential-proxy-rejection-ledger.test.ts
@@ -8,7 +8,8 @@ import { test, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
 import { createServer as createHttpServer, request as httpRequest, type Server, type IncomingMessage, type ServerResponse } from 'node:http';
 import type { request as httpsRequest } from 'node:https';
-import { createProxyServer, appendRejection, requestModel, MAX_RECENT_REJECTIONS, type ProxyDeps, type RejectionRecord } from '../skills/quota-tracker/scripts/credential-proxy.ts';
+import { createProxyServer, appendRejection, requestModel, decodeRejectionBody, MAX_RECENT_REJECTIONS, type ProxyDeps, type RejectionRecord } from '../skills/quota-tracker/scripts/credential-proxy.ts';
+import { gzipSync, brotliCompressSync, zstdCompressSync } from 'node:zlib';
 
 const NOW = 1_700_000_000_000;
 let upstreamHandler: (req: IncomingMessage, res: ServerResponse) => void = () => {};
@@ -69,6 +70,33 @@ test('a 429 credits rejection is forwarded unchanged AND recorded with status, p
 	assert.equal(recorded[0].path, '/v1/messages?beta=true');
 	assert.equal(recorded[0].ts, new Date(NOW).toISOString(), 'stamped from the injected clock');
 	assert.match(recorded[0].snippet, /out of usage credits/);
+});
+
+test('a COMPRESSED rejection body is decoded before it is recorded', async () => {
+	// The upstream compresses whatever the client's accept-encoding asked for, so an
+	// uncompressed fixture cannot see this: every real snippet on a live host was mojibake.
+	const body = '{"error":{"type":"invalid_request_error","message":"credit balance is too low"}}';
+	for (const [enc, compress] of [['gzip', gzipSync], ['br', brotliCompressSync], ['zstd', zstdCompressSync]] as const) {
+		recorded = [];
+		upstreamHandler = (_req, res) => {
+			res.writeHead(400, { 'content-type': 'application/json', 'content-encoding': enc });
+			res.end(compress(Buffer.from(body)));
+		};
+		const port = await startProxy();
+		await call(port);
+		await settle();
+		assert.equal(recorded.length, 1, enc);
+		assert.match(recorded[0].snippet, /credit balance is too low/, `${enc} body must be readable`);
+		assert.equal(recorded[0].content_encoding, enc, `${enc} must be recorded`);
+	}
+});
+
+test('an undecodable body says so instead of emitting mojibake', () => {
+	const garbage = Buffer.from([0x1f, 0x8b, 0x08, 0x00, 0xff, 0xfe]);   // gzip header, truncated
+	assert.match(decodeRejectionBody(garbage, 'gzip'), /^<undecodable gzip body: 6 bytes>$/);
+	assert.match(decodeRejectionBody(garbage, 'weird-codec'), /content-encoding: weird-codec/);
+	assert.equal(decodeRejectionBody(Buffer.from('plain'), ''), 'plain', 'no encoding is still plain text');
+	assert.equal(decodeRejectionBody(Buffer.from('plain'), 'identity'), 'plain');
 });
 
 test('the record attributes the rejection to the requesting client: model from the body, user-agent, peer port', async () => {

--- a/tests/credential-proxy-rejection-ledger.test.ts
+++ b/tests/credential-proxy-rejection-ledger.test.ts
@@ -8,8 +8,8 @@ import { test, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
 import { createServer as createHttpServer, request as httpRequest, type Server, type IncomingMessage, type ServerResponse } from 'node:http';
 import type { request as httpsRequest } from 'node:https';
-import { createProxyServer, appendRejection, requestModel, decodeRejectionBody, MAX_RECENT_REJECTIONS, type ProxyDeps, type RejectionRecord } from '../skills/quota-tracker/scripts/credential-proxy.ts';
-import { gzipSync, brotliCompressSync, zstdCompressSync } from 'node:zlib';
+import { createProxyServer, appendRejection, requestModel, decodeRejectionBody, buildDecoders, MAX_RECENT_REJECTIONS, type ProxyDeps, type RejectionRecord } from '../skills/quota-tracker/scripts/credential-proxy.ts';
+import * as zlib from 'node:zlib';
 
 const NOW = 1_700_000_000_000;
 let upstreamHandler: (req: IncomingMessage, res: ServerResponse) => void = () => {};
@@ -76,7 +76,9 @@ test('a COMPRESSED rejection body is decoded before it is recorded', async () =>
 	// The upstream compresses whatever the client's accept-encoding asked for, so an
 	// uncompressed fixture cannot see this: every real snippet on a live host was mojibake.
 	const body = '{"error":{"type":"invalid_request_error","message":"credit balance is too low"}}';
-	for (const [enc, compress] of [['gzip', gzipSync], ['br', brotliCompressSync], ['zstd', zstdCompressSync]] as const) {
+	const codecs: [string, (b: Buffer) => Buffer][] = [['gzip', zlib.gzipSync], ['br', zlib.brotliCompressSync]];
+	if (typeof zlib.zstdCompressSync === 'function') codecs.push(['zstd', zlib.zstdCompressSync]);
+	for (const [enc, compress] of codecs) {
 		recorded = [];
 		upstreamHandler = (_req, res) => {
 			res.writeHead(400, { 'content-type': 'application/json', 'content-encoding': enc });
@@ -89,6 +91,18 @@ test('a COMPRESSED rejection body is decoded before it is recorded', async () =>
 		assert.match(recorded[0].snippet, /credit balance is too low/, `${enc} body must be readable`);
 		assert.equal(recorded[0].content_encoding, enc, `${enc} must be recorded`);
 	}
+});
+
+test('a Node without zstd still loads and still decodes everything else', () => {
+	// package.json allows Node 22.5.0; zstdDecompressSync landed in 22.15.0. A named import of a
+	// missing export is an ESM linkage failure — it kills the whole proxy before any try/catch.
+	const floor = { gunzipSync: zlib.gunzipSync, inflateSync: zlib.inflateSync, brotliDecompressSync: zlib.brotliDecompressSync };
+	const d = buildDecoders(floor);
+	assert.deepEqual(Object.keys(d).sort(), ['br', 'deflate', 'gzip', 'x-gzip'], 'zstd absent, the rest present');
+	assert.equal(typeof d.gzip, 'function', 'gzip must still work on the floor');
+	assert.ok(!('zstd' in d), 'an absent codec must not appear as undefined');
+	assert.ok('zstd' in buildDecoders(zlib as Record<string, unknown>) === (typeof zlib.zstdDecompressSync === 'function'),
+		'present exactly when this runtime supports it');
 });
 
 test('an undecodable body says so instead of emitting mojibake', () => {


### PR DESCRIPTION
## The defect

The rejection ledger added in #3795 exists to answer "why was this request refused" — the class of failure where every unified-status header still reads `allowed`.

It records the body like this:

```ts
const snippet = redactForLog(Buffer.concat(rejChunks).toString('utf8').slice(0, REJECTION_SNIPPET_BYTES));
```

`content-encoding` is never consulted, and the word does not appear anywhere in the file. The proxy forwards the client's `accept-encoding` untouched, so upstream compresses the response — and the snippet is those compressed bytes decoded as UTF-8.

## Before — the live ledger on one host

All ten entries, every one unreadable:

```
2026-09-05T23:52:28  429  unreadable= 66/110  head='�8\x00\x00������t�\x1e�\x0evѱ���`\x07\x03�*\x18'
2026-09-06T05:36:19  429  unreadable= 92/159  head='\x03\\\x00\x00������t\x15��_\x0c\x0c�\x00\x1c�\x01�j\x00�'
2026-09-06T19:21:04  400  unreadable= 81/147  head='�R\x00\x00������t\x15��\x1eD/\x0e�zp\x00\x07���'
```

10 of 10 undecodable — the ledger has never once said why a request was rejected on this host. `health-check.py` prints the snippet straight into its warn line, so the operator-facing output is that mojibake.

Redaction is inert for the same reason: `redactForLog` was scrubbing compressed bytes, and it cannot match a secret it cannot read.

## Why the existing test passed

`tests/credential-proxy-rejection-ledger.test.ts` sends an uncompressed fixture:

```ts
upstreamHandler = (_req, res) => { res.writeHead(429, { 'content-type': 'application/json' }); res.end(body); };
```

The fixture was built from what the code expects, not from what the real upstream sends. That is the whole gap.

## After

`decodeRejectionBody` handles gzip / x-gzip / deflate / br / zstd, records `content_encoding` on the entry, and returns a legible placeholder — `<undecodable gzip body: 6 bytes>` — when a body cannot be decoded, instead of mojibake that reads like a corrupt API message. Redaction now runs on the decoded text.

New tests drive a real compressed response through the proxy for all three encodings the API actually uses:

```
# tests 47
# pass 47
# fail 0
```
(`tsx --test tests/credential-proxy-*.test.ts`, plus `tests/health-check-core-request-rejections.test.py` 15/15.)

**Mutation-checked**: restoring the original `.toString('utf8')` line makes it `# pass 6 / # fail 1` — the compressed-body test is the one that fails, so it is guarding the actual defect.

## Notes

- Truncation interacts with this: the collector stops at `REJECTION_SNIPPET_BYTES`, so a body larger than that decompresses to an error and now yields the placeholder rather than garbage. Real 4xx JSON bodies compress to a few hundred bytes (the samples above are 110–162), so this is the rare path, and it now names itself.
- `content_encoding` is optional and additive; `health-check.py` reads the ledger by field and ignores extras.