### PR TITLE
fix(proactive-loop): a quota read with no windows crashed the tier instead of refusing

### DIFF
--- a/skills/proactive-loop/scripts/quota-tier.py
+++ b/skills/proactive-loop/scripts/quota-tier.py
@@ -96,7 +96,14 @@ def main(argv=None) -> int:
     ap.add_argument("--reset7", help="7d reset, ISO")
     ap.add_argument("--reset7oi", help="top-tier (7d_oi) weekly reset, ISO")
     a = ap.parse_args(argv)
-    q = parse(sys.stdin.read())
+    try:
+        q = parse(sys.stdin.read())
+    except ValueError as e:
+        # No quota-state.json is a NORMAL state (credential proxy off), which
+        # health-check rates ok — so it must refuse like every other window.
+        print(f"quota-tier: cannot read quota windows ({e}); nothing to tier. "
+              f"Is the credential proxy running? Nothing guessed.", file=sys.stderr)
+        return 2
     now = datetime.datetime.now()
     r5 = datetime.datetime.fromisoformat(a.reset5) if a.reset5 else None
     r7 = datetime.datetime.fromisoformat(a.reset7) if a.reset7 else None

--- a/skills/proactive-loop/scripts/quota-tier.py
+++ b/skills/proactive-loop/scripts/quota-tier.py
@@ -105,8 +105,18 @@ def main(argv=None) -> int:
               f"Is the credential proxy running? Nothing guessed.", file=sys.stderr)
         return 2
     now = datetime.datetime.now()
-    r5 = datetime.datetime.fromisoformat(a.reset5) if a.reset5 else None
-    r7 = datetime.datetime.fromisoformat(a.reset7) if a.reset7 else None
+    flags = {}
+    for flag, raw in (("--reset5", a.reset5), ("--reset7", a.reset7)):
+        try:
+            flags[flag] = datetime.datetime.fromisoformat(raw) if raw else None
+        except ValueError as e:
+            # The reset refusal below says "pass --reset5/--reset7"; a mistyped
+            # date there must refuse like stdin does, not traceback with no TIER.
+            print(f"quota-tier: {flag} is not a parseable ISO datetime ({e}); "
+                  f"fix it or drop it to use the printed reset lines. "
+                  f"Nothing guessed.", file=sys.stderr)
+            return 2
+    r5, r7 = flags["--reset5"], flags["--reset7"]
     if not (r5 and r7):
         # Fall back to the printed reset lines, year inferred and bounds-checked.
         try:

--- a/tests/proactive-loop-quota-tier.test.py
+++ b/tests/proactive-loop-quota-tier.test.py
@@ -127,6 +127,15 @@ class ResetFallback(unittest.TestCase):
         self.assertEqual(rc, 2)
         self.assertIn("cannot resolve reset times", out)
 
+    def test_no_window_lines_at_all_is_a_refusal_not_a_traceback(self):
+        """read-quota prints this whenever the credential proxy is off — a state
+        health-check rates ok — and the loop's step 0.5 then got no TIER line."""
+        for text in ("No quota-state.json found. Is the credential proxy running?\n", ""):
+            rc, out = self._run(text)
+            self.assertEqual(rc, 2, out)
+            self.assertIn("cannot read quota windows", out)
+            self.assertNotIn("Traceback", out)
+
 
 class FreshWindowZeroBurn(unittest.TestCase):
     """A just-reset 7d window has used7 == 0, so `burn` is 0 and then divides.

--- a/tests/proactive-loop-quota-tier.test.py
+++ b/tests/proactive-loop-quota-tier.test.py
@@ -136,6 +136,16 @@ class ResetFallback(unittest.TestCase):
             self.assertIn("cannot read quota windows", out)
             self.assertNotIn("Traceback", out)
 
+    def test_unparseable_reset_flags_are_a_refusal_not_a_traceback(self):
+        """The reset refusal says "pass --reset5/--reset7"; a mistyped date on
+        that very flag must not reproduce the traceback this file refuses."""
+        text = "5h window: 10% used, 90% remaining\n7d window: 20% used, 80% remaining\n"
+        for argv in (["--reset5", "not-a-date"], ["--reset7", "not-a-date"]):
+            rc, out = self._run(text, argv)
+            self.assertEqual(rc, 2, out)
+            self.assertIn(f"{argv[0]} is not a parseable ISO datetime", out)
+            self.assertNotIn("Traceback", out)
+
 
 class FreshWindowZeroBurn(unittest.TestCase):
     """A just-reset 7d window has used7 == 0, so `burn` is 0 and then divides.


### PR DESCRIPTION
## The defect

`quota-tier.py` already refuses legibly when it has utilization but no usable reset — `cannot
resolve reset times ... Nothing guessed.`, exit 2. The case where it has **no window lines at all**
took a different path: `parse()` raised an uncaught `ValueError` and the process died with a
traceback on exit 1.

That input is not exotic. `read-quota.py` prints `No quota-state.json found. Is the credential
proxy running?` whenever the credential proxy is off — a state `health-check.py` explicitly rates
**ok**:

```
  ✓ quota-telemetry   ok   credential proxy not running — quota telemetry not expected
  ✓ core-quota        ok   no quota-state.json (absence handled by quota-telemetry)
```

So on a host health-check calls healthy, the proactive loop's step 0.5 —
`read-quota.py | quota-tier.py` — emitted a traceback and **no `TIER` line at all**. The tier that
caps step 6's depth was simply absent. Found live during a `/proactive-loop` pass.

## Before — at the parent commit (`origin/main` @ `38bd20ec`)

```
$ python3 ~/.claude/skills/quota-tracker/scripts/read-quota.py | python3 skills/proactive-loop/scripts/quota-tier.py
Traceback (most recent call last):
  File ".../skills/proactive-loop/scripts/quota-tier.py", line 156, in <module>
    sys.exit(main())
             ~~~~^^
  File ".../skills/proactive-loop/scripts/quota-tier.py", line 99, in main
    q = parse(sys.stdin.read())
  File ".../skills/proactive-loop/scripts/quota-tier.py", line 84, in parse
    out = {"used5": grab("5h", "used"), "rem5": grab("5h", "rem"),
                    ~~~~^^^^^^^^^^^^^^
  File ".../skills/proactive-loop/scripts/quota-tier.py", line 71, in grab
    raise ValueError(f"no {win} window line in input")
ValueError: no 5h window line in input
EXIT=1
```

## After — at HEAD

```
$ python3 ~/.claude/skills/quota-tracker/scripts/read-quota.py | python3 skills/proactive-loop/scripts/quota-tier.py
quota-tier: cannot read quota windows (no 5h window line in input); nothing to tier. Is the credential proxy running? Nothing guessed.
EXIT=2
```

Exit 2 is the loop's documented "cannot answer" code, and it is the code this file already returns
for its two sibling refusals. Nothing is guessed.

## Tests

`tests/proactive-loop-quota-tier.test.py`, new case
`test_no_window_lines_at_all_is_a_refusal_not_a_traceback`, placed next to the existing
`test_missing_reset_lines_are_cannot_answer_not_guessed` it mirrors. It covers both real shapes of
the input: `read-quota.py`'s literal message, and empty stdin.

Positive control — the test fails at the parent and passes at HEAD:

```
$ git checkout -- skills/proactive-loop/scripts/quota-tier.py   # test only, fix removed
$ python3 tests/proactive-loop-quota-tier.test.py
...
ValueError: no 5h window line in input
----------------------------------------------------------------------
Ran 26 tests in 0.007s
FAILED (errors=1)

$ git apply /tmp/qt-fix.patch                                    # fix restored
$ python3 tests/proactive-loop-quota-tier.test.py
----------------------------------------------------------------------
Ran 26 tests in 0.007s
OK
```

## Scope

Two files, +17/-1. No prompt or tool-behavior changes. The refusal message and exit code follow the
shape already used twice in `main()`; no new convention is introduced.
