### PR TITLE
fix(model-switch): `default` names no family, so its acceptance line never matched

### DIFF
--- a/skills/model-switch/scripts/pane-observe.sh
+++ b/skills/model-switch/scripts/pane-observe.sh
@@ -17,7 +17,10 @@ fam="$(printf '%s' "$REQ" | sed -E 's/^claude-([a-z]+)-?.*/\1/; s/\[1m\]$//')"
 ver="$(printf '%s' "$REQ" | sed -nE 's/^claude-[a-z]+-([0-9]+(-[0-9]+)*).*/\1/p' | tr '-' '.')"
 # Exact display name at a boundary: "Opus 5" must not accept "Opus 5.1"; an alias
 # (no version) accepts whichever version the CLI chose for that family.
-if [ -n "$ver" ]; then ACCEPT="Set model to ${fam} $(printf '%s' "$ver" | sed 's/\./\\./g')([^0-9.]|$)"
+# `default` names no family — it resolves to whatever the CLI's default is, so the
+# echo says "Set model to Opus 5" and a ${fam}-anchored pattern can never match.
+if [ "$fam" = default ]; then ACCEPT="Set model to [A-Za-z]"
+elif [ -n "$ver" ]; then ACCEPT="Set model to ${fam} $(printf '%s' "$ver" | sed 's/\./\\./g')([^0-9.]|$)"
 else ACCEPT="Set model to ${fam}( [0-9][0-9.]*)?([^0-9.a-z]|$)"; fi
 DIALOG='Yes, switch'
 # A failed capture is a failed observation, never a zero.

--- a/tests/switch-model.test.sh
+++ b/tests/switch-model.test.sh
@@ -21,7 +21,7 @@ case " $* " in *" capture-pane "*)
   [ -n "${TMUX_NO_ACCEPT:-}" ] && { k=0; dlg=""; }
   # Render what the real CLI prints for each ACCEPTED send (display name, not id);
   # TMUX_ACCEPT_AS forces a different model's line; TMUX_PERSIST_SETTINGS mimics the CLI saving the pick.
-  disp() { case "$1" in claude-opus-5-1*) echo "Opus 5.1";; opus|claude-opus-5*) echo "Opus 5";; sonnet|claude-sonnet-5*) echo "Sonnet 5";; haiku|claude-haiku-4-5*) echo "Haiku 4.5";; fable|claude-fable-5-1*) echo "Fable 5.1";; default) echo "Default (recommended)";; *) echo "$1";; esac; }
+  disp() { case "$1" in claude-opus-5-1*) echo "Opus 5.1";; opus|claude-opus-5*) echo "Opus 5";; sonnet|claude-sonnet-5*) echo "Sonnet 5";; haiku|claude-haiku-4-5*) echo "Haiku 4.5";; fable|claude-fable-5-1*) echo "Fable 5.1";; default) echo "Opus 5";; *) echo "$1";; esac; }
   acc=""; i=0
   while [ "$i" -lt "$k" ]; do
     i=$((i+1)); sent="$(grep -- "-l /model" "$TMUX_LOG" | sed -n "${i}p" | sed 's/.*-l \/model //')"
@@ -34,7 +34,7 @@ SH
 chmod +x "$T/bin/tmux"
 export PATH="$T/bin:$PATH" TMUX_LOG="$T/tmux.log" SUTANDO_TMUX_SOCKET="/tmp/sutando-tmux.sock"
 printf '{"model":"claude-opus-5","permissions":{"allow":["Bash"]}}\n' > "$T/cfg/settings.json"; SETTINGS_BEFORE="$(cat "$T/cfg/settings.json")"
-fails=0; ok(){ echo "  ok   $1"; }; fail(){ echo "  FAIL $1 — $2"; fails=$((fails+1)); }
+fails=0; oks=0; ok(){ oks=$((oks+1)); echo "  ok   $1"; }; fail(){ echo "  FAIL $1 — $2"; fails=$((fails+1)); }
 run(){ : > "$TMUX_LOG"; rm -f "$TMUX_LOG.caps"; "$HERE/scripts/switch-model.sh" --accept-timeout 3 "$@" --state-dir "$T/state" --brain "$T/cfg" > "$T/out" 2> "$T/err"; echo $?; }
 settings_untouched(){ [ "$(cat "$T/cfg/settings.json")" = "$SETTINGS_BEFORE" ]; }
 
@@ -114,6 +114,9 @@ rc=$(TMUX_ACCEPT_AS=claude-opus-5-1 run claude-opus-5 --accept-timeout 1); [ "$r
 rc=$(run claude-opus-5-1); R=$(python3 -c "import json;print(json.load(open('$T/state/model-switch.json'))['model'])" 2>/dev/null)
 [ "$rc" = 0 ] && [ "$R" = "claude-opus-5-1" ] && ok "31 ...and the exact version is accepted (Opus 5.1)" || fail "31" "rc=$rc R=$R $(cat "$T/err")"
 rc=$(TMUX_ACCEPT_AS=claude-opus-5-1 run opus); [ "$rc" = 0 ] && ok "32 an alias (opus) accepts whichever version the CLI chose" || fail "32 alias" "rc=$rc $(cat "$T/err")"
+# `default` resolves to a family, so the CLI echoes that family and never the word
+# "default": a ${fam}-anchored pattern built from the request can never match it.
+rc=$(run default); [ "$rc" = 0 ] && ok "32b default accepts the family the CLI resolved it to" || fail "32b default" "rc=$rc $(cat "$T/err")"
 rm -f "$T/state/model-switch.json" "$T/tmux.log.caps"
 # capture order in a run: sender dry-run x2, BASELINE (3rd), sender send — fail the 3rd
 rc=$(TMUX_FAIL_CAPTURE_N=3 run sonnet); [ "$rc" = 7 ] && ! grep -q -- "-l /model" "$TMUX_LOG" && [ ! -e "$T/state/model-switch.json" ] && grep -q "could not read the core pane" "$T/err" \
@@ -121,4 +124,4 @@ rc=$(TMUX_FAIL_CAPTURE_N=3 run sonnet); [ "$rc" = 7 ] && ! grep -q -- "-l /model
 rm -f "$T/tmux.log.caps"
 # The capture counter must reset per run: run() truncates the log, so reset the counter with it.
 
-echo; [ $fails -eq 0 ] && echo "switch-model: all 33 checks pass" || { echo "switch-model: $fails FAILED"; exit 1; }
+echo; [ $fails -eq 0 ] && echo "switch-model: all $oks checks pass" || { echo "switch-model: $fails FAILED"; exit 1; }


### PR DESCRIPTION
The "Default (auto-fallback)" menu item has never been able to report success. It sends the literal `/model default`; `pane-observe.sh` derives the expected family from that requested string and greps for `Set model to default`, which the CLI never prints — `default` resolves to a real family, so the echo reads `Set model to Opus 5`. The line is sent and Enter pressed; only the confirmation read fails, at exit 8 after 20s, and the script then records nothing.

## Evidence it is structural, not a timeout

From `logs/sutando-app-debug.log` on this host — the app writes every dialog it raises:

```
19:53:30Z  Default (auto-fallback)  exit 8  sent '/model default' but saw no acceptance OF THAT MODEL within 20s
19:53:50Z  Default (auto-fallback)  exit 8  (identical)
20:05:39Z  Default (auto-fallback)  exit 8  (identical, core idle this time)
```

Three clicks, busy core and idle core, byte-identical wording. A timing failure does not reproduce that way.

## Control — the pattern against the CLI's real echo

`Set model to Opus 5` is what the CLI prints for `/model default`:

```
BEFORE (origin/main logic, req=default)   grep -Eci "Set model to default( [0-9][0-9.]*)?([^0-9.a-z]|$)"   ->  0
AFTER  (this change,        req=default)  grep -Eci "Set model to [A-Za-z]"                                  ->  1
```

## Regression — named models keep exact matching

The relaxation is confined to `default`; every other request takes the unchanged branches:

```
req=opus              'Opus 5'=1  'Opus 5.1'=1  'Fable 5.1'=0   alias accepts any version of ITS family
req=claude-opus-5     'Opus 5'=1  'Opus 5.1'=0  'Fable 5.1'=0   exactness preserved
req=claude-opus-5-1   'Opus 5'=0  'Opus 5.1'=1  'Fable 5.1'=0   exactness preserved
```

No cross-family acceptance in any case.

## Scope

One file, one `if` arm. Not fixed here: the switch may already be succeeding while the app reports failure (exit 8 records nothing), so a core that looks switched despite an error dialog is consistent with this bug and needs no separate cause.

Stand: Echo Act IV Pro
