### PR TITLE
fix(app): tick the model the proxy saw, not the last switch this menu completed

### DIFF
--- a/src/Sutando/main.swift
+++ b/src/Sutando/main.swift
@@ -2752,22 +2752,46 @@ extension AppDelegate: NSMenuDelegate {
     }
 
     /// The model the switch script last recorded as accepted (state/model-switch.json).
-    func recordedModel() -> String? {
-        guard let data = FileManager.default.contents(atPath: workspace + "/state/model-switch.json"),
-              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
-        return root["model"] as? String
+    /// The model the proxy last saw on the wire. `model-switch.json` records only
+    /// switches this menu completed, so it goes stale the moment anything else sets
+    /// the model — including the CLI's own default.
+    func liveModel() -> String? {
+        guard let data = FileManager.default.contents(atPath: workspace + "/state/quota-state.json"),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let last = root["last_request"] as? [String: Any] else { return nil }
+        return last["model"] as? String
+    }
+
+    /// (family, version) from either vocabulary: a menu id is a bare family alias or
+    /// a full claude-<family>-<ver> id, optionally context-tagged; the wire always
+    /// carries the full id. An alias has no version, so it matches any version of
+    /// its family; a versioned id must match exactly. Ids stay in the manifest.
+    func modelKey(_ id: String) -> (String, String?) {
+        var t = id
+        if let r = t.range(of: "[1m]") { t.removeSubrange(r) }
+        guard t.hasPrefix("claude-") else { return (t, nil) }
+        let parts = t.dropFirst("claude-".count).split(separator: "-", maxSplits: 1)
+        let fam = String(parts.first ?? "")
+        let ver = parts.count > 1 ? parts[1].replacingOccurrences(of: "-", with: ".") : nil
+        return (fam, ver)
+    }
+
+    func sameModel(_ menuID: String, _ live: String) -> Bool {
+        let (mf, mv) = modelKey(menuID), (lf, lv) = modelKey(live)
+        guard mf == lf else { return false }
+        return mv == nil || mv == lv
     }
 
     func menuNeedsUpdate(_ menu: NSMenu) {
         guard menu === modelSubmenu else { return }
         menu.removeAllItems()
-        let current = recordedModel()
+        let current = liveModel()
         if let choices = modelChoices() {
             for c in choices {
                 let it = NSMenuItem(title: c.title, action: #selector(switchModel(_:)), keyEquivalent: "")
                 it.target = self
                 it.representedObject = c.id
-                it.state = (c.id == current) ? .on : .off
+                it.state = (current.map { sameModel(c.id, $0) } ?? false) ? .on : .off
                 menu.addItem(it)
             }
         } else {

--- a/tests/app-model-submenu.test.sh
+++ b/tests/app-model-submenu.test.sh
@@ -16,7 +16,8 @@ assert len(pairs) >= 2 and all(len(p) == 2 and p[0].strip() and p[1].strip() for
 assert "default" in [p[0].strip() for p in pairs]
 PY
 grep -q 'title: "Other model' "$F" && grep -q 'func switchOtherModel' "$F" && ok "2e a free-form Other model… entry exists for ids the list lacks" || fail "2e" "no Other model entry"
-grep -q '"/state/model-switch.json"' "$F" && grep -q 'it.state = (c.id == current)' "$F" && ok "2f the recorded model is check-marked" || fail "2f" "no current-model mark"
+grep -q '"/state/quota-state.json"' "$F" && grep -q 'last_request' "$F" && ok "2f the tick reads the LIVE model the proxy saw, not the switch record" || fail "2f" "tick still sourced from model-switch.json"
+grep -q 'func sameModel' "$F" && ! grep -q 'c.id == current' "$F" && ok "2g ...compared by family/version, not raw id equality across two vocabularies" || fail "2g" "raw id comparison remains"
 grep -q 'runCoreAction(script: repoRoot + "/scripts/switch-model.sh"' "$F" && ok "3 the handler runs scripts/switch-model.sh through the shared runner" || fail "3" "handler does not call the script"
 grep -A2 'scripts/switch-model.sh' "$F" | grep -q '"--confirm"' && ok "4 ...with --confirm (the click is the owner's instruction)" || fail "4" "no --confirm"
 grep -A2 'scripts/switch-model.sh' "$F" | grep -q '"--socket", sutandoTmuxSocket' && ok "5 ...on the configured socket" || fail "5" "socket not passed"


### PR DESCRIPTION
The Model submenu's checkmark reads `state/model-switch.json` — a record of switches **this menu confirmed**. Anything else that sets the model never appears there: the CLI's own default, a `/model` typed in the pane, or a switch whose confirmation read failed. So the tick drifts and stays drifted.

Observed on this host: the menu ticked **Fable 5.1** (recorded Sep 5 17:33) while the dashboard and `quota-state.json → last_request.model` both read **claude-opus-5**. Two days stale.

`src/dashboard.py:252` already solved this and wrote down why:

> Read from what the proxy observed on the wire, not from a launch-time marker: /model switches mid-session, and a stamped model would go stale.

## The part that is not a one-liner

The two sides speak different vocabularies, so `c.id == current` could never match:

```
menu representedObject   a bare family alias, or a full id, optionally context-tagged
wire last_request.model  always the full id
```

`modelKey()` reduces both to `(family, version)`. An alias carries no version and matches any version of its family; a versioned id must match exactly. Derivation replicated and enumerated:

```
menu=<alias>            wire=<same family>      -> True
menu=<alias>            wire=<other family>     -> False
menu=<versioned+tag>    wire=<same fam+ver>     -> True
menu=<versioned+tag>    wire=<other family>     -> False
menu=default            wire=<anything>         -> False
```

`default` ticking nothing is deliberate: it names no family, so the family it resolved to is what gets the tick — which is the correct answer to "what is in use".

## Control

Tests 2f/2g pinned the old behaviour *by name* — the stale path and the raw comparison — so the suite could not have failed on this bug:

```
WITH this change                                       all checks pass
WITHOUT it (main.swift reverted to origin/main)        FAIL 2f  tick still sourced from model-switch.json
                                                       FAIL 2g  raw id comparison remains
                                                       2 FAILED
```

## Scope

Separate from #4013 on purpose: that one is the acceptance matcher (`default` never confirming), this one is the display. Different defects, different controls.

The suite here is grep-over-source, so it pins structure and cannot execute the comparison — the enumerated cases above come from replicating `modelKey`'s derivation, not from running the app.

Stand: Echo Act IV Pro
