### PR TITLE
feat(web-client): one-at-a-time triage queue for pending questions

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -114,6 +114,7 @@ One entry per agent-facing module. 5 without a usable header comment.
 - **`owner_activity.py`** — Atomic publication of the owner's most recent messaging activity.
 - **`peer-watch.py`** — Read a peer host's restart-watch signal WITHOUT confusing a stale view for a dead peer.
 - **`pending_questions_md.py`** — Locating the `# Resolved` divider in pending-questions.md — one definition.
+- **`pending_questions_triage.py`** — Triage-queue policy for pending-questions.md: ranking, re-check verdict, dismissal.
 - **`personal-claude-compact-hint.sh`** — SessionStart(compact) hook — re-inject PERSONAL_CLAUDE.md after context compaction.
 - **`presenter-mode.ts`** — Provider-neutral presenter-mode sentinel policy — TS twin of src/presenter_mode.py (#2501).
 - **`presenter_mode.py`** — Provider-neutral presenter-mode sentinel policy.

--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -239,6 +239,24 @@ PQ_ANSWERED_RE = re.compile(r'\*\*Status:\*\*\s*(resolved|answered|done|complete
 PQ_STATUS_RE = re.compile(r'\*\*Status:\*\*.*')
 PQ_FIELD_RE = re.compile(r'\*\*(?:Status|Options|Asked|Question):\*\*')
 PQ_OPTIONS_RE = re.compile(r'\*\*Options:\*\*\s*(.+)')
+PQ_DATE_RE = re.compile(r'^(\d{4}-\d{2}-\d{2})(T\d{2}:\d{2}(?::\d{2})?Z)?')
+
+
+def _parse_asked_date(title: str) -> tuple[str | None, datetime | None]:
+    """Leading date on a section's `## ` heading, e.g. '2026-08-22 — ...' or
+    '2026-08-20T02:20Z — ...'. (None, None) when the heading carries no date.
+    """
+    m = PQ_DATE_RE.match(title)
+    if not m:
+        return None, None
+    asked = m.group(0)
+    formats = ("%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%dT%H:%MZ") if m.group(2) else ("%Y-%m-%d",)
+    for fmt in formats:
+        try:
+            return asked, datetime.strptime(asked, fmt)
+        except ValueError:
+            continue
+    return None, None
 
 
 def parse_pending_questions(content: str) -> list[dict]:
@@ -278,10 +296,13 @@ def parse_pending_questions(content: str) -> list[dict]:
             continue
         # Whitespace-normalised so a reflow of the same prose keeps the id.
         qid = "Q" + hashlib.sha1(" ".join(section.split()).encode()).hexdigest()[:12]
+        asked, asked_dt = _parse_asked_date(title)
         q = {
             "id": qid,
             "text": title,
             "detail": PQ_FIELD_RE.split(body)[0].strip() or title,
+            "asked": asked,
+            "age_days": (datetime.now() - asked_dt).days if asked_dt else None,
             "start": start,
             "end": end,
         }
@@ -459,10 +480,14 @@ def _pending_question_rows() -> list[dict]:
     pending_file = Path(personal_path("pending-questions.md", WORKSPACE_DIR))
     if not pending_file.exists():
         return []
-    return [
+    rows = [
         {key: value for key, value in question.items() if key not in ("start", "end")}
         for question in parse_pending_questions(pending_file.read_text())
     ]
+    # Oldest first. An undated heading cannot be ranked by age and must sort LAST,
+    # never default to 0 — that would put it ahead of everything genuinely waiting.
+    rows.sort(key=lambda row: (row["age_days"] is None, -(row["age_days"] or 0)))
+    return rows
 
 
 def _active_tasks_payload(watcher_ok: bool, core_ok: bool) -> dict:

--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -47,7 +47,8 @@ import stat
 import subprocess
 import sys
 import threading
-from datetime import datetime
+from datetime import datetime, timezone
+from typing import Optional
 from pathlib import Path
 from urllib.parse import urlparse, unquote
 
@@ -242,7 +243,7 @@ PQ_OPTIONS_RE = re.compile(r'\*\*Options:\*\*\s*(.+)')
 PQ_DATE_RE = re.compile(r'^(\d{4}-\d{2}-\d{2})(T\d{2}:\d{2}(?::\d{2})?Z)?')
 
 
-def _parse_asked_date(title: str) -> tuple[str | None, datetime | None]:
+def _parse_asked_date(title: str) -> tuple[Optional[str], Optional[datetime]]:
     """Leading date on a section's `## ` heading, e.g. '2026-08-22 — ...' or
     '2026-08-20T02:20Z — ...'. (None, None) when the heading carries no date.
     """
@@ -253,7 +254,9 @@ def _parse_asked_date(title: str) -> tuple[str | None, datetime | None]:
     formats = ("%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%dT%H:%MZ") if m.group(2) else ("%Y-%m-%d",)
     for fmt in formats:
         try:
-            return asked, datetime.strptime(asked, fmt)
+            # Headings are UTC; a naive parse against a local now() reports a question
+            # asked minutes ago as -1 days, which the age sort then ranks first.
+            return asked, datetime.strptime(asked, fmt).replace(tzinfo=timezone.utc)
         except ValueError:
             continue
     return None, None
@@ -302,7 +305,7 @@ def parse_pending_questions(content: str) -> list[dict]:
             "text": title,
             "detail": PQ_FIELD_RE.split(body)[0].strip() or title,
             "asked": asked,
-            "age_days": (datetime.now() - asked_dt).days if asked_dt else None,
+            "age_days": max(0, (datetime.now(timezone.utc) - asked_dt).days) if asked_dt else None,
             "start": start,
             "end": end,
         }

--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -47,6 +47,7 @@ import stat
 import subprocess
 import sys
 import threading
+import time
 from datetime import datetime, timezone
 from typing import Optional
 from pathlib import Path
@@ -129,6 +130,7 @@ PORT = int(_PORT_ENV) if _PORT_ENV is not None else 7843
 # over the public workspace.
 from util_paths import personal_path  # noqa: E402
 from pending_questions_md import active_region  # noqa: E402
+import pending_questions_triage as pq_triage  # noqa: E402
 from task_body_guard import confine_user_content  # noqa: E402
 from task_body_guard import header_safe_value  # noqa: E402
 from signal_room_tasks import (SIGNAL_ROOM_TIER, SIGNAL_TASK_PREFIX, SignalRoomBusy,
@@ -478,8 +480,61 @@ def _active_task_rows() -> list[dict]:
     return task_workstreams.enrich_task_rows(WORKSPACE_DIR, rows)
 
 
-def _pending_question_rows() -> list[dict]:
-    """Return open questions without parser-only splice offsets."""
+# How many referenced PRs one queue render will probe, and how long a verdict is
+# reused. Bounded so triaging a long queue cannot turn into an unbounded gh fan-out.
+PQ_REF_PROBE_LIMIT = 12
+PQ_REF_PROBE_TTL = 120
+PQ_REF_PROBE_TIMEOUT = 5
+
+_pq_ref_cache: dict = {}
+_pq_ref_cache_lock = threading.Lock()
+
+
+def _dismissed_questions_path() -> Path:
+    return Path(personal_path("dismissed-questions.json", WORKSPACE_DIR))
+
+
+def _probe_ref_states(refs: list) -> dict:
+    """Live state of the PRs a question references, as `(repo, number)` pairs.
+
+    Failure is silent on purpose: an unreachable gh must leave the queue exactly as
+    it was, never mark a question resolved and never drop it.
+    """
+    states: dict = {}
+    now = time.time()
+    stale: list = []
+    with _pq_ref_cache_lock:
+        for ref in refs:
+            hit = _pq_ref_cache.get(ref)
+            if hit and now - hit[0] < PQ_REF_PROBE_TTL:
+                if hit[1]:
+                    states[ref] = hit[1]
+            else:
+                stale.append(ref)
+    for ref in stale[:PQ_REF_PROBE_LIMIT]:
+        state = None
+        try:
+            probe = subprocess.run(
+                ["gh", "pr", "view", str(ref[1]), "--repo", ref[0], "--json", "state"],
+                capture_output=True, text=True, timeout=PQ_REF_PROBE_TIMEOUT,
+            )
+            if probe.returncode == 0:
+                state = (json.loads(probe.stdout) or {}).get("state") or None
+        except Exception:
+            state = None
+        with _pq_ref_cache_lock:
+            _pq_ref_cache[ref] = (time.time(), state)
+        if state:
+            states[ref] = state
+    return states
+
+
+def _pending_question_rows(recheck: bool = False) -> list[dict]:
+    """Open questions, dismissed ones removed, ordered for the triage queue.
+
+    `recheck` probes the referenced PRs first, so a question whose blocker has since
+    merged is labelled at the moment it is shown rather than carried for weeks.
+    """
     pending_file = Path(personal_path("pending-questions.md", WORKSPACE_DIR))
     if not pending_file.exists():
         return []
@@ -487,10 +542,35 @@ def _pending_question_rows() -> list[dict]:
         {key: value for key, value in question.items() if key not in ("start", "end")}
         for question in parse_pending_questions(pending_file.read_text())
     ]
-    # Oldest first. An undated heading cannot be ranked by age and must sort LAST,
-    # never default to 0 — that would put it ahead of everything genuinely waiting.
-    rows.sort(key=lambda row: (row["age_days"] is None, -(row["age_days"] or 0)))
-    return rows
+    rows = pq_triage.without_dismissed(
+        rows, pq_triage.load_dismissed(_dismissed_questions_path())
+    )
+    ref_states = {}
+    if recheck:
+        wanted: list = []
+        for row in rows:
+            refs = pq_triage.extract_refs(row.get("text"), row.get("detail"))
+            # Only references that carry their own repo are looked up; a bare number
+            # in this multi-repo file would resolve against the wrong repository.
+            for ref in pq_triage.probeable(refs):
+                if ref not in wanted:
+                    wanted.append(ref)
+        ref_states = _probe_ref_states(wanted)
+    pq_triage.apply_recheck(rows, ref_states)
+    return pq_triage.rank(rows)
+
+
+def _questions_queue_payload() -> dict:
+    """Triage queue, re-checked live at the moment it is asked for."""
+    return {"questions": _pending_question_rows(recheck=True)}
+
+
+def dismiss_question(qid: str) -> tuple:
+    """Dismiss `qid` permanently. Returns an (status, body) pair for the route."""
+    if not qid:
+        return 400, {"error": "id required"}
+    pq_triage.dismiss(_dismissed_questions_path(), qid)
+    return 200, {"ok": True, "id": qid}
 
 
 def _active_tasks_payload(watcher_ok: bool, core_ok: bool) -> dict:
@@ -922,6 +1002,10 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 "snapshot_hash": inference.snapshot_hash,
             }
             self.send_private_json(200, payload)
+        elif path == "/questions/queue":
+            if not self.check_auth():
+                return
+            self.send_json(200, _questions_queue_payload())
         elif path == "/tasks/active":
             # List active tasks + system status for the web client
             watcher_ok = subprocess.run(["/usr/bin/pgrep", "-f", "watch-tasks"], capture_output=True).returncode == 0
@@ -1352,6 +1436,17 @@ class Handler(http.server.BaseHTTPRequestHandler):
                         self.send_json(404, {"error": f"question {qid} not found or already answered"})
                 else:
                     self.send_json(404, {"error": "no pending questions"})
+            except Exception as e:
+                self.send_json(400, {"error": str(e)})
+            return
+
+        if path == "/question/dismiss":
+            if not self.check_auth():
+                return
+            try:
+                length = int(self.headers.get("Content-Length", 0))
+                data = json.loads(self.rfile.read(length))
+                self.send_json(*dismiss_question(str(data.get("id", "")).strip()))
             except Exception as e:
                 self.send_json(400, {"error": str(e)})
             return

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -1578,6 +1578,7 @@ WORKSPACE_ROOT_SENTINEL_GLOBS = (".*-migrated*", ".legacy-notice-printed")
 WORKSPACE_ROOT_PERSONAL_ASSETS = frozenset({
     "PERSONAL_CLAUDE.md",
     "current-track.md",      # per-host under hosts/<host>/; personal_path() falls back to the root
+    "dismissed-questions.json",  # per-host, alongside pending-questions.md
     "stand-identity.json",
     "stand-avatar.png",
     "voice-context-active",

--- a/src/pending_questions_triage.py
+++ b/src/pending_questions_triage.py
@@ -1,0 +1,192 @@
+"""Triage-queue policy for pending-questions.md: ranking, re-check verdict, dismissal.
+
+Policy only — no file reads, no subprocesses. The HTTP adapter owns the IO (reading
+the markdown, probing GitHub, serving rows) and calls in here for every decision, so
+the queue's behaviour is testable without a workspace, a network, or a browser.
+
+The queue shows ONE question at a time, so the order is the feature: whatever sorts
+first is what the owner is asked about, and everything else is invisible until they
+act. Two signals decide it — how long a question has waited, and how much is blocked
+behind it.
+"""
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import re
+import tempfile
+from typing import Iterable, Optional
+
+# A reference carrying its own repository: `owner/repo#123`, or a github.com pull/
+# issue URL. These are the only ones whose repository is known from the text alone.
+QUALIFIED_REF_RE = re.compile(
+    r'(?:https?://github\.com/)?'
+    r'([A-Za-z0-9][\w.-]*/[A-Za-z0-9][\w.-]*)'
+    r'(?:/(?:pull|issues)/|#)(\d{1,7})(?!\w)'
+)
+
+# `src/agent-api.py#3` is a file anchor, not `owner/repo#3`.
+SOURCE_FILE_RE = re.compile(r'\.(py|ts|tsx|js|mjs|json|md|sh|txt|ya?ml|toml|cfg|ini)$', re.I)
+
+# `#123` as a standalone token. Requires a non-word char (or string start) before the
+# `#` so `foo#3` and colour literals like `#3fa9c1` are not read as issue references.
+REF_RE = re.compile(r'(?:(?<=\W)|^)#(\d{1,7})(?!\w)')
+
+# Days of waiting one blocked reference is worth when ranking. Chosen, not derived.
+BLOCKED_REF_DAYS = 7
+
+# Re-check verdicts. `stale` is advisory — a stale row is still shown and still
+# answerable; nothing is ever dropped on the strength of a probe.
+RECHECK_STALE = "stale"
+RECHECK_BLOCKING = "blocking"
+
+_OPEN_STATES = {"OPEN"}
+_RESOLVED_STATES = {"MERGED", "CLOSED"}
+
+
+def extract_refs(*texts: Optional[str]) -> list[tuple]:
+    """References a question makes, as `(repo, number)` pairs in first-seen order.
+
+    `repo` is None when the text does not say which repository the number belongs
+    to. That distinction is the whole point: these questions discuss several repos
+    in one prose file, so a bare `#292` resolved against whichever checkout happens
+    to be running answers about a different pull request that merged long ago.
+    """
+    blob = "\n".join(t or "" for t in texts)
+    refs: list[tuple] = []
+    for match in QUALIFIED_REF_RE.finditer(blob):
+        if SOURCE_FILE_RE.search(match.group(1)):
+            continue
+        ref = (match.group(1), int(match.group(2)))
+        if ref not in refs:
+            refs.append(ref)
+    # A question whose qualified references all name ONE repo has said which repo it
+    # is about; its bare numbers inherit that. With none or several, they stay unbound.
+    named = {repo for repo, _ in refs}
+    inherited = next(iter(named)) if len(named) == 1 else None
+    # A qualified ref's '#' always follows a word character, which REF_RE's lookbehind
+    # rejects — so the qualified matches above cannot be counted a second time here.
+    for match in REF_RE.finditer(blob):
+        ref = (inherited, int(match.group(1)))
+        if ref not in refs:
+            refs.append(ref)
+    return refs
+
+
+def apply_recheck(rows: list[dict], ref_states: Optional[dict[int, str]] = None) -> list[dict]:
+    """Annotate each row with `refs`, `blocks` and a `recheck` verdict, in place.
+
+    `ref_states` maps a reference number to the state the probe observed; a reference
+    the probe could not decide is simply absent. Absence is never treated as resolved
+    — an undecidable reference still counts as blocking, so a failed or empty probe
+    leaves the ranking exactly as it was rather than silently demoting the row.
+    """
+    states = ref_states or {}
+    for row in rows:
+        refs = extract_refs(row.get("text"), row.get("detail"))
+        row["refs"] = [ref_label(ref) for ref in refs]
+        known = {ref: states[ref] for ref in refs if ref in states}
+        resolved = [ref for ref, state in known.items() if state in _RESOLVED_STATES]
+        # Unknown counts as open: the probe failing must not look like "nothing is blocked".
+        row["blocks"] = len(refs) - len(resolved)
+        if refs and len(resolved) == len(refs):
+            row["recheck"] = {
+                "status": RECHECK_STALE,
+                "note": _stale_note(known, resolved),
+                "refs": [ref_label(ref) for ref in resolved],
+            }
+        elif resolved:
+            row["recheck"] = {
+                "status": RECHECK_BLOCKING,
+                "note": _stale_note(known, resolved),
+                "refs": [ref_label(ref) for ref in resolved],
+            }
+        else:
+            row["recheck"] = None
+    return rows
+
+
+def ref_label(ref: tuple) -> str:
+    """How a reference is written on the card: qualified only when its repo is known."""
+    repo, number = ref
+    return f"{repo}#{number}" if repo else f"#{number}"
+
+
+def probeable(refs: Iterable[tuple]) -> list[tuple]:
+    """The references whose repository is known, and so can actually be looked up."""
+    out: list[tuple] = []
+    for ref in refs:
+        if ref[0] and ref not in out:
+            out.append(ref)
+    return out
+
+
+def _stale_note(known: dict, resolved: list) -> str:
+    return ", ".join(f"{ref_label(ref)} {known[ref].lower()}" for ref in resolved)
+
+
+def rank_key(row: dict) -> tuple:
+    """Sort key: undated last, then most-waited-and-most-blocking first.
+
+    An undated heading cannot be ranked by age and must sort LAST rather than
+    default to 0, which would put the one unrankable question ahead of everything
+    genuinely waiting.
+    """
+    age = row.get("age_days")
+    blocks = row.get("blocks") or 0
+    score = (age or 0) + BLOCKED_REF_DAYS * blocks
+    return (age is None, -score, -(age or 0))
+
+
+def rank(rows: list[dict]) -> list[dict]:
+    """Return `rows` ordered for the queue. Never adds or removes a row."""
+    return sorted(rows, key=rank_key)
+
+
+# --- dismissal ---------------------------------------------------------------
+
+# Permanent by design: a changed situation is written as a NEW section, which
+# hashes to a new id. So this stores ids, never "until" state.
+
+def load_dismissed(path) -> set[str]:
+    """Dismissed question ids. A missing or unreadable store means none."""
+    try:
+        with open(path, "r") as handle:
+            data = json.load(handle)
+    except (OSError, ValueError):
+        return set()
+    ids = data.get("dismissed") if isinstance(data, dict) else data
+    if not isinstance(ids, list):
+        return set()
+    return {str(qid) for qid in ids if isinstance(qid, (str, int))}
+
+
+def save_dismissed(path, ids: Iterable[str]) -> None:
+    """Replace the store atomically; a reader never observes a truncated file."""
+    path = str(path)
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    payload = json.dumps({"dismissed": sorted(set(ids))}, indent=1)
+    handle, tmp = tempfile.mkstemp(dir=os.path.dirname(path) or ".", suffix=".tmp")
+    try:
+        with os.fdopen(handle, "w") as out:
+            out.write(payload)
+            out.flush()
+            os.fsync(out.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
+
+
+def dismiss(path, qid: str) -> set[str]:
+    """Record `qid` as dismissed forever and return the resulting id set."""
+    ids = load_dismissed(path)
+    ids.add(str(qid))
+    save_dismissed(path, ids)
+    return ids
+
+
+def without_dismissed(rows: list[dict], dismissed: set[str]) -> list[dict]:
+    return [row for row in rows if row.get("id") not in dismissed]

--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -537,6 +537,14 @@ const HTML = /* html */ `<!DOCTYPE html>
   #dynamic-region .dr-questions .q-title { color: #f0ad4e; font-size: 13px; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px; }
   #dynamic-region .dr-questions .q-item { color: #ddd; padding: 10px 0; border-bottom: 1px solid #2e281844; }
   #dynamic-region .dr-questions .q-item:last-child { border-bottom: none; }
+  #dynamic-region .q-queue-meta { display: flex; gap: 10px; align-items: baseline; font-size: 11px; color: #8a8a99; margin-bottom: 6px; }
+  #dynamic-region .q-wait { color: #f0ad4e; font-weight: 600; }
+  #dynamic-region .q-blocks { color: #7c83ff; }
+  #dynamic-region .q-recheck { font-size: 11px; margin: 6px 0; padding: 5px 8px; border-radius: 6px; background: #2e281844; color: #f0ad4e; }
+  #dynamic-region .q-recheck.q-stale { background: #1d3a2a; color: #4ecca3; }
+  #dynamic-region .q-nav { display: flex; gap: 6px; margin-top: 8px; flex-wrap: wrap; }
+  #dynamic-region .q-nav .q-btn { flex: 0 0 auto; }
+  #dynamic-region .q-empty { color: #666; font-size: 12px; text-align: center; padding: 12px; }
   #dynamic-region .q-actions { margin-top: 10px; display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
   #dynamic-region .q-btn {
     padding: 6px 16px; border-radius: 14px; font-size: 15px; cursor: pointer;
@@ -2934,10 +2942,7 @@ function answerQuestion(qid, answer) {
         if (actions) actions.innerHTML = '<span style="color:#4ecca3;font-size:12px">Answered: ' + esc(answer.trim()) + '</span>';
       }
       // Remove after brief delay so user sees confirmation
-      setTimeout(function() {
-        window._drQuestions = (window._drQuestions || []).filter(function(q) { return q.id !== qid; });
-        updateDynamicRegion();
-      }, 1500);
+      setTimeout(function() { dropQuestionFromQueue(qid); }, 1500);
       // Show in transcript too
       var el = document.createElement('div');
       el.className = 't-entry t-system';
@@ -3248,6 +3253,7 @@ window._drTaskCount = 0;
 window._drTabsRendered = false;
 
 function switchDRTab(tab) {
+  window._drQueueChecked = false;
   window._drActiveTab = tab;
   window._drLocalContent = true; // prevent poll from clearing content
   updateTabHighlights();
@@ -3386,25 +3392,13 @@ function renderTabContent() {
     });
 
   } else if (tab === 'questions') {
-    var questions = window._drQuestions || [];
-    if (questions.length === 0) {
-      container.innerHTML = '<div style="color:#666;font-size:12px;text-align:center;padding:12px">No pending questions</div>';
-    } else {
-      container.innerHTML = '<div class="dr-questions">' +
-        questions.map(function(q) {
-          return '<div class="q-item"><b>' + esc(q.id) + '</b>: ' + esc(q.text) +
-            (q.detail ? '<div style="color:#999;font-size:11px;margin-top:2px;white-space:pre-wrap">' + esc(q.detail) + '</div>' : '') +
-            '<div class="q-actions">' +
-            (q.options ? q.options.map(function(opt) {
-              return '<button class="q-btn" data-qid="' + q.id + '" data-ans="' + esc(opt) + '" style="border-color:#4ecca366;color:#4ecca3">' + esc(opt) + '</button>';
-            }).join('') :
-            '<button class="q-btn q-yes" data-qid="' + q.id + '" data-ans="Yes">Yes</button>' +
-            '<button class="q-btn q-no" data-qid="' + q.id + '" data-ans="No">No</button>') +
-            '<input class="q-input" data-qid="' + q.id + '" placeholder="Or type a response...">' +
-            '<button class="q-btn q-send" data-qid="' + q.id + '">Send</button>' +
-            '</div></div>';
-        }).join('') + '</div>';
+    // Re-check immediately before display, once per visit rather than per re-render.
+    if (!window._drQueueChecked) {
+      window._drQueueChecked = true;
+      refreshQuestionQueue().then(function() { updateDynamicRegion(); });
     }
+    if (!window._drQueue) window._drQueue = window._drQuestions || [];
+    container.innerHTML = renderQuestionQueue(window._drQueue, window._drQueueIndex || 0);
 
   } else if (tab === 'activity') {
     fetch(API_BASE + '/activity').then(function(r){return r.json()}).then(function(data) {
@@ -3553,12 +3547,144 @@ function updateDynamicRegion() {
   }
 }
 
+// ─── Pending-question triage queue helpers
+// Pure: they take rows and a cursor and return HTML. The queue shows ONE question,
+// so every fact the owner needs to rank it has to be on the card itself.
+function questionWaitLabel(q) {
+  var age = q && q.age_days;
+  if (age === null || age === undefined) return 'age unknown';
+  if (age === 0) return 'asked today';
+  return 'waiting ' + age + (age === 1 ? ' day' : ' days');
+}
+
+function questionBlocksLabel(q) {
+  var refs = (q && q.refs) || [];
+  var blocks = (q && q.blocks) || 0;
+  if (!refs.length) return '';
+  if (!blocks) return 'nothing still blocked';
+  return 'blocking ' + blocks + (blocks === 1 ? ' item' : ' items');
+}
+
+// A re-check that could not decide returns nothing rather than a reassuring note:
+// silence here means "not checked", never "checked and fine".
+function questionRecheckHtml(q) {
+  var rc = q && q.recheck;
+  if (!rc || !rc.note) return '';
+  var stale = rc.status === 'stale';
+  var lead = stale ? 'Re-checked just now: everything this blocks is done ('
+                   : 'Re-checked just now: partly resolved (';
+  return '<div class="q-recheck' + (stale ? ' q-stale' : '') + '">' +
+    esc(lead + rc.note + ')') + '</div>';
+}
+
+function questionQueueCursor(rows, index) {
+  var n = (rows || []).length;
+  if (!n) return 0;
+  return ((index % n) + n) % n;
+}
+
+function renderQuestionQueue(rows, index) {
+  rows = rows || [];
+  if (!rows.length) {
+    return '<div class="q-empty">No pending questions</div>';
+  }
+  var i = questionQueueCursor(rows, index);
+  var q = rows[i];
+  var blocks = questionBlocksLabel(q);
+  var answerBtns = q.options
+    ? q.options.map(function(opt) {
+        return '<button class="q-btn" data-qid="' + esc(q.id) + '" data-ans="' + esc(opt) +
+          '" style="border-color:#4ecca366;color:#4ecca3">' + esc(opt) + '</button>';
+      }).join('')
+    : '<button class="q-btn q-yes" data-qid="' + esc(q.id) + '" data-ans="Approved">Approve</button>' +
+      '<button class="q-btn q-no" data-qid="' + esc(q.id) + '" data-ans="Rejected">Reject</button>';
+  return '<div class="dr-questions"><div class="q-item">' +
+    '<div class="q-queue-meta">' +
+      '<span>' + esc((i + 1) + ' of ' + rows.length) + '</span>' +
+      '<span class="q-wait">' + esc(questionWaitLabel(q)) + '</span>' +
+      (blocks ? '<span class="q-blocks">' + esc(blocks) + '</span>' : '') +
+    '</div>' +
+    '<b>' + esc(q.text) + '</b>' +
+    questionRecheckHtml(q) +
+    (q.detail && q.detail !== q.text
+      ? '<div style="color:#999;font-size:11px;margin-top:4px;white-space:pre-wrap">' + esc(q.detail) + '</div>'
+      : '') +
+    '<div class="q-actions">' + answerBtns +
+      '<input class="q-input" data-qid="' + esc(q.id) + '" placeholder="Or type a response...">' +
+      '<button class="q-btn q-send" data-qid="' + esc(q.id) + '">Send</button>' +
+    '</div>' +
+    '<div class="q-nav">' +
+      '<button class="q-btn" data-qid="' + esc(q.id) + '" data-qact="reply">Reply in chat</button>' +
+      '<button class="q-btn" data-qid="' + esc(q.id) + '" data-qact="next">Next</button>' +
+      '<button class="q-btn" data-qid="' + esc(q.id) + '" data-qact="dismiss" style="border-color:#66333366;color:#c77">Dismiss</button>' +
+    '</div>' +
+    '</div></div>';
+}
+// ─── End pending-question triage queue helpers
+
+// Re-check runs when the queue is shown or advanced — human cadence, not the 3s poll.
+function refreshQuestionQueue() {
+  return fetch(API_BASE + '/questions/queue')
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      if (data && data.questions) {
+        window._drQueue = data.questions;
+        window._drQuestions = data.questions;
+      }
+      return window._drQueue;
+    })
+    .catch(function() { return window._drQueue; });
+}
+
+function advanceQuestionQueue(step) {
+  window._drQueueIndex = questionQueueCursor(
+    window._drQueue || [], (window._drQueueIndex || 0) + step);
+  updateDynamicRegion();
+}
+
+function dropQuestionFromQueue(qid) {
+  window._drQueue = (window._drQueue || []).filter(function(q) { return q.id !== qid; });
+  window._drQuestions = (window._drQuestions || []).filter(function(q) { return q.id !== qid; });
+  window._drQueueIndex = questionQueueCursor(window._drQueue, window._drQueueIndex || 0);
+  updateDynamicRegion();
+}
+
+function dismissQuestion(qid) {
+  fetch(API_BASE + '/question/dismiss', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({id: qid})
+  }).then(function(r) { return r.json(); }).then(function(d) {
+    if (d && d.ok) dropQuestionFromQueue(qid);
+    else alert('Failed: ' + ((d && d.error) || 'unknown error'));
+  }).catch(function() { alert('Could not reach agent API'); });
+}
+
+function replyToQuestionInChat(qid) {
+  var rows = window._drQueue || [];
+  var q = null;
+  for (var i = 0; i < rows.length; i++) { if (rows[i].id === qid) { q = rows[i]; break; } }
+  var input = document.getElementById('textInput');
+  if (!input) return;
+  input.value = 'Re: ' + ((q && q.text) || qid) + ' — ';
+  input.focus();
+  input.setSelectionRange(input.value.length, input.value.length);
+}
+
 // Event delegation for question actions
 document.addEventListener('click', function(e) {
   var btn = e.target.closest && e.target.closest('[data-qid]');
   if (!btn) return;
   var qid = btn.dataset.qid;
-  if (btn.dataset.ans) {
+  var qact = btn.dataset.qact;
+  if (qact === 'next') {
+    // Free by construction: no request, no write. The row stays and comes back round.
+    advanceQuestionQueue(1);
+  } else if (qact === 'dismiss') {
+    dismissQuestion(qid);
+  } else if (qact === 'reply') {
+    replyToQuestionInChat(qid);
+  } else if (btn.dataset.ans) {
     answerQuestion(qid, btn.dataset.ans);
   } else if (btn.classList.contains('q-send')) {
     var inp = document.querySelector('.q-input[data-qid="' + qid + '"]');

--- a/tests/agent-api-pending-questions.test.py
+++ b/tests/agent-api-pending-questions.test.py
@@ -25,7 +25,9 @@ import importlib.util
 import sys
 import tempfile
 import unittest
+from datetime import datetime, timedelta
 from pathlib import Path
+from unittest import mock
 
 REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "src"))
@@ -180,6 +182,71 @@ class TestParse(unittest.TestCase):
         self.assertEqual(api.parse_pending_questions(answered), [])
 
 
+    def test_dated_heading_parses_asked_and_age_days(self):
+        """`## YYYY-MM-DD — ...` gives a bare-date `asked` and a non-negative age."""
+        dated = "# Q\n\n## 2020-01-01 — sutando-life CI: something old\nBody.\n"
+        q = api.parse_pending_questions(dated)[0]
+        self.assertEqual(q["asked"], "2020-01-01")
+        expected_age = (datetime.now() - datetime(2020, 1, 1)).days
+        self.assertEqual(q["age_days"], expected_age)
+
+    def test_datetime_heading_t_z_form_parses_asked_and_age_days(self):
+        """`## YYYY-MM-DDTHH:MMZ — ...` is the other heading shape in the wild."""
+        dated = "# Q\n\n## 2020-01-01T02:20Z — should this host do X?\nBody.\n"
+        q = api.parse_pending_questions(dated)[0]
+        self.assertEqual(q["asked"], "2020-01-01T02:20Z")
+        expected_age = (datetime.now() - datetime(2020, 1, 1, 2, 20)).days
+        self.assertEqual(q["age_days"], expected_age)
+
+    def test_undated_heading_gives_null_asked_and_age(self):
+        """No leading date on the heading — must not fabricate an age."""
+        q = api.parse_pending_questions(FREE_FORM)[0]
+        self.assertIsNone(q["asked"])
+        self.assertIsNone(q["age_days"])
+
+
+class TestPendingQuestionRows(unittest.TestCase):
+    """`_pending_question_rows()` orders by age — oldest first — with undated
+    questions sorted last (never defaulted to age 0, which would put them
+    first instead)."""
+
+    def _rows(self, content: str) -> list[dict]:
+        with tempfile.TemporaryDirectory() as tmp:
+            pending = Path(tmp) / "pending-questions.md"
+            pending.write_text(content)
+            with mock.patch.object(api, "personal_path", return_value=pending):
+                return api._pending_question_rows()
+
+    def test_rows_are_oldest_first_undated_sorts_last(self):
+        today = datetime.now()
+        just_now = today.strftime("%Y-%m-%d")  # age_days == 0
+        mid = (today - timedelta(days=10)).strftime("%Y-%m-%d")
+        old = (today - timedelta(days=40)).strftime("%Y-%m-%d")
+        # Undated BEFORE the age-0 heading: the one order in which defaulting
+        # undated to 0 would survive a stable sort and pass anyway.
+        mixed = (
+            "# Pending Questions\n\n"
+            "## Undated question\nBody.\n\n"
+            f"## {just_now} — asked just now\nBody.\n\n"
+            f"## {old} — asked weeks ago\nBody.\n\n"
+            f"## {mid} — asked a while ago\nBody.\n"
+        )
+        texts = [row["text"] for row in self._rows(mixed)]
+        self.assertEqual(texts, [
+            f"{old} — asked weeks ago",
+            f"{mid} — asked a while ago",
+            f"{just_now} — asked just now",
+            "Undated question",
+        ])
+
+    def test_rows_carry_asked_and_age_days_after_stripping_offsets(self):
+        rows = self._rows("# Q\n\n## 2020-01-01 — old one\nBody.\n")
+        self.assertNotIn("start", rows[0])
+        self.assertNotIn("end", rows[0])
+        self.assertEqual(rows[0]["asked"], "2020-01-01")
+        self.assertIsInstance(rows[0]["age_days"], int)
+
+
 class TestAnswer(unittest.TestCase):
     def test_free_form_question_is_answerable(self):
         """The regression: listed by GET /status, then 404 on POST /answer."""
@@ -232,6 +299,7 @@ if __name__ == "__main__":
     loader = unittest.TestLoader()
     suite = unittest.TestSuite([
         loader.loadTestsFromTestCase(TestParse),
+        loader.loadTestsFromTestCase(TestPendingQuestionRows),
         loader.loadTestsFromTestCase(TestAnswer),
     ])
     result = unittest.TextTestRunner(verbosity=2).run(suite)

--- a/tests/agent-api-pending-questions.test.py
+++ b/tests/agent-api-pending-questions.test.py
@@ -25,7 +25,8 @@ import importlib.util
 import sys
 import tempfile
 import unittest
-from datetime import datetime, timedelta
+import subprocess
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest import mock
 
@@ -205,6 +206,41 @@ class TestParse(unittest.TestCase):
         self.assertIsNone(q["age_days"])
 
 
+class TestPython39AndTimezones(unittest.TestCase):
+    """agent-api.py has no `from __future__ import annotations`, so annotations are
+    evaluated at def time — a PEP 604 union breaks import on the supported 3.9."""
+
+    def test_the_module_defines_its_helpers_on_python_39(self):
+        py39 = Path("/usr/bin/python3")
+        if not py39.exists():
+            self.skipTest("no system python3 to check the floor against")
+        ver = subprocess.run([str(py39), "-c", "import sys;print('%d.%d' % sys.version_info[:2])"],
+                             capture_output=True, text=True).stdout.strip()
+        if ver != "3.9":
+            self.skipTest(f"system python3 is {ver}, not the 3.9 floor")
+        src = Path(api.__file__).read_text()
+        start = src.index("def _parse_asked_date")
+        end = src.index("\n\n", src.index("return None, None", start))
+        prog = ("from datetime import datetime, timezone\nfrom typing import Optional\nimport re\n"
+                "PQ_DATE_RE = re.compile(r'^(\\d{4}-\\d{2}-\\d{2})(T\\d{2}:\\d{2}(?::\\d{2})?Z)?')\n"
+                + src[start:end] + "\nprint(_parse_asked_date('2020-01-01T02:20Z x')[0])\n")
+        r = subprocess.run([str(py39), "-c", prog], capture_output=True, text=True)
+        self.assertEqual(0, r.returncode, f"3.9 rejected the helper: {r.stderr[-300:]}")
+        self.assertEqual("2020-01-01T02:20Z", r.stdout.strip())
+
+    def test_a_Z_heading_is_utc_not_local(self):
+        """Parsed naive and compared to a local now(), a just-asked question reports -1."""
+        _, dt = api._parse_asked_date("2020-01-01T02:20Z — x")
+        self.assertIsNotNone(dt.tzinfo, "a Z heading must parse as aware UTC")
+        self.assertEqual(0, dt.utcoffset().total_seconds())
+
+    def test_a_future_dated_heading_does_not_sort_first(self):
+        """Clock skew or a typo gives a negative age, which -(age) would rank ahead of all."""
+        ahead = (datetime.now(timezone.utc) + timedelta(days=2)).strftime("%Y-%m-%dT%H:%MZ")
+        q = api.parse_pending_questions(f"# Q\n\n## {ahead} — from the future\nBody.\n")[0]
+        self.assertEqual(0, q["age_days"], "a future heading must clamp to 0, never go negative")
+
+
 class TestPendingQuestionRows(unittest.TestCase):
     """`_pending_question_rows()` orders by age — oldest first — with undated
     questions sorted last (never defaulted to age 0, which would put them
@@ -299,6 +335,7 @@ if __name__ == "__main__":
     loader = unittest.TestLoader()
     suite = unittest.TestSuite([
         loader.loadTestsFromTestCase(TestParse),
+        loader.loadTestsFromTestCase(TestPython39AndTimezones),
         loader.loadTestsFromTestCase(TestPendingQuestionRows),
         loader.loadTestsFromTestCase(TestAnswer),
     ])

--- a/tests/agent-api-pending-questions.test.py
+++ b/tests/agent-api-pending-questions.test.py
@@ -228,6 +228,16 @@ class TestPython39AndTimezones(unittest.TestCase):
         self.assertEqual(0, r.returncode, f"3.9 rejected the helper: {r.stderr[-300:]}")
         self.assertEqual("2020-01-01T02:20Z", r.stdout.strip())
 
+    def test_a_shaped_but_impossible_date_is_not_an_age(self):
+        """`2026-13-45` matches the heading regex and no strptime format — the branch
+        must fall through to (None, None) rather than raise or invent an age."""
+        asked, dt = api._parse_asked_date("2026-13-45 — not a real date")
+        self.assertIsNone(asked)
+        self.assertIsNone(dt)
+        q = api.parse_pending_questions("# Q\n\n## 2026-13-45 — not a real date\nBody.\n")[0]
+        self.assertIsNone(q["asked"])
+        self.assertIsNone(q["age_days"])
+
     def test_a_Z_heading_is_utc_not_local(self):
         """Parsed naive and compared to a local now(), a just-asked question reports -1."""
         _, dt = api._parse_asked_date("2020-01-01T02:20Z — x")

--- a/tests/agent-api-question-queue-e2e.test.py
+++ b/tests/agent-api-question-queue-e2e.test.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""E2E for the triage queue's two HTTP routes: GET /questions/queue, POST /question/dismiss.
+
+Unit coverage of the ranking, re-check verdict and dismissal store lives in
+pending-questions-triage.test.py. This drives the routes against a real server,
+because a route can be wired to the wrong unit, skip its auth check, or return a
+shape the client cannot read while every underlying function is perfectly correct.
+
+Run: python3 tests/agent-api-question-queue-e2e.test.py
+Exit: 0 = all pass, 1 = failure
+"""
+import http.server
+import importlib.util
+import json
+import sys
+import tempfile
+import threading
+import urllib.error
+import urllib.request
+from pathlib import Path
+from unittest import mock
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+
+from util_paths import _host_label  # noqa: E402 — needs the sys.path above
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules[name] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+api = _load("agent_api", REPO / "src" / "agent-api.py")
+
+PQ = """# Pending Questions
+
+## 2026-08-01 — ALPHA, oldest and blocking nothing
+Prose only.
+
+## 2026-08-20 — BRAVO, blocked on sonichi/sutando#4242
+Waiting on a pull request.
+
+# Resolved
+
+## 2026-07-01 — Archived
+Must never be offered as open.
+"""
+
+tmp = Path(tempfile.mkdtemp(prefix="pq-queue-e2e-"))
+api.WORKSPACE_DIR = tmp
+api.API_TOKEN = "test-token-123"
+
+# Per-host file FIRST so personal_path's first probe hits: a fresh tmp otherwise
+# falls through to the operator's vault-synced memory tree. See agent-api-answer-e2e.
+PQ_FILE = tmp / "hosts" / _host_label() / "pending-questions.md"
+PQ_FILE.parent.mkdir(parents=True, exist_ok=True)
+PQ_FILE.write_text(PQ)
+
+_resolved = Path(api.personal_path("pending-questions.md", tmp))
+assert _resolved == PQ_FILE, f"personal_path escaped the tmp workspace: {_resolved}"
+
+# Handler runs on the MAIN thread; requests come from a worker. Inverted on purpose
+# — the coverage tracer misses handler-THREAD execution.
+server = http.server.HTTPServer(("127.0.0.1", 0), api.Handler)
+server.timeout = 0.5
+BASE = f"http://127.0.0.1:{server.server_address[1]}"
+
+failures = []
+ran = 0
+
+
+def check(name, cond, detail=""):
+    global ran
+    ran += 1
+    print(("  ok  " if cond else "  FAIL ") + name + (f" — {detail}" if detail and not cond else ""))
+    if not cond:
+        failures.append(name)
+
+
+def _raw_req(method, path, body=None, token="test-token-123"):
+    r = urllib.request.Request(f"{BASE}{path}", method=method,
+                               data=None if body is None else json.dumps(body).encode())
+    if token:
+        r.add_header("Authorization", f"Bearer {token}")
+    r.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(r, timeout=10) as resp:
+            return resp.status, json.loads(resp.read().decode() or "{}")
+    except urllib.error.HTTPError as e:
+        try:
+            payload = json.loads(e.read().decode() or "{}")
+        except Exception:
+            payload = {}
+        return e.code, payload
+    except Exception as e:
+        return -1, {"error": repr(e)}
+
+
+def req(method, path, body=None, token="test-token-123"):
+    out = {}
+    t = threading.Thread(target=lambda: out.update(
+        zip(("code", "data"), _raw_req(method, path, body, token))), daemon=True)
+    t.start()
+    while t.is_alive():
+        server.handle_request()
+    t.join()
+    return out["code"], out["data"]
+
+
+print("agent-api question-queue e2e")
+
+# The probe is the one part that would reach the network; its own behaviour is
+# unit-tested, so the route is exercised against a decided verdict.
+_probe = mock.patch.object(
+    api, "_probe_ref_states", return_value={("sonichi/sutando", 4242): "MERGED"})
+_probe.start()
+
+code, data = req("GET", "/questions/queue")
+questions = data.get("questions", [])
+check("GET /questions/queue → 200", code == 200, f"got {code}")
+check("the archive is not offered", len(questions) == 2, f"got {len(questions)}")
+check("every row carries the wait the card renders",
+      all("age_days" in q for q in questions))
+
+stale = [q for q in questions if q.get("recheck")]
+check("the merged blocker is labelled stale, live, on the way out",
+      len(stale) == 1 and stale[0]["recheck"]["status"] == "stale",
+      f"got {[q.get('recheck') for q in questions]}")
+check("...and the stale row is still offered, not dropped",
+      any("BRAVO" in q["text"] for q in questions))
+_probe.stop()
+
+# A failing probe must change nothing a client can see except the labels.
+with mock.patch.object(api.subprocess, "run", side_effect=OSError("gh missing")):
+    code, data = req("GET", "/questions/queue")
+check("a failed re-check still returns every question", len(data.get("questions", [])) == 2,
+      f"got {len(data.get('questions', []))}")
+check("...and labels none of them resolved",
+      all(q.get("recheck") is None for q in data.get("questions", [])))
+
+code, _ = req("GET", "/questions/queue", token=None)
+check("GET /questions/queue without a token → 401", code == 401, f"got {code}")
+
+# Dismissal, through the route, twice — the second is the resurface guard.
+target = next(q["id"] for q in questions if "ALPHA" in q["text"])
+code, data = req("POST", "/question/dismiss", {"id": target})
+check("POST /question/dismiss → 200", code == 200 and data.get("ok") is True, f"got {code} {data}")
+
+with mock.patch.object(api, "_probe_ref_states", return_value={}):
+    code, data = req("GET", "/questions/queue")
+left = [q["id"] for q in data.get("questions", [])]
+check("the dismissed question is gone from the queue", target not in left, f"got {left}")
+check("...and only that one went", len(left) == 1, f"got {len(left)}")
+
+check("dismissing never edits the questions file", PQ_FILE.read_text() == PQ)
+
+code, data = req("POST", "/question/dismiss", {"id": ""})
+check("POST /question/dismiss with no id → 400", code == 400, f"got {code} {data}")
+
+code, _ = req("POST", "/question/dismiss", {"id": "Qx"}, token=None)
+check("POST /question/dismiss without a token → 401", code == 401, f"got {code}")
+
+code, data = req("POST", "/question/dismiss")
+check("POST /question/dismiss with no body → 400", code == 400, f"got {code} {data}")
+
+server.server_close()
+print(f"\nagent-api-question-queue-e2e: {ran - len(failures)}/{ran} passed")
+if failures:
+    print("failed: " + ", ".join(failures))
+sys.exit(1 if failures else 0)

--- a/tests/pending-questions-triage.test.py
+++ b/tests/pending-questions-triage.test.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""Behavioural tests for the pending-questions triage queue.
+
+The queue shows ONE question at a time, which changes what a bug costs. In the old
+flat list a mis-ranked question was still on screen; here whatever sorts first is
+the only thing the owner is asked, so an ordering or filtering defect makes real
+questions invisible rather than merely inconvenient.
+
+Two properties get the most coverage because they are the ones that lose data:
+
+  * a failed re-check must never look like "nothing is blocked" or "already
+    resolved" — an undecided reference stays blocking and the row stays visible;
+  * dismissal is permanent and is the ONLY thing allowed to remove a row.
+
+Run: python3 tests/pending-questions-triage.test.py
+Exit: 0 = all pass, 1 = failure
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+
+import pending_questions_triage as triage  # noqa: E402
+from util_paths import _host_label  # noqa: E402 — needs the sys.path above
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules[name] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+api = _load("agent_api_triage", REPO / "src" / "agent-api.py")
+
+
+def _row(qid, text="", detail="", age=None):
+    return {"id": qid, "text": text, "detail": detail, "age_days": age}
+
+
+class ReferenceExtraction(unittest.TestCase):
+    def test_distinct_refs_in_first_seen_order(self):
+        self.assertEqual(
+            [(None, 3346), (None, 3344)],
+            triage.extract_refs("PR #3346/#3344", "again #3346"),
+        )
+
+    def test_a_colour_literal_is_not_an_issue_reference(self):
+        # '#3fa9c1' starts with a digit; a naive \d+ reads it as issue 3.
+        self.assertEqual([], triage.extract_refs("brand colour #3fa9c1"))
+
+    def test_a_hash_inside_a_word_is_not_a_reference(self):
+        self.assertEqual([], triage.extract_refs("anchor foo#9 in the doc"))
+
+    def test_a_source_file_anchor_is_not_a_repository_reference(self):
+        self.assertEqual([], triage.extract_refs("see src/agent-api.py#3"))
+
+    def test_a_qualified_reference_keeps_its_repository(self):
+        self.assertEqual(
+            [("sonichi/sutando", 3998)], triage.extract_refs("sonichi/sutando#3998")
+        )
+
+    def test_a_pull_request_url_is_a_qualified_reference(self):
+        self.assertEqual(
+            [("sonichi/sutando", 12)],
+            triage.extract_refs("https://github.com/sonichi/sutando/pull/12"),
+        )
+
+    def test_bare_numbers_inherit_the_one_repository_the_question_names(self):
+        self.assertEqual(
+            [("sonichi/sutando", 3998), ("sonichi/sutando", 3747)],
+            triage.extract_refs("sonichi/sutando#3998 and also #3747"),
+        )
+
+    def test_bare_numbers_stay_unbound_when_no_repository_is_named(self):
+        # The live file discusses several repositories in one prose corpus, so
+        # `#292` there is NOT this checkout's #292 — it is undecidable.
+        self.assertEqual([(None, 292)], triage.extract_refs("sutando-life CI, see #292"))
+
+    def test_bare_numbers_stay_unbound_when_two_repositories_are_named(self):
+        refs = triage.extract_refs("a/b#1 and c/d#2 and bare #3")
+        self.assertIn((None, 3), refs)
+
+
+class Probeable(unittest.TestCase):
+    def test_only_repository_qualified_references_are_looked_up(self):
+        refs = [("a/b", 1), (None, 2), ("a/b", 1)]
+        self.assertEqual([("a/b", 1)], triage.probeable(refs))
+
+    def test_an_unbound_reference_is_never_probed_so_can_never_be_called_stale(self):
+        self.assertEqual([], triage.probeable([(None, 292), (None, 818)]))
+
+
+class RecheckVerdict(unittest.TestCase):
+    def test_an_undecided_reference_still_counts_as_blocking(self):
+        # The probe returned nothing (offline, rate-limited, gh absent). Treating
+        # that as resolved would demote a genuinely blocking question.
+        rows = triage.apply_recheck([_row("Q1", "waiting on a/b#10 and a/b#11")], {})
+        self.assertEqual(2, rows[0]["blocks"])
+        self.assertIsNone(rows[0]["recheck"])
+
+    def test_every_reference_resolved_marks_the_row_stale_and_keeps_it(self):
+        rows = triage.apply_recheck(
+            [_row("Q1", "blocked on a/b#10", "and a/b#11")],
+            {("a/b", 10): "MERGED", ("a/b", 11): "CLOSED"},
+        )
+        self.assertEqual(1, len(rows), "a stale question must still be shown")
+        self.assertEqual(triage.RECHECK_STALE, rows[0]["recheck"]["status"])
+        self.assertEqual(0, rows[0]["blocks"])
+        self.assertIn("a/b#10 merged", rows[0]["recheck"]["note"])
+
+    def test_a_partly_resolved_row_is_reported_as_still_blocking(self):
+        rows = triage.apply_recheck(
+            [_row("Q1", "a/b#10 a/b#11")],
+            {("a/b", 10): "MERGED", ("a/b", 11): "OPEN"},
+        )
+        self.assertEqual(triage.RECHECK_BLOCKING, rows[0]["recheck"]["status"])
+        self.assertEqual(1, rows[0]["blocks"])
+
+    def test_a_row_with_no_references_gets_no_verdict(self):
+        rows = triage.apply_recheck(
+            [_row("Q1", "what should I be called?")], {("a/b", 10): "MERGED"}
+        )
+        self.assertEqual(0, rows[0]["blocks"])
+        self.assertIsNone(rows[0]["recheck"])
+
+
+class Ranking(unittest.TestCase):
+    def test_what_it_blocks_can_outrank_a_longer_wait(self):
+        older = _row("older", "no refs", age=10)
+        blocking = _row("blocking", "holds up a/b#10", age=5)
+        triage.apply_recheck([older, blocking], {})
+        self.assertEqual(
+            ["blocking", "older"], [r["id"] for r in triage.rank([older, blocking])]
+        )
+
+    def test_a_longer_wait_still_wins_when_neither_blocks(self):
+        a = _row("a", age=3)
+        b = _row("b", age=30)
+        triage.apply_recheck([a, b], {})
+        self.assertEqual(["b", "a"], [r["id"] for r in triage.rank([a, b])])
+
+    def test_an_undated_question_sorts_last_rather_than_defaulting_to_zero(self):
+        # Placed FIRST and tied against a true age-0 row: the only arrangement
+        # where "defaulted to 0" and "genuinely 0" differ.
+        undated = _row("undated", age=None)
+        fresh = _row("fresh", age=0)
+        triage.apply_recheck([undated, fresh], {})
+        self.assertEqual(
+            ["fresh", "undated"], [r["id"] for r in triage.rank([undated, fresh])]
+        )
+
+    def test_ranking_never_adds_or_drops_a_row(self):
+        rows = [_row(str(n), "a/b#%d" % n, age=n) for n in range(6)]
+        triage.apply_recheck(rows, {})
+        self.assertEqual({r["id"] for r in rows}, {r["id"] for r in triage.rank(rows)})
+
+
+class Dismissal(unittest.TestCase):
+    def setUp(self):
+        self.dir = Path(tempfile.mkdtemp(prefix="pq-dismiss-"))
+        self.store = self.dir / "state" / "dismissed-questions.json"
+
+    def test_a_dismissed_id_is_remembered(self):
+        triage.dismiss(self.store, "Qabc")
+        self.assertEqual({"Qabc"}, triage.load_dismissed(self.store))
+
+    def test_a_missing_or_corrupt_store_dismisses_nothing(self):
+        self.assertEqual(set(), triage.load_dismissed(self.store))
+        self.store.parent.mkdir(parents=True, exist_ok=True)
+        self.store.write_text("{ not json")
+        self.assertEqual(set(), triage.load_dismissed(self.store))
+
+    def test_a_store_of_the_wrong_shape_dismisses_nothing(self):
+        # Anything but a list of ids is refused outright; coercing it risks
+        # reading some unrelated structure as "these questions are gone".
+        self.store.parent.mkdir(parents=True, exist_ok=True)
+        self.store.write_text(json.dumps({"dismissed": {"Q1": True}}))
+        self.assertEqual(set(), triage.load_dismissed(self.store))
+
+    def test_a_failed_write_leaves_no_temp_file_behind(self):
+        triage.dismiss(self.store, "Qkeep")
+        with mock.patch("os.replace", side_effect=OSError("disk full")):
+            with self.assertRaises(OSError):
+                triage.save_dismissed(self.store, {"Qnew"})
+        self.assertEqual([], list(self.store.parent.glob("*.tmp")))
+        self.assertEqual({"Qkeep"}, triage.load_dismissed(self.store))
+
+    def test_only_the_dismissed_row_is_removed(self):
+        rows = [_row("Q1"), _row("Q2"), _row("Q3")]
+        kept = triage.without_dismissed(rows, {"Q2"})
+        self.assertEqual(["Q1", "Q3"], [r["id"] for r in kept])
+
+    def test_a_concurrent_reader_never_sees_a_truncated_store(self):
+        # The production writer, not a stand-in: a plain `open(...,'w')` truncates
+        # before it writes, so a reader in that window loses every dismissal.
+        triage.dismiss(self.store, "seed")
+        observations = []
+        stop = threading.Event()
+
+        def reader():
+            while not stop.is_set():
+                observations.append(triage.load_dismissed(self.store))
+
+        t = threading.Thread(target=reader)
+        t.start()
+        try:
+            for n in range(200):
+                triage.dismiss(self.store, "Q%d" % n)
+        finally:
+            stop.set()
+            t.join()
+        self.assertTrue(observations, "reader thread never sampled the store")
+        self.assertTrue(
+            all("seed" in seen for seen in observations),
+            "a reader observed a store missing an already-committed dismissal",
+        )
+        self.assertEqual([], list(self.dir.glob("state/*.tmp")), "temp file left behind")
+
+
+PQ_FIXTURE = """# Pending Questions
+
+## 2026-08-01 — Old and unblocked
+Nothing references a PR here.
+
+## 2026-08-20 — Blocked on sonichi/sutando#4242
+This one is waiting on a pull request.
+
+## 2026-08-25 — Blocked on sonichi/sutando#4243
+So is this one.
+
+# Resolved
+
+## 2026-07-01 — Archived
+Must never be offered as open.
+"""
+
+
+class ReferenceProbe(unittest.TestCase):
+    """The gh lookup itself — the one part of the re-check that touches the network."""
+
+    def setUp(self):
+        api._pq_ref_cache.clear()
+
+    def _probe(self, returncode=0, stdout='{"state": "MERGED"}'):
+        return mock.patch.object(
+            api.subprocess, "run",
+            return_value=subprocess.CompletedProcess([], returncode, stdout, ""),
+        )
+
+    def test_a_successful_lookup_reports_the_state(self):
+        with self._probe() as run:
+            self.assertEqual({("a/b", 7): "MERGED"}, api._probe_ref_states([("a/b", 7)]))
+        argv = run.call_args[0][0]
+        self.assertEqual(["--repo", "a/b"], argv[argv.index("--repo"):argv.index("--repo") + 2],
+                         "the lookup must name the repository, not the ambient checkout")
+
+    def test_a_nonzero_exit_decides_nothing(self):
+        with self._probe(returncode=1, stdout=""):
+            self.assertEqual({}, api._probe_ref_states([("a/b", 7)]))
+
+    def test_unparseable_output_decides_nothing(self):
+        with self._probe(stdout="not json"):
+            self.assertEqual({}, api._probe_ref_states([("a/b", 7)]))
+
+    def test_a_second_look_inside_the_window_does_not_rerun_gh(self):
+        with self._probe() as run:
+            api._probe_ref_states([("a/b", 7)])
+            api._probe_ref_states([("a/b", 7)])
+        self.assertEqual(1, run.call_count, "the cache did not spare a repeat lookup")
+
+    def test_a_cached_undecided_result_is_not_retried_either(self):
+        with self._probe(returncode=1, stdout="") as run:
+            api._probe_ref_states([("a/b", 7)])
+            self.assertEqual({}, api._probe_ref_states([("a/b", 7)]))
+        self.assertEqual(1, run.call_count)
+
+    def test_the_fan_out_is_capped_however_many_references_a_question_makes(self):
+        refs = [("a/b", n) for n in range(api.PQ_REF_PROBE_LIMIT + 5)]
+        with self._probe() as run:
+            api._probe_ref_states(refs)
+        self.assertEqual(api.PQ_REF_PROBE_LIMIT, run.call_count)
+
+
+class AdapterRows(unittest.TestCase):
+    """The API adapter over a workspace that is provably not the operator's."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="pq-triage-ws-"))
+        host = _host_label()
+        # Per-host file FIRST so personal_path's first probe hits: a fresh tmp
+        # otherwise falls through to the operator's vault-synced memory tree.
+        self.pq = self.tmp / "hosts" / host / "pending-questions.md"
+        self.pq.parent.mkdir(parents=True, exist_ok=True)
+        self.pq.write_text(PQ_FIXTURE)
+        self._saved_ws = api.WORKSPACE_DIR
+        api.WORKSPACE_DIR = self.tmp
+        resolved = Path(api.personal_path("pending-questions.md", self.tmp))
+        assert resolved == self.pq, f"workspace escaped tmp: {resolved} != {self.pq}"
+
+    def tearDown(self):
+        api.WORKSPACE_DIR = self._saved_ws
+
+    def test_no_questions_file_yields_no_rows_rather_than_an_error(self):
+        self.pq.unlink()
+        self.assertEqual([], api._pending_question_rows())
+
+    def test_rows_are_ranked_and_exclude_the_resolved_section(self):
+        rows = api._pending_question_rows()
+        self.assertEqual(3, len(rows))
+        self.assertNotIn("Archived", " ".join(r["text"] for r in rows))
+
+    def test_a_dismissed_question_stops_being_offered(self):
+        rows = api._pending_question_rows()
+        target = rows[0]["id"]
+        status, body = api.dismiss_question(target)
+        self.assertEqual((200, True), (status, body["ok"]))
+        remaining = api._pending_question_rows()
+        self.assertEqual(len(rows) - 1, len(remaining))
+        self.assertNotIn(target, [r["id"] for r in remaining])
+
+    def test_dismissing_does_not_write_to_the_questions_file(self):
+        before = self.pq.read_text()
+        api.dismiss_question(api._pending_question_rows()[0]["id"])
+        self.assertEqual(before, self.pq.read_text())
+
+    def test_an_empty_id_is_rejected_rather_than_stored(self):
+        status, _ = api.dismiss_question("")
+        self.assertEqual(400, status)
+        self.assertEqual(set(), triage.load_dismissed(api._dismissed_questions_path()))
+
+    def test_a_live_recheck_labels_a_merged_blocker_without_dropping_the_row(self):
+        probe = {("sonichi/sutando", 4242): "MERGED"}
+        with mock.patch.object(api, "_probe_ref_states", return_value=probe):
+            rows = api._pending_question_rows(recheck=True)
+        self.assertEqual(3, len(rows), "re-check must never remove a question")
+        stale = next(r for r in rows if "sonichi/sutando#4242" in r["refs"])
+        self.assertEqual(triage.RECHECK_STALE, stale["recheck"]["status"])
+        still = next(r for r in rows if "sonichi/sutando#4243" in r["refs"])
+        self.assertIsNone(still["recheck"], "an undecided reference is not a verdict")
+
+    def test_a_failing_probe_leaves_every_question_visible_and_unlabelled(self):
+        with mock.patch.object(api.subprocess, "run", side_effect=OSError("gh missing")):
+            rows = api._pending_question_rows(recheck=True)
+        self.assertEqual(3, len(rows))
+        self.assertTrue(all(r["recheck"] is None for r in rows))
+        self.assertEqual(
+            1, next(r for r in rows if "sonichi/sutando#4242" in r["refs"])["blocks"]
+        )
+
+    def test_the_queue_payload_carries_the_rechecked_rows(self):
+        api._pq_ref_cache.clear()
+        with mock.patch.object(api, "_probe_ref_states", return_value={}):
+            payload = api._questions_queue_payload()
+        self.assertEqual(3, len(payload["questions"]))
+        self.assertIn("age_days", payload["questions"][0])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)

--- a/tests/web-client-question-queue.test.py
+++ b/tests/web-client-question-queue.test.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Behavioural coverage for the web client's pending-question triage queue.
+
+The browser half of this feature had no tests at all: the flat question list was
+rendered, escaped and wired to POST /answer entirely unguarded. That mattered less
+when every question was on screen. The queue renders exactly ONE, so a defect in
+the cursor, the ordering it is handed, or the wait label does not degrade the view
+— it decides which single question the owner is asked, and hides the rest.
+
+These execute the real helper source out of web-client.ts in node, rather than
+asserting on its text. An earlier generation of pending-question tests asserted on
+source text and passed for the entire period POST /answer was 100% broken.
+
+Run: python3 tests/web-client-question-queue.test.py
+Exit: 0 = all pass, 1 = failure
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SOURCE = (REPO / "src" / "web-client.ts").read_text()
+
+START = "// ─── Pending-question triage queue helpers"
+END = "// ─── End pending-question triage queue helpers"
+
+
+def _helper_source() -> str:
+    assert START in SOURCE, "the triage queue helpers lost their extraction marker"
+    start = SOURCE.index(START)
+    end = SOURCE.index(END, start)
+    return SOURCE[start:end]
+
+
+def _node() -> str:
+    node = shutil.which("node")
+    if not node:
+        raise unittest.SkipTest("node is not available")
+    return node
+
+
+SHIM = r"""
+function esc(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+"""
+
+
+def _probe(script: str):
+    """Run the real helper source plus `script` in node; return its JSON stdout."""
+    program = SHIM + _helper_source() + "\n" + script
+    result = subprocess.run(
+        [_node(), "--input-type=module", "-e", program],
+        capture_output=True, text=True, timeout=60,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"node exited {result.returncode}: {result.stderr.strip()}")
+    return json.loads(result.stdout)
+
+
+ROWS = """
+const rows = [
+  {id: 'Q1', text: 'Oldest thing', detail: 'detail one', age_days: 29, refs: [], blocks: 0, recheck: null},
+  {id: 'Q2', text: 'Blocked thing', detail: 'detail two', age_days: 5, refs: [10], blocks: 1, recheck: null},
+  {id: 'Q3', text: 'Fresh thing', detail: 'detail three', age_days: 0, refs: [], blocks: 0, recheck: null}
+];
+"""
+
+
+class OneAtATime(unittest.TestCase):
+    def test_only_the_cursor_question_is_rendered(self):
+        out = _probe(ROWS + """
+        const html = renderQuestionQueue(rows, 0);
+        console.log(JSON.stringify({
+          items: (html.match(/class="q-item"/g) || []).length,
+          inputs: (html.match(/class="q-input"/g) || []).length,
+          hasFirst: html.includes('Oldest thing'),
+          hasSecond: html.includes('Blocked thing'),
+          hasThird: html.includes('Fresh thing')
+        }));
+        """)
+        self.assertEqual(1, out["items"], "the queue rendered more than one question")
+        self.assertEqual(1, out["inputs"])
+        self.assertTrue(out["hasFirst"])
+        self.assertFalse(out["hasSecond"], "a non-cursor question leaked into the card")
+        self.assertFalse(out["hasThird"])
+
+    def test_the_card_says_where_in_the_queue_it_is(self):
+        out = _probe(ROWS + """
+        console.log(JSON.stringify({
+          first: renderQuestionQueue(rows, 0).includes('1 of 3'),
+          second: renderQuestionQueue(rows, 1).includes('2 of 3')
+        }));
+        """)
+        self.assertTrue(out["first"])
+        self.assertTrue(out["second"])
+
+    def test_an_empty_queue_says_so_instead_of_rendering_a_card(self):
+        out = _probe("""
+        const html = renderQuestionQueue([], 0);
+        console.log(JSON.stringify({empty: html.includes('No pending questions'),
+                                    items: (html.match(/class="q-item"/g) || []).length}));
+        """)
+        self.assertTrue(out["empty"])
+        self.assertEqual(0, out["items"])
+
+
+class Cursor(unittest.TestCase):
+    def test_next_wraps_rather_than_running_off_the_end(self):
+        # Next has to be free to press: from the last question it returns to the
+        # first, so skipping never strands the owner on an empty card.
+        out = _probe(ROWS + """
+        console.log(JSON.stringify([0,1,2,3,4].map(function(i){
+          return questionQueueCursor(rows, i);
+        })));
+        """)
+        self.assertEqual([0, 1, 2, 0, 1], out)
+
+    def test_a_cursor_past_a_shrunken_queue_is_clamped_not_crashed(self):
+        out = _probe("""
+        console.log(JSON.stringify({
+          cursor: questionQueueCursor([{id:'a'}], 7),
+          empty: questionQueueCursor([], 3)
+        }));
+        """)
+        self.assertEqual(0, out["cursor"])
+        self.assertEqual(0, out["empty"])
+
+
+class WaitIsVisible(unittest.TestCase):
+    def test_the_wait_is_spelled_out_on_the_card(self):
+        out = _probe("""
+        console.log(JSON.stringify({
+          many: questionWaitLabel({age_days: 29}),
+          one: questionWaitLabel({age_days: 1}),
+          today: questionWaitLabel({age_days: 0}),
+          unknown: questionWaitLabel({age_days: null})
+        }));
+        """)
+        self.assertEqual("waiting 29 days", out["many"])
+        self.assertEqual("waiting 1 day", out["one"])
+        self.assertEqual("asked today", out["today"])
+        self.assertEqual("age unknown", out["unknown"],
+                         "an undated question must not read as brand new")
+
+    def test_the_wait_label_reaches_the_rendered_card(self):
+        out = _probe(ROWS + """
+        console.log(JSON.stringify({shown: renderQuestionQueue(rows, 0).includes('waiting 29 days')}));
+        """)
+        self.assertTrue(out["shown"])
+
+    def test_what_is_blocked_is_stated_only_when_something_is(self):
+        out = _probe("""
+        console.log(JSON.stringify({
+          none: questionBlocksLabel({refs: [], blocks: 0}),
+          one: questionBlocksLabel({refs: [10], blocks: 1}),
+          many: questionBlocksLabel({refs: [10, 11], blocks: 2}),
+          cleared: questionBlocksLabel({refs: [10], blocks: 0})
+        }));
+        """)
+        self.assertEqual("", out["none"])
+        self.assertEqual("blocking 1 item", out["one"])
+        self.assertEqual("blocking 2 items", out["many"])
+        self.assertEqual("nothing still blocked", out["cleared"])
+
+
+class RecheckBanner(unittest.TestCase):
+    def test_a_stale_verdict_is_shown_on_the_card(self):
+        out = _probe("""
+        const html = questionRecheckHtml({recheck: {status: 'stale', note: '#3346 merged'}});
+        console.log(JSON.stringify({shown: html.includes('#3346 merged'), stale: html.includes('q-stale')}));
+        """)
+        self.assertTrue(out["shown"])
+        self.assertTrue(out["stale"])
+
+    def test_an_undecided_recheck_renders_nothing_rather_than_a_reassurance(self):
+        # Silence means "not checked". A banner saying anything at all here would
+        # make an unreachable gh look like a clean bill of health.
+        out = _probe("""
+        console.log(JSON.stringify({
+          none: questionRecheckHtml({recheck: null}),
+          blank: questionRecheckHtml({recheck: {status: 'stale', note: ''}}),
+          missing: questionRecheckHtml({})
+        }));
+        """)
+        self.assertEqual("", out["none"])
+        self.assertEqual("", out["blank"])
+        self.assertEqual("", out["missing"])
+
+
+class Actions(unittest.TestCase):
+    def test_the_card_offers_approve_reject_reply_next_and_dismiss(self):
+        out = _probe(ROWS + """
+        const html = renderQuestionQueue(rows, 0);
+        console.log(JSON.stringify({
+          approve: html.includes('data-ans="Approved"'),
+          reject: html.includes('data-ans="Rejected"'),
+          reply: html.includes('data-qact="reply"'),
+          next: html.includes('data-qact="next"'),
+          dismiss: html.includes('data-qact="dismiss"'),
+          send: html.includes('q-send')
+        }));
+        """)
+        for action in ("approve", "reject", "reply", "next", "dismiss", "send"):
+            self.assertTrue(out[action], f"the {action} action is missing from the card")
+
+    def test_declared_options_replace_the_default_approve_reject_pair(self):
+        out = _probe("""
+        const rows = [{id: 'Q1', text: 'Pick', age_days: 2, refs: [], blocks: 0,
+                       recheck: null, options: ['Revert', 'Leave it']}];
+        const html = renderQuestionQueue(rows, 0);
+        console.log(JSON.stringify({
+          revert: html.includes('data-ans="Revert"'),
+          leave: html.includes('data-ans="Leave it"'),
+          approved: html.includes('data-ans="Approved"')
+        }));
+        """)
+        self.assertTrue(out["revert"])
+        self.assertTrue(out["leave"])
+        self.assertFalse(out["approved"], "options must replace, not accompany, approve/reject")
+
+    def test_every_action_carries_the_question_id_it_acts_on(self):
+        out = _probe(ROWS + """
+        const html = renderQuestionQueue(rows, 1);
+        console.log(JSON.stringify({
+          ids: (html.match(/data-qid="Q2"/g) || []).length,
+          wrong: (html.match(/data-qid="Q1"/g) || []).length
+        }));
+        """)
+        self.assertGreaterEqual(out["ids"], 5)
+        self.assertEqual(0, out["wrong"], "an action was wired to a question not on screen")
+
+
+class Escaping(unittest.TestCase):
+    def test_question_text_and_options_are_escaped(self):
+        out = _probe("""
+        const rows = [{id: 'Q<1>', text: '<img src=x onerror=boom>', detail: '<b>d</b>',
+                       age_days: 1, refs: [], blocks: 0, recheck: null,
+                       options: ['<script>evil()</script>']}];
+        const html = renderQuestionQueue(rows, 0);
+        console.log(JSON.stringify({
+          img: html.includes('<img src=x'),
+          script: html.includes('<script>'),
+          escaped: html.includes('&lt;img src=x')
+        }));
+        """)
+        self.assertFalse(out["img"], "question text was injected as live HTML")
+        self.assertFalse(out["script"], "an option was injected as live HTML")
+        self.assertTrue(out["escaped"])
+
+    def test_a_recheck_note_is_escaped(self):
+        out = _probe("""
+        const html = questionRecheckHtml({recheck: {status: 'stale', note: '<img src=x>'}});
+        console.log(JSON.stringify({raw: html.includes('<img src=x'), esc: html.includes('&lt;img')}));
+        """)
+        self.assertFalse(out["raw"])
+        self.assertTrue(out["esc"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)


### PR DESCRIPTION
## Why

The questions surface renders **every** open question at once, in one flat list, with no wait time on any of them and no action but answer. On this host that is 15 questions; eight are two to four weeks old and every one is still valid. Age was the only thing separating them and nothing showed it.

The owner's ask is a one-at-a-time triage queue: approve / reject / reply / next / dismiss, ordered by what a question blocks and how long it has waited, with a live re-check before the card is shown.

**Stacked on #3991** (`feat/question-age-ordering`), which adds `asked` / `age_days` — the data this queue ranks on. Base is that branch so the diff here is child-only; **merge order: #3991 first, then retarget this to `main` and re-run its checks.** #3991 currently carries an unresolved test-timezone blocker, so this cannot merge before that is cleared.

## What

**`src/pending_questions_triage.py` (new, policy — no IO).** Ranking, the re-check verdict, and the dismissal store. `src/agent-api.py` keeps the IO (reading the markdown, shelling to `gh`, serving rows); `src/web-client.ts` keeps the rendering.

**Queue behaviour.** One card at a time, showing position (`3 of 15`), the wait spelled out (`waiting 29 days`), and what is still blocked. `Next` is free by construction — no request, no write; the cursor advances and the row comes back round. `Dismiss` is permanent (`POST /question/dismiss`) — a changed situation is written as a *new* section, which hashes to a new id and returns as a new row, so there is no snooze or until-changed state to keep. `Reply` hands the question to the chat composer. Approve/reject/free-text go through the existing, already-tested `POST /answer` — no new answering mechanism.

**Live re-check** (`GET /questions/queue`) runs when the queue is shown or re-shown, at human cadence rather than on the 3s poll.

## The judgement worth reviewing: which references are decidable

My first implementation probed every `#N` against the repo `gh` happens to be pointing at. Running it over the real file showed why that is wrong:

```
1. wait=16d  blocks=12  refs=['#292','#818','#293','#247',…]   sutando-life CI: the workflow is off…
2. wait=15d  blocks=10  refs=['#3274','#3238','#3263',…]       SYSTEMIC: at least 5 named PRs are blocked…
```

Row 1's numbers are **sutando-life** PRs; row 2's are **sutando** PRs. `gh pr view 292` in this checkout answers about `sonichi/sutando#292` — merged long ago — so the top question would have been labelled *"everything this blocks is done"* on the strength of an unrelated PR, on a question that is live.

So a reference is looked up **only when the text says which repository it belongs to**: `owner/repo#N`, a github.com pull/issues URL, or a bare number in a question whose qualified references all name one repo. Of 30 references on the live host, 29 are bare and unbound; those count as blocking and are left **undecided**. Nothing is dropped, hidden, reordered into invisibility, or marked resolved by a probe that failed or could not decide.

The honest cost: on today's corpus exactly one reference is probeable. The re-check gets more useful as questions carry qualified references, and it is correct rather than confidently wrong today.

## Before / after — backend

Both revisions run against a **copy** of the live `pending-questions.md` (source untouched, hash checked below).

```
################ BEFORE — parent e559acfc (#3991 head)
15 questions, in the order the UI receives them:
  1. wait=29d   2026-08-09 — What name should I answer to?
  2. wait=29d   2026-08-09 — How should the ag2space token alias gap be fi
  3. wait=28d   2026-08-10 — Register the four Claude Code hooks? One of t
  4. wait=21d   2026-08-17 — team+collaborator task duplicate-processed 4x
keys on a row: ['age_days', 'asked', 'detail', 'id', 'text']

################ AFTER — HEAD
15 questions, in the order the UI receives them:
  1. wait=16d  blocks=12 refs=['#292','#818',…]              sutando-life CI: the workflow is off AND Acti
  2. wait=15d  blocks=10 refs=['#3274','#3238',…]            SYSTEMIC: at least 5 named PRs are blocked on
  3. wait=28d  blocks=1  refs=['sonichi/sutando#3998']       Register the four Claude Code hooks? One of t
  4. wait=21d  blocks=2  refs=['#215','#3959']               team+collaborator task duplicate-processed 4x
keys on a row: ['age_days', 'asked', 'blocks', 'detail', 'id', 'recheck', 'refs', 'text']
```

## Before / after — the card

Same three rows through the parent's renderer and this one:

```
BEFORE — parent (flat list)        AFTER — HEAD (triage queue)
{ "cards": 3,                      { "cards": 1,
  "chars": 1555,                     "chars": 1018,
  "showsWait": false,                "showsWait": true,
  "showsPosition": false,            "showsPosition": true,
  "hasNext": false,                  "hasNext": true,
  "hasDismiss": false,               "hasDismiss": true,
  "hasReply": false }                "hasReply": true }
```

Rendered card for a question whose blocker has merged:

```html
<div class="q-queue-meta">
<span>1 of 1</span>
<span class="q-wait">waiting 14 days</span>
<span class="q-blocks">nothing still blocked</span>
<b>Revert or leave PR #3346/#3344?</b>
<div class="q-recheck q-stale">Re-checked just now: everything this blocks is done (sonichi/sutando#3963 merged)</div>
<button class="q-btn q-yes" data-qid="Q1" data-ans="Approved">Approve</button>
<button class="q-btn q-no"  data-qid="Q1" data-ans="Rejected">Reject</button>
<button class="q-btn" data-qid="Q1" data-qact="reply">Reply in chat</button>
<button class="q-btn" data-qid="Q1" data-qact="next">Next</button>
<button class="q-btn" data-qid="Q1" data-qact="dismiss">Dismiss</button>
```

## The re-check, end to end, with real `gh` and no mocks

A zero needs a positive control, so both arms are here. Ground truth first, independently:

```
$ gh pr view 3998 --repo sonichi/sutando --json number,state   ->  #3998 OPEN
$ gh pr view 3963 --repo sonichi/sutando --json number,state   ->  #3963 MERGED
```

Fixture naming both, through `_pending_question_rows(recheck=True)`:

```
blocks=1  no verdict (still blocking)        Still waiting on sonichi/sutando#3998?
blocks=0  stale — sonichi/sutando#3963 merged   Should we revert … sonichi/sutando#3963?
```

And over the **real** 15 questions: `15 questions returned in 0.41s (nothing dropped)`, zero labels — correct, because the single probeable reference (#3998) is genuinely still open.

## Tests — ran counts, not "OK"

New coverage, and the web client's question surface had **none** before this:

| suite | ran |
|---|---|
| `tests/pending-questions-triage.test.py` (new) | **39**, OK |
| `tests/web-client-question-queue.test.py` (new) | **15**, OK |
| `tests/agent-api-question-queue-e2e.test.py` (new) | **15/15** |

`web-client-question-queue` executes the real helper source out of `web-client.ts` in node rather than asserting on its text — the earlier generation of pending-question tests asserted on source text and passed for the entire period `POST /answer` was 100% broken.

Unchanged suites, re-run at this head: `agent-api-pending-questions` 23 OK · `agent-api-answer-e2e` 22/22 · `pending-questions-readers-agree` 11/11 (the one that would catch the new keys putting agent-api out of step with the other three readers) · `agent-api-active-tasks-payload` OK · `answer-format` 69 checks. `review-checks.sh` PASS · `tsc --noEmit` clean · `eslint src/web-client.ts` 0 errors (5 pre-existing `any` warnings, none on added lines).

## Mutation proof — that the new tests are live

Each fix reverted one at a time, `__pycache__` cleared between arms:

```
policy: BLOCKED_REF_DAYS 7 -> 0 (blocking stops mattering)            rc=1  FAILED (failures=1)
policy: an UNKNOWN ref counts as resolved (probe failure looks clean) rc=1  FAILED (failures=3)
policy: undated question defaults to age 0 instead of sorting last    rc=1  FAILED (failures=1)
policy: probe BARE refs too (wrong-repo lookups)                      rc=1  FAILED (failures=2)
policy: dismissal store written with a truncating open()              rc=1  FAILED (failures=1)
policy: without_dismissed returns everything                          rc=1  FAILED (failures=2)
ui: render every question instead of the cursor one                   rc=1  FAILED (failures=3)
ui: cursor clamps instead of wrapping (Next dead-ends)                rc=1  FAILED (failures=1)
ui: question text interpolated without esc()                          rc=1  FAILED (failures=1)
ui: an undated question reads as asked today                          rc=1  FAILED (failures=1)
ui: an undecided re-check renders a reassuring banner                 rc=1  FAILED (failures=1)
RESTORED  pending-questions-triage.test.py                            rc=0  Ran 39 tests  OK
RESTORED  web-client-question-queue.test.py                           rc=0  Ran 15 tests  OK
```

The dismissal-store arm is a concurrency test against the **production writer**: a plain truncating `open()` loses every already-committed dismissal for a reader in that window.

## The live file was not touched

`pending-questions.md` on this host holds 15 real waiting questions. Everything above ran against copies in temp workspaces, and the adapter tests assert the resolved path is inside the tmp workspace before writing anything — without that assertion `personal_path` falls through to the operator's vault-synced memory tree, which is how a fixture once reached the vault.

```
baseline sha : 905c21390554f11b77715866e6ff8fd20ba31c53dd865da9933dc2057892b76e
current  sha : 905c21390554f11b77715866e6ff8fd20ba31c53dd865da9933dc2057892b76e
open questions via the API parser: 15  (baseline at session start: 15) — same 15 ids
```

## What I chose rather than derived

- **`BLOCKED_REF_DAYS = 7`** — one blocked reference is worth a week of waiting. Mine, not the owner's. The alternative shapes are strict tiers (anything blocking outranks anything not, which buries a 29-day unblocked question forever) or pure age (which is what we have today). A different weight is a one-line change and the ranking test pins the current one.
- **`Reply` targets the chat composer.** The questions carry no channel field, so there is no origin channel to jump to; the composer is the channel this surface has. If "jump to channel" meant the originating Discord/Telegram thread, that needs provenance on the question that does not exist yet, and is a separate change.
- **Approve/Reject write `Approved` / `Rejected`** into the status line where the old buttons wrote `Yes` / `No`. Declared `**Options:**` still replace both, unchanged.

## Two things CI caught that I had missed

Both were real and are fixed here, not argued away:

- **`refuse docs/src-map.md stale vs src/`** — a new `src/` module needs `scripts/gen-src-map.py` re-run. Done.
- **`diff coverage >= 95%`** — the two new route handlers were unexercised: the unit tests call the named units directly, so `GET /questions/queue` and `POST /question/dismiss` themselves never ran. Covered now by `agent-api-question-queue-e2e.test.py`, which serves on the **main thread** while requesting from a worker — the inversion `agent-api-answer-e2e` documents, because the coverage tracer misses handler-thread execution. It pins both routes' auth gates, the 400s, the stale label arriving over the wire, and that a dismissal never edits the questions file.
- **`health-check-root-tidy-personal-assets`** — my first draft resolved the dismissal store as `personal_path("state/dismissed-questions.json")`. That guard exists because the tidy probe's remedy ("move to state/") breaks `personal_path()`, and it flagged the nested argument. The store now follows the convention the guard documents — a bare per-host name beside `pending-questions.md`, registered in `WORKSPACE_ROOT_PERSONAL_ASSETS` exactly as `current-track.md` is. It passes at the parent commit and failed at mine, which is how I know it was mine and not inherited.

`src/pending_questions_triage.py` is at **100% line coverage** from its own suite. Getting there deleted a piece of dead code rather than adding a test for it: the extraction had span-tracking to stop a qualified reference being counted twice, which can never fire — a qualified `#` always follows a word character, which the bare-reference lookbehind already rejects.

## Out of scope, deliberately

The PR-state and health feeds are not represented here — only `pending-questions.md`. That is a real gap and a later piece of work.
