### PR TITLE
fix(x-twitter): the credential error names the route that still works

### DIFF
--- a/skills/x-twitter/x-post.py
+++ b/skills/x-twitter/x-post.py
@@ -79,8 +79,15 @@ TWEET_URL = "https://api.twitter.com/2/tweets"
 def get_auth():
     _require_requests()
     if not all([API_KEY, API_SECRET, ACCESS_TOKEN, ACCESS_TOKEN_SECRET]):
+        # Name the OTHER route here, at the point of failure: a host can lack
+        # API keys and still have a signed-in browser that posts fine.
         print("Error: X API credentials not set in .env")
         print("Need: X_API_KEY, X_API_SECRET, X_ACCESS_TOKEN, X_ACCESS_TOKEN_SECRET")
+        print("This is the API route only. An agent with the Chrome tools can "
+              "post from a signed-in x.com session instead — navigate to "
+              "x.com/compose/post, type, file_upload to the hidden media input "
+              "(never click it: that opens a native picker), Post, then read "
+              "the permalink back off the profile to verify.", file=sys.stderr)
         sys.exit(1)
     return OAuth1(API_KEY, API_SECRET, ACCESS_TOKEN, ACCESS_TOKEN_SECRET)
 


### PR DESCRIPTION
A host can have no X API keys and still have a signed-in browser that posts
fine. This one does. The error said only what was missing, so it read as "this
machine cannot post" — and I reported exactly that to the owner, twice, over
four days, while the browser session was live the whole time.

The error now names the working route in its own output: compose URL, file_upload
to the HIDDEN media input (clicking the image button opens a native picker no
automation can see), then read the permalink back off the profile to verify.

Point-of-failure, not documentation: whoever hits this is told the answer by the
thing that failed. A note in a skill file or a memory is read by someone already
looking; this is read by someone who has just been stopped.

Verified: running `x-post.py post` with no credentials prints the route.
review-checks PASSes all three scanners.

Measured on Chis-Mac-mini today: no X credentials in `.env` or the vault, and a live signed-in x.com session that published https://x.com/Chi_Wang_/status/2097028327039291817 with an image attached on the first attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)