### PR TITLE
fix(check-dedup-targets): the audit glob never reached a month-nested archive

### DIFF
--- a/skills/proactive-loop/scripts/check-dedup-targets.py
+++ b/skills/proactive-loop/scripts/check-dedup-targets.py
@@ -109,7 +109,9 @@ def main(argv) -> int:
         if not rd.is_dir():
             print("cannot answer: no results/ directory", file=sys.stderr)
             return 2
-        files = [f for f in rd.glob("*.txt")] + [f for f in (rd / "archive").glob("*.txt")]
+        # Results archive into month subdirectories (see agent-api.py, which iterates
+        # archive/*/), so a flat glob audits almost nothing.
+        files = [f for f in rd.glob("*.txt")] + [f for f in (rd / "archive").glob("**/*.txt")]
     bad = check(ws, files)
     print(f"checked {len(files)} result file(s)")
     for name, tid, why in bad:

--- a/tests/proactive-loop-check-dedup-targets.test.py
+++ b/tests/proactive-loop-check-dedup-targets.test.py
@@ -199,5 +199,39 @@ class Refusals(unittest.TestCase):
         self.assertIn("not importable", buf.getvalue() + err.getvalue())
 
 
+class MonthNestedArchive(unittest.TestCase):
+    """Results archive into `archive/<YYYY-MM>/` (agent-api.py iterates `archive/*/`),
+    but the audit globbed `archive/*.txt` and so audited almost nothing. Measured on a
+    live workspace: 943 files seen, 3157 present, 2214 invisible."""
+
+    def _nested(self):
+        ws = Path(tempfile.mkdtemp())
+        month = ws / "results" / "archive" / "2026-09"
+        month.mkdir(parents=True)
+        # a dedup onto a holder that delivers nothing — the audit's whole purpose
+        (month / "task-a.txt").write_text("[deduped: task-b]\n")
+        (month / "task-b.txt").write_text("[no-send]\n")
+        return ws
+
+    def test_the_audit_sees_a_month_nested_archive(self):
+        # Drive main() with NO argv so the script's own enumeration runs. Building the
+        # file list here instead would re-implement the line under test and pass either way.
+        ws = self._nested()
+        buf, err = io.StringIO(), io.StringIO()
+        with mock.patch.object(cdt, "workspace", lambda: ws), \
+                contextlib.redirect_stdout(buf), contextlib.redirect_stderr(err):
+            rc = cdt.main([])
+        out = buf.getvalue() + err.getvalue()
+        self.assertEqual(1, rc, f"the nested dedup onto a [no-send] holder must be found: {out}")
+        self.assertIn("task-a.txt", out)
+        self.assertIn("checked 2 result file(s)", out)
+
+    def test_a_flat_glob_would_have_seen_nothing(self):
+        # Pins WHY this regressed: the old expression is not merely narrower, it is empty.
+        ws = self._nested()
+        flat = list((ws / "results" / "archive").glob("*.txt"))
+        self.assertEqual([], flat, "the pre-fix glob returns nothing on the real layout")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## The defect

`check-dedup-targets.py` in audit mode (no argv) enumerates:

```python
files = [f for f in rd.glob("*.txt")] + [f for f in (rd / "archive").glob("*.txt")]
```

Results archive into `archive/<YYYY-MM>/`. `src/agent-api.py:402` already knows this — it iterates `(RESULT_DIR / "archive").glob("*/")` as month directories. The flat glob matches nothing inside them.

## Measured on a live workspace

```
audit glob (flat):      943 files
recursive glob:        3157 files
invisible to the audit: 2214
```

**70% of archived results were never audited.** The docstring says "audit results/ + archive"; it audited results/ and whatever happened to sit loose at the archive root.

`src/dedup_soundness.py:70` — the policy owner this script otherwise defers to — has globbed `**/` all along:

```python
hits = sorted(list(arch.glob(f"**/{task_id}.txt")) + list(arch.glob(f"**/{task_id}-*.txt")))
```

So this is one copy of an archive-layout assumption drifting flat while the owner stayed correct.

## Why the tests did not catch it

The `_ws` fixture writes archive files at the archive root:

```python
for n, b in (archive or {}).items():
    (ws / "results" / "archive" / n).write_text(b)
```

That is the one layout the flat glob handles. The fixture was built from what the code expects rather than from what the archiver produces, so every existing test passed on a directory shape that does not occur in production.

## The fix

One glob made recursive, with the reason in a comment.

## Tests

New `MonthNestedArchive` case builds `results/archive/2026-09/` containing a dedup onto a `[no-send]` holder, then **drives `main([])`** so the script's own enumeration runs.

That detail is load-bearing. My first version of this test built the file list itself with a recursive glob and passed it to `check()` — re-implementing the line under test, so it passed with the bug restored. Caught by mutation:

```
with the fix:        Ran 21 tests — OK
flat glob restored:  Ran 21 tests — FAILED (failures=1)
```

A second test pins *why* it regressed: on the real layout the pre-fix expression returns `[]`, not merely fewer files.

`review-checks.sh`: PASS (hardcoded-paths + root-artifacts + prose-cap clean).

## Scope

Audit mode only. The `target_body` archive lookup that exists in some deployed builds is not on `main`, so nothing here touches per-target resolution.