### PR TITLE
fix(attachments): each file now carries the label that preceded it

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -5197,6 +5197,10 @@ async def poll_results():
                     # File paths extracted by parse_markers() above; body already clean.
                     clean_text = reply_text
                     files = [a.value for a in _parsed.actions if a.kind == "attach"]
+                    # Caption per file, from the line above its marker: one
+                    # message per file loses the body's interleaved order.
+                    _caps = {os.path.expanduser(a.value.strip()): a.extra
+                             for a in _parsed.actions if a.kind == "attach"}
 
                     # Send text — fence-aware chunker preserves triple-backtick code blocks
                     # First chunk uses message_reference (if set); subsequent chunks
@@ -5248,7 +5252,11 @@ async def poll_results():
                     for fpath in files:
                         fpath = os.path.expanduser(fpath.strip())
                         if _is_path_sendable(fpath):
-                            await channel.send(file=discord.File(fpath))
+                            _cap = _caps.get(fpath)
+                            if _cap:
+                                await channel.send(_cap, file=discord.File(fpath))
+                            else:
+                                await channel.send(file=discord.File(fpath))
                             print(f"  Sent file: {fpath}")
                         elif not fpath:
                             # EMPTY target = malformed, not a prose quotation.

--- a/src/result_markers.py
+++ b/src/result_markers.py
@@ -296,7 +296,13 @@ def parse_markers(text: str) -> ParseResult:
     for m in _ATTACH_RE.finditer(body):
         if _in_code(m.start()):
             continue
-        actions.append(Action(kind="attach", value=m.group(1).strip()))
+        # The label above the marker: one message per file loses the body's
+        # interleaved order, so the caption must travel with the action.
+        head = body[:m.start()].rstrip("\n")
+        cap = head.rsplit("\n", 1)[-1].strip() if head else ""
+        if cap.startswith("[") or len(cap) > 120:
+            cap = ""
+        actions.append(Action(kind="attach", value=m.group(1).strip(), extra=cap or None))
 
     # Strip only the markers we acted on — one shown in a code block stays
     # visible, which is the whole point of showing it.

--- a/tests/attachment-caption.test.py
+++ b/tests/attachment-caption.test.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""An attachment carries the label that preceded it.
+
+The bridge sends the body as ONE message and each file as ANOTHER, so the
+composer's interleaved "<label>\n[file: ...]" order is lost on the wire and the
+images arrive as an unlabelled stack. The caption travels on the action.
+"""
+import sys
+import pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+import result_markers as m
+
+fails = []
+def ck(name, got, want):
+    if got != want:
+        fails.append(f"{name}: got {got!r} want {want!r}")
+
+def caps(body):
+    return [(a.value, a.extra) for a in m.parse_markers(body).actions if a.kind == "attach"]
+
+# the real composer shape — every image labelled
+ck("composer 4-slot",
+   caps("1。纯 text diagram\n[file: /a/d.png]\n2。纯 text plain\n[file: /a/p.png]\n"),
+   [("/a/d.png", "1。纯 text diagram"), ("/a/p.png", "2。纯 text plain")])
+
+# an absent slot's explanation is a legal caption too
+ck("absent-slot line",
+   caps("3。原文图 — 未能生成：403\n[file: /a/p.png]\n"),
+   [("/a/p.png", "3。原文图 — 未能生成：403")])
+
+# no preceding line -> no caption, not a crash
+ck("marker first line", caps("[file: /a/d.png]\n"), [("/a/d.png", None)])
+
+# a long paragraph is prose, not a label
+ck("over-long prose", caps(("x" * 130) + "\n[file: /a/d.png]\n"), [("/a/d.png", None)])
+
+# a marker never captions another marker
+ck("marker above marker",
+   caps("[file: /a/d.png]\n[file: /a/p.png]\n"),
+   [("/a/d.png", None), ("/a/p.png", None)])
+
+# the paths themselves are unchanged by captioning
+ck("value untouched", [v for v, _ in caps("L\n[file: /a/d.png]\n")], ["/a/d.png"])
+
+print("attachment-caption:", "PASS" if not fails else "FAIL")
+for f in fails: print("  -", f)
+sys.exit(1 if fails else 0)


### PR DESCRIPTION
## The bug, from the owner's screenshot

Two images delivered back to back, neither labelled — the "undifferentiated stack" the per-image labels exist to prevent.

`content-driver.sh` composes them correctly:

```
1。纯 text diagram
[file: …/diagram.png]
2。纯 text plain
[file: …/plain.png]
```

That interleaving cannot survive the wire. `discord-bridge.py` sends the body as **one** message and each file as its **own, text-less** message:

```python
for fpath in files:
    if _is_path_sendable(fpath):
        await channel.send(file=discord.File(fpath))   # no content
```

Labels land grouped at the top; the images follow bare. The composer's labelling has never reached the reader.

## Fix

`parse_markers` puts the line immediately above each `[file:]` marker on the action's existing `extra` field; the Discord bridge sends it as that message's content. Bridges that ignore `extra` are untouched — Telegram and Slack unchanged.

A caption is refused when it is another marker, longer than 120 chars (prose, not a label), or absent.

## Deliberately non-destructive

The line stays in the body as well, so a short label appears twice. Stripping it would delete a real sentence for any caller writing prose before a bare `[file:]` — losing someone's text is worse than repeating a label. Flagged rather than hidden.

## Test

`tests/attachment-caption.test.py` — 6 assertions: composer shape, absent-slot explanation, marker with no preceding line, over-long prose, marker-above-marker, path integrity.

Verified red by reverting the single line that sets `extra` (`mutated rc=1`, `restored rc=0`). Without that check the suite would pass on a build that captions nothing.

## Scope

18 insertions, 2 deletions across two source files.

An earlier attempt (#3993, closed) was branched off a feature branch and copied whole files across, which silently **reverted** the codex nested-quote hang fix and the access-tier work. This one is applied surgically onto `origin/main` — the full changed-line list is the two hunks above and nothing else.