### PR TITLE
fix(health-check): the hooks warn prescribed installing an opt-in-only hook

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -10898,9 +10898,8 @@ def check_claude_hook_registration(
             bits.append(f"{len(foreign)} registered but NOT running the installer's command "
                         f"— a different program, another checkout, or the path is "
                         f"only an argument ({', '.join(foreign)})")
-        # The remedy must not tell a reader to run the bare installer when the only thing
-        # missing is the transcript archiver: that is the one hook left to explicit opt-in,
-        # and the bare command registers it. --fix already refuses it; the text did not.
+        # The bare installer registers the opt-in-only transcript archiver, so the remedy
+        # must not prescribe it when that hook is the only thing missing.
         only_archive = bool(missing) and set(missing) == {_TRANSCRIPT_ARCHIVE_HOOK} and not foreign
         remedy = ("that hook copies full transcripts to ~/Desktop and is left to explicit opt-in — "
                   "it is not repaired automatically; run `bash src/install-claude-hooks.sh` only if "

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -10898,8 +10898,17 @@ def check_claude_hook_registration(
             bits.append(f"{len(foreign)} registered but NOT running the installer's command "
                         f"— a different program, another checkout, or the path is "
                         f"only an argument ({', '.join(foreign)})")
+        # The remedy must not tell a reader to run the bare installer when the only thing
+        # missing is the transcript archiver: that is the one hook left to explicit opt-in,
+        # and the bare command registers it. --fix already refuses it; the text did not.
+        only_archive = bool(missing) and set(missing) == {_TRANSCRIPT_ARCHIVE_HOOK} and not foreign
+        remedy = ("that hook copies full transcripts to ~/Desktop and is left to explicit opt-in — "
+                  "it is not repaired automatically; run `bash src/install-claude-hooks.sh` only if "
+                  "you intend to enable it"
+                  if only_archive else
+                  "re-run `SUTANDO_HOOKS_OMIT_TRANSCRIPT_ARCHIVE=1 bash src/install-claude-hooks.sh`")
         result = {"name": name, "status": "warn",
-                  "detail": f"{'; '.join(bits)} in {settings} — re-run `bash src/install-claude-hooks.sh`"}
+                  "detail": f"{'; '.join(bits)} in {settings} — {remedy}"}
         if missing:
             # Keyed structurally so --fix cannot fire on the warn branches the
             # installer can't repair; `foreign` excluded (displacement unverified).

--- a/tests/health-check-claude-hook-registration.test.py
+++ b/tests/health-check-claude-hook-registration.test.py
@@ -87,6 +87,27 @@ class TestHookRegistration(unittest.TestCase):
         self.assertIn("2 NOT registered", out["detail"])
         self.assertNotIn("Stop:", out["detail"], "a registered hook must not be reported missing")
 
+    def test_remedy_omits_the_archive_hook_when_other_hooks_are_missing(self):
+        # The bare installer registers the transcript archiver. Anyone repairing an unrelated
+        # missing hook by following this text would enable an egress the owner has not opted into.
+        h = self._all_registered()
+        del h["Stop"]
+        self._settings(h)
+        out = self.hc.check_claude_hook_registration(repo_dir=self.repo)
+        self.assertEqual(out["status"], "warn")
+        self.assertIn("SUTANDO_HOOKS_OMIT_TRANSCRIPT_ARCHIVE=1", out["detail"])
+
+    def test_remedy_does_not_prescribe_a_repair_when_only_the_archiver_is_missing(self):
+        # --fix already refuses this case; the text used to prescribe the bare command anyway.
+        h = self._all_registered()
+        h["PreCompact"] = [{"hooks": [{"command": f"bash {self.repo}/src/session-handoff.sh"}]}]
+        self._settings(h)
+        out = self.hc.check_claude_hook_registration(repo_dir=self.repo)
+        self.assertEqual(out["status"], "warn")
+        self.assertIn("explicit opt-in", out["detail"])
+        self.assertIn("only if you intend", out["detail"])
+        self.assertNotIn("re-run", out["detail"], "an opt-in is not a repair instruction")
+
     def test_registered_but_pointing_at_ANOTHER_checkout_warns(self):
         # The failure that looks healthiest: present, so an existence check passes,
         # but aimed at a stale copy — this host ran a 5-day-old script for days.


### PR DESCRIPTION
## The code refuses; the text beside it prescribes

`--fix` deliberately will not register the transcript archiver (`health-check.py`, the `claude-hooks` repair):

```python
scoped = [h for h in c["_unregistered_hooks"] if h != _TRANSCRIPT_ARCHIVE_HOOK]
if not scoped:   # "not repairing — the only unregistered hook copies full transcripts"
...
env={**os.environ, "SUTANDO_HOOKS_OMIT_TRANSCRIPT_ARCHIVE": "1"}
```

Its comment says why: *"a routine timer must not make that egress decision"*, and *"its absence keeps warning"*. That design is correct and this PR does not touch it.

The **warn text** said:

```
⚠ claude-hooks  1 NOT registered (PreCompact:sutando-conversations/)
                — re-run `bash src/install-claude-hooks.sh`
```

That is the bare command, which registers exactly the hook `--fix` declines. So a reader repairing the warn does what the code beside it refuses to do.

## Evidence this is not hypothetical

Following that text on a live host registered:

```
PreCompact: cp "$TRANSCRIPT_PATH" "$HOME/Desktop/sutando-conversations/$(date …).jsonl"
```

on a host where it was not approved. Nothing was copied — `$TRANSCRIPT_PATH` is never set (`session-handoff.sh:52`: *"Claude Code hooks pass transcript_path via stdin JSON ONLY — there is no `$TRANSCRIPT_PATH` env var"*) — and it was reverted within the hour. But the instruction is what produced the attempt, and the workspace record shows a previous session doing the same thing on 2026-09-06. Two readers, one instruction.

## The change

Two branches instead of one string:

- **only the archiver missing** → say it is left to explicit opt-in and is not repaired automatically, and do not phrase it as a repair;
- **anything else missing** → prescribe `SUTANDO_HOOKS_OMIT_TRANSCRIPT_ARCHIVE=1 bash src/install-claude-hooks.sh`.

The opt-in message at the `--fix` refusal site is left alone: naming the bare command there is correct, because opting in is precisely what it describes.

## Evidence

```
tests/health-check-claude-hook-registration.test.py   28 tests  OK   (2 new)
tests/claude-hooks-autofix.test.py                     9 tests  OK
tests/install-claude-hooks-transcript-optout.test.sh            OK
```

Mutation-checked — restoring the old single string fails **both** new tests, so they gate the behaviour rather than describing it:

```
detail: … — {remedy}   ->   … — re-run `bash src/install-claude-hooks.sh`
  FAIL test_remedy_does_not_prescribe_a_repair_when_only_the_archiver_is_missing
  FAIL test_remedy_omits_the_archive_hook_when_other_hooks_are_missing
  CAUGHT   (file restored byte-equal afterwards)
```

The second test also asserts the opt-in branch contains no `re-run`, because an opt-in is not a repair instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
