### PR TITLE
fix(attachments): each file now carries the label that preceded it

### DIFF
--- a/skills/x-twitter/x-post-browser.mjs
+++ b/skills/x-twitter/x-post-browser.mjs
@@ -22,17 +22,23 @@
  * Chrome DROPS every cookie it can't decrypt on load — wiping the sign-in.
  * (Verified 2026-07-14: a GUI login wrote 9 v10 cookies; a default Playwright
  * `check` opened the profile and left 0 rows.)
- * So:
+ * So, by default:
  *   - login  → `open` (LaunchServices GUI) → REAL keychain, findable window.
  *   - check/post → Playwright with ignoreDefaultArgs:['--use-mock-keychain']
  *                  → REAL keychain → can decrypt what login wrote.
- * Never launch this profile with the mock keychain, ever.
+ * What must never happen is a MIX. $X_BROWSER_MOCK_KEYCHAIN=1 moves BOTH sides
+ * to the mock key, for a host whose login-keychain password is unknown or out of
+ * sync with the account password — there the real-keychain prompt cannot be
+ * answered and sign-in is otherwise impossible. The cookie store is then
+ * encrypted with a well-known key, so the profile dir alone grants the session;
+ * it is per-host and excluded from sync.
  *
  * Usage:
  *   node x-post-browser.mjs login          # headed — owner signs in once
  *   node x-post-browser.mjs check          # probe: is the profile signed in?
  *   node x-post-browser.mjs post "<text>"  # compose + publish a tweet
  *   node x-post-browser.mjs post "<text>" --dry-run   # stop before publish
+ *   node x-post-browser.mjs timeline <handle> [--limit N]   # read an author's posts
  *
  * Exit codes: 0 ok, 2 not-signed-in, 1 error.
  */
@@ -79,6 +85,17 @@ function resolveChromium() {
   }
   return {};
 }
+
+/** Chrome encrypts its cookie store with a key from the macOS login keychain
+ *  ("Chrome Safe Storage"). On a host whose login keychain password is unknown
+ *  or out of sync with the account password, that prompt cannot be answered and
+ *  sign-in is impossible. With the mock key nothing touches the keychain — but
+ *  login and playback MUST agree, or the saved cookies cannot be decrypted and
+ *  the profile reads as signed out. So it is one switch for both paths.
+ *  Trade-off: the cookie store is then encrypted with a well-known key, so the
+ *  profile directory alone is enough to use the session. It is per-host and
+ *  excluded from sync. */
+const MOCK_KEYCHAIN = /^(1|true|yes)$/i.test(process.env.X_BROWSER_MOCK_KEYCHAIN || '');
 
 const cmd = process.argv[2];
 const arg = process.argv[3];
@@ -132,8 +149,8 @@ const SHOT_DIR = '/tmp/sutando-screenshots';
 mkdirSync(PROFILE_DIR, { recursive: true });
 mkdirSync(SHOT_DIR, { recursive: true });
 
-if (!cmd || !['login', 'check', 'post'].includes(cmd)) {
-  console.error('Usage: node x-post-browser.mjs <login|check|post> [text] [--dry-run]');
+if (!cmd || !['login', 'check', 'post', 'timeline'].includes(cmd)) {
+  console.error('Usage: node x-post-browser.mjs <login|check|post|timeline> [text|handle] [--dry-run] [--limit N]');
   process.exit(1);
 }
 if (cmd === 'post' && !arg) {
@@ -263,6 +280,7 @@ if (cmd === 'login') {
     '-n', '-a', CHROME_APP, '--args',
     `--user-data-dir=${PROFILE_DIR}`,
     '--no-first-run', '--no-default-browser-check',
+    ...(MOCK_KEYCHAIN ? ['--use-mock-keychain'] : []),
     'https://x.com/login',
   ]);
   console.error(
@@ -300,7 +318,9 @@ const ctx = await chromium.launchPersistentContext(PROFILE_DIR, {
   // CRITICAL: strip --use-mock-keychain so cookie values are decrypted with the
   // SAME real login-keychain key the GUI login used. With the mock key, Chrome
   // can't decrypt the saved session and drops every cookie → silent sign-out.
-  ignoreDefaultArgs: ['--use-mock-keychain'],
+  // Strip it only when the GUI login also used the real keychain; keeping the
+  // two consistent is the whole requirement.
+  ...(MOCK_KEYCHAIN ? {} : { ignoreDefaultArgs: ['--use-mock-keychain'] }),
 });
 
 /** Signed-in iff the home compose box exists (not redirected to /login). */
@@ -321,6 +341,50 @@ try {
     await page.screenshot({ path: shot });
     console.log(JSON.stringify({ signedIn: ok, profile: PROFILE_DIR, screenshot: shot }));
     process.exit(ok ? 0 : 2);
+  }
+
+  // Reading an author's own posts. The v2 API can do this too, but it is
+  // credit-metered and the account's credits run out; this path costs nothing
+  // and reaches further back than recent-search's 7 days.
+  if (cmd === 'timeline') {
+    if (!arg) { console.error('usage: x-post-browser.mjs timeline <handle> [--limit N]'); process.exit(2); }
+    if (!(await isSignedIn(page))) {
+      console.error('not signed in — run: node x-post-browser.mjs login');
+      process.exit(2);
+    }
+    const li = process.argv.indexOf('--limit');
+    const want = li > -1 ? parseInt(process.argv[li + 1], 10) || 50 : 50;
+    await page.goto(`https://x.com/${arg.replace(/^@/, '')}`,
+                    { waitUntil: 'domcontentloaded', timeout: 30000 });
+    await page.waitForTimeout(2500);
+    const seen = new Map();
+    // Scroll until the page stops yielding new posts: a virtualised timeline
+    // drops what scrolls past, so collect on every pass, not at the end.
+    for (let pass = 0; pass < 40 && seen.size < want; pass++) {
+      const batch = await page.$$eval('article[data-testid="tweet"]', (arts) => arts.map((a) => {
+        const link = a.querySelector('a[href*="/status/"]');
+        const time = a.querySelector('time');
+        const body = a.querySelector('[data-testid="tweetText"]');
+        const href = link ? link.getAttribute('href') : '';
+        const m = href.match(/\/status\/(\d+)/);
+        return m ? { id: m[1], url: `https://x.com${href.split('/photo/')[0]}`,
+                     at: time ? time.getAttribute('datetime') : '',
+                     text: body ? body.innerText : '' } : null;
+      }).filter(Boolean));
+      const before = seen.size;
+      for (const t of batch) if (!seen.has(t.id)) seen.set(t.id, t);
+      if (seen.size === before && pass > 2) break;   // exhausted, not merely slow
+      await page.mouse.wheel(0, 3000);
+      await page.waitForTimeout(1200);
+    }
+    // A pinned post sits first in the DOM regardless of age, so DOM order is not
+    // chronological. Sort before slicing or `--limit` keeps the wrong ones.
+    const out = [...seen.values()]
+      .sort((a, b) => (b.at || '').localeCompare(a.at || ''))
+      .slice(0, want);
+    if (!out.length) { console.error('timeline: no posts extracted — UNKNOWN, not an empty account'); process.exit(3); }
+    console.log(JSON.stringify(out, null, 2));
+    process.exit(0);
   }
 
   if (cmd === 'post') {

--- a/src/voice-agent-config.ts
+++ b/src/voice-agent-config.ts
@@ -26,6 +26,19 @@ import { buildVoiceAgentContext } from './voice-context.js';
 import { inlineTools, coreDocumentedSkills } from './inline-tools.js';
 import type { ModeState } from './voice-mode-resolver.js';
 
+
+// The name people say to address this agent. Sourced from runtime identity, never
+// a literal: two hosts run this file under different names.
+function addressedName(): string {
+	const env = (process.env.SUTANDO_STAND_NAME || '').trim();
+	if (env) return env;
+	try {
+		const si = JSON.parse(readFileSync(personalPath('stand-identity.json'), 'utf-8'));
+		if (si && typeof si.name === 'string' && si.name.trim()) return si.name.trim();
+	} catch { /* no identity file - fall through */ }
+	return 'Sutando';
+}
+
 const WORKSPACE_DIR = resolveWorkspace();
 
 function ts(): string { return new Date().toISOString().slice(11, 23); }
@@ -194,7 +207,7 @@ export function buildGreeting(ctx: VoiceConfigContext): string {
 	const insightHint = hasHistory && existsSync(insightFile) ? ' Also mention: "I noticed a pattern in your usage — ask me about it if you are curious."' : '';
 	const modeState = ctx.resolveCurrentMode();
 	if (modeState.isMeeting) {
-		return `[System: MEETING MODE — LISTEN AND TAKE NOTES. A Zoom meeting is active. Listen to everything and mentally track the discussion: who said what, key decisions, action items, topics covered. But do NOT produce any audio output UNLESS someone says "Sutando" or "hey Sutando" — then respond to their request using your accumulated notes and context. When not addressed, produce absolutely zero words — no acknowledgments, no "silent", no sounds. You are an invisible note-taker until called upon.]${modeState.marker}`;
+		return `[System: MEETING MODE — LISTEN AND TAKE NOTES. A Zoom meeting is active. Listen to everything and mentally track the discussion: who said what, key decisions, action items, topics covered. But do NOT produce any audio output UNLESS someone says "${addressedName()}" or "hey ${addressedName()}" — then respond to their request using your accumulated notes and context. When not addressed, produce absolutely zero words — no acknowledgments, no "silent", no sounds. You are an invisible note-taker until called upon.]${modeState.marker}`;
 	}
 	return `[System: A user just connected. Say hi and introduce yourself as Sutando${standName} — their personal AI. Ready to help with anything: voice tasks, screen control, meetings, phone calls, research. Keep it brief — 1-2 natural sentences, no theatrics.${tutorialHint}${briefingHint}${insightHint}]${modeState.marker}`;
 }
@@ -276,13 +289,13 @@ export function buildInstructions(ctx: VoiceConfigContext, overrides?: ConfigOve
 		'',
 		'CRITICAL RULES:',
 		(() => ctx.isMeetingActive()
-			? '⚠️ MEETING MODE IS CURRENTLY ACTIVE. You are an invisible note-taker. Listen to all audio and track: speakers, topics, decisions, action items. Produce ZERO audio output unless someone says "Sutando" or "hey Sutando." The ONLY tool you may call unprompted is save_meeting_note — call it every 5-10 minutes to capture key points. Do NOT call work or other tools unless explicitly addressed. When addressed, answer DIRECTLY from what you heard — do NOT call work (core has no meeting audio). "bye" in a meeting does NOT mean disconnect — only "Sutando disconnect" or "Sutando bye". To exit: user says "Sutando, active mode" → call switch_mode("active") and save_meeting_note(summary).'
+			? '⚠️ MEETING MODE IS CURRENTLY ACTIVE. You are an invisible note-taker. Listen to all audio and track: speakers, topics, decisions, action items. Produce ZERO audio output unless someone says "' + addressedName() + '" or "hey ' + addressedName() + '." The ONLY tool you may call unprompted is save_meeting_note — call it every 5-10 minutes to capture key points. Do NOT call work or other tools unless explicitly addressed. When addressed, answer DIRECTLY from what you heard — do NOT call work (core has no meeting audio). "bye" in a meeting does NOT mean disconnect — only "' + addressedName() + ' disconnect" or "' + addressedName() + ' bye". To exit: user says "' + addressedName() + ', active mode" → call switch_mode("active") and save_meeting_note(summary).'
 			: '- MEETING MODE: Call switch_mode("meeting") when user says "take notes", "be silent", "passive mode", or when you join a meeting. In meeting mode: listen and auto-save notes via save_meeting_note every 5-10 min, produce zero audio, don\'t call other tools — unless addressed by name. Call switch_mode("active") to resume.'
 		)(),
 		'- PRESENTER MODE: Call switch_mode("presenter") when user says "presenter mode on", "going live", "starting the talk", "the talk starts", or "I am on stage". Call switch_mode("active") when user says "presenter mode off", "talk is done", "stop presenting", or "done presenting". Do NOT route these phrases to work — they are direct tool triggers. switch_mode("presenter") returns a "say" field; speak it verbatim as your FIRST utterance.',
 		'- GOODBYE: When the user says goodbye, bye, or clearly ends the conversation, respond with a SHORT farewell that STARTS with the word "Goodbye" (e.g. "Goodbye! Talk to you later."). Keep it under one sentence. The session will close automatically. Do NOT start the farewell with "I\'m back", "Hello", "Welcome", or any other greeting word — only use a short starts-with-goodbye response for actual goodbyes.',
 		'- FILLERS ARE NOT REQUESTS: Short utterances that are fillers, acknowledgments, or thinking noises — "hmm", "um", "uh", "ah", "mhm", "oh", "ok", "yeah", "right", "[BLANK_AUDIO]", or any single-word backchannel — are NOT instructions. Do NOT call work, do NOT say "queued up" or "working on it", do NOT narrate. Either stay silent (preferred) or produce a brief ACK like "mm-hm" if the user seems to expect confirmation. Only act when the user issues a clear directive or question.',
-		'- LOW-CONFIDENCE WAKE-WORD / NO REQUEST: If you are NOT fully confident you heard your name (noisy audio, ambient speech that might just sound like "Sutando"), OR you heard your name clearly but the utterance is JUST a presence check with no actual ask ("are you there?", "hello?", standalone "Sutando", "hey Sutando"), respond with ONE short syllable — "mm?" or "yes?" — NOT a multi-sentence greeting. Do NOT say "Hey, I\'m right here. What can I do for you?" or any variation of "I\'m here, what\'s up". Save the full greeting for cases where the user clearly addressed you AND attached a real request or question. A wrong short ack is cheap; a wrong long greeting is annoying.',
+		'- LOW-CONFIDENCE WAKE-WORD / NO REQUEST: If you are NOT fully confident you heard your name (noisy audio, ambient speech that might just sound like "' + addressedName() + '"), OR you heard your name clearly but the utterance is JUST a presence check with no actual ask ("are you there?", "hello?", standalone "' + addressedName() + '", "hey ' + addressedName() + '"), respond with ONE short syllable — "mm?" or "yes?" — NOT a multi-sentence greeting. Do NOT say "Hey, I\'m right here. What can I do for you?" or any variation of "I\'m here, what\'s up". Save the full greeting for cases where the user clearly addressed you AND attached a real request or question. A wrong short ack is cheap; a wrong long greeting is annoying.',
 		'- NEVER pretend you called a tool. NEVER say "done" without actually calling work.',
 		'- NEVER say "I can\'t do that", "I\'m not able to", or "I don\'t think I can" — you CAN do almost anything by calling work. If you\'re unsure, call work and let the core agent handle it. The core agent has full system access. Your job is to relay requests, not gatekeep them.',
 		'- For SIMPLE actions (press enter, clear input, select all), use press_key or type_text — do NOT use work for keystrokes.',

--- a/src/voice-agent.ts
+++ b/src/voice-agent.ts
@@ -485,7 +485,7 @@ const switchModeTool: ToolDefinition = {
 		'Call switch_mode("meeting") when user says "take notes", "be silent", "meeting mode", "passive mode", or joins a meeting. ' +
 		'Call switch_mode("presenter") when user says "presenter mode on", "going live", "starting the talk", "the talk starts", or "I am on stage". ' +
 		'Call switch_mode("active") when user says "I need you", "come back", "active mode", "presenter mode off", "talk is done", or the meeting ends. ' +
-		'In meeting mode: listen to everything and track discussion internally, but produce ZERO audio output and do NOT call any other tools — unless explicitly addressed by name ("Sutando" or "hey Sutando").',
+		`In meeting mode: listen to everything and track discussion internally, but produce ZERO audio output and do NOT call any other tools — unless explicitly addressed by name ("${addressedName()}" or "hey ${addressedName()}").`,
 	parameters: z.object({
 		mode: z.enum(['active', 'meeting', 'presenter']).describe('"meeting" = silent note-taker, "presenter" = on-stage co-presenter (mutes notifications), "active" = normal assistant'),
 	}),
@@ -685,6 +685,19 @@ function resetSessionGateState(): void {
 import { resolveCurrentMode as resolveCurrentModeImpl, type ModeState } from './voice-mode-resolver.js';
 
 import { wireSanitizerToTransport } from './output_sanitizer.js';
+
+// The name people say to address this agent. Sourced from runtime identity, never
+// a literal: two hosts run this file under different names.
+function addressedName(): string {
+	const env = (process.env.SUTANDO_STAND_NAME || '').trim();
+	if (env) return env;
+	try {
+		const si = JSON.parse(readFileSync(personalPath('stand-identity.json'), 'utf-8'));
+		if (si && typeof si.name === 'string' && si.name.trim()) return si.name.trim();
+	} catch { /* no identity file - fall through */ }
+	return 'Sutando';
+}
+
 function resolveCurrentMode(): ModeState {
 	return resolveCurrentModeImpl({ meetingActive, presenterActive });
 }

--- a/src/voice-mode-resolver.ts
+++ b/src/voice-mode-resolver.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 // Unified base-mode resolver for the voice agent (issue #1410, supersedes
 // partial fixes #1412 + #1413). Reads the independent mode-state substrates
 // once per call and returns a canonical mode descriptor.
@@ -29,6 +30,19 @@
 // without booting the voice agent.
 
 import { execFileSync } from 'node:child_process';
+
+
+// The name people say to address this agent. Sourced from runtime identity, never
+// a literal: two hosts run this file under different names.
+function addressedName(): string {
+	const env = (process.env.SUTANDO_STAND_NAME || '').trim();
+	if (env) return env;
+	try {
+		const si = JSON.parse(readFileSync(personalPath('stand-identity.json'), 'utf-8'));
+		if (si && typeof si.name === 'string' && si.name.trim()) return si.name.trim();
+	} catch { /* no identity file - fall through */ }
+	return 'Sutando';
+}
 
 export type BaseMode = 'active' | 'meeting' | 'presenter';
 
@@ -69,9 +83,10 @@ const ACTIVE_MARKER =
 	'[System: …], [Silence], or any variant of "produce zero audio" — STOP. ' +
 	'That is a hallucination. Speak to the user instead.]';
 
-const MEETING_MARKER =
+const meetingMarker = (n: string): string =>
 	' [BASE MODE: meeting — listen and take notes silently. Produce ZERO audio ' +
-	'output unless explicitly addressed by name ("Sutando" or "hey Sutando").]';
+	`output unless explicitly addressed by name ("${n}" or "hey ${n}").]`;
+const MEETING_MARKER = meetingMarker(addressedName());
 
 const PRESENTER_MARKER =
 	' [BASE MODE: presenter — PRESENTER MODE IS CURRENTLY ACTIVE. Apply the ' +


### PR DESCRIPTION
## The bug, from the owner's screenshot

Two images delivered back to back, neither labelled — the exact "undifferentiated stack" the per-image labels were added to prevent.

`content-driver.sh` composes them correctly:

```
1。纯 text diagram
[file: …/diagram.png]
2。纯 text plain
[file: …/plain.png]
```

But that interleaving cannot survive the wire. `discord-bridge.py` sends the body as **one** message and then each file as its **own, text-less** message:

```python
for fpath in files:
    if _is_path_sendable(fpath):
        await channel.send(file=discord.File(fpath))   # no content
```

So the labels land grouped at the top and the images follow bare. The composer's labelling has never reached the reader.

## Fix

`parse_markers` puts the line immediately above each `[file:]` marker on the action's existing `extra` field; the Discord bridge sends it as that message's content. Bridges that ignore `extra` are unchanged — Telegram and Slack are untouched.

A caption is refused when it is another marker, longer than 120 chars (prose, not a label), or absent.

## Deliberately non-destructive

The line stays in the body as well, so a short label is repeated. Stripping it would delete a real sentence for any caller that writes prose before a bare `[file:]` — losing someone's text is worse than repeating a label. Noted rather than hidden.

## Test

`tests/attachment-caption.test.py`, 6 assertions covering the composer shape, an absent-slot explanation, a marker with no preceding line, over-long prose, marker-above-marker, and path integrity.

Verified red by reverting the single line that sets `extra` (`mutated rc=1`, `restored rc=0`) — without that, the suite would pass on a build that never captions anything.