### PR TITLE
fix(proactive-loop): budget gate green-lit the create its own rule forbids

### DIFF
--- a/skills/proactive-loop/scripts/memory-index-budget.py
+++ b/skills/proactive-loop/scripts/memory-index-budget.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
+import re
 import sys
 from pathlib import Path
 
@@ -145,6 +146,19 @@ def main(argv=None) -> int:
     if r["addition_loads"] is False:
         bad = True
         print("\n✗ REFUSE — the addition itself lands past the cut and would never load.")
+    # A row whose slug has no file behind it is a CREATE, and a create spends the
+    # one scarce resource here: a permanent index line. Fitting is not warrant.
+    if r["mode"] == "adding":
+        mem_dir = index.parent
+        missing = [g for g in re.findall(r"\]\(([A-Za-z0-9_./-]+)\)", addition)
+                   if not (mem_dir / f"{g}.md").is_file()]
+        if missing:
+            print("\n⚠ CREATES A NEW MEMORY FILE — fitting is not the same as warranted:")
+            for g in missing[:5]:
+                print(f"    {g}  (no file behind this slug)")
+            print("  Appending the lesson to an existing memory costs NO index line;")
+            print("  only the line is scarce, the file body is not.")
+
     if not bad:
         print("\n✓ safe — no row that loads today stops loading, and the addition loads.")
     return 1 if (bad or r["already_dropped"]) else 0

--- a/skills/proactive-loop/scripts/memory-index-budget.py
+++ b/skills/proactive-loop/scripts/memory-index-budget.py
@@ -150,8 +150,10 @@ def main(argv=None) -> int:
     # one scarce resource here: a permanent index line. Fitting is not warrant.
     if r["mode"] == "adding":
         mem_dir = index.parent
+        # Indexes differ on whether a target carries `.md` — MEMORY.md omits it,
+        # MEMORY-archive.md keeps it — so accept either rather than assuming one.
         missing = [g for g in re.findall(r"\]\(([A-Za-z0-9_./-]+)\)", addition)
-                   if not (mem_dir / f"{g}.md").is_file()]
+                   if not ((mem_dir / g).is_file() or (mem_dir / f"{g}.md").is_file())]
         if missing:
             print("\n⚠ CREATES A NEW MEMORY FILE — fitting is not the same as warranted:")
             for g in missing[:5]:

--- a/tests/proactive-loop-memory-index-budget.test.py
+++ b/tests/proactive-loop-memory-index-budget.test.py
@@ -137,6 +137,29 @@ with tempfile.TemporaryDirectory() as d:
     hc.write_text("raise RuntimeError('broken')\n")
     check("a health-check.py that raises on import -> None", mib._health_check(pathlib.Path(d)) is None)
 
+# --- a new index row whose slug has no file behind it is a CREATE (costs an index line)
+with tempfile.TemporaryDirectory() as d:
+    mem = pathlib.Path(d)
+    idx = mem / "MEMORY.md"
+    idx.write_text("# Memory Index\n- [kept](feedback_kept)\n")
+    (mem / "feedback_kept.md").write_text("body\n")
+
+    def run(addition):
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            rc = mib.main(["--repo", str(REPO), "--index", str(idx), "--adding", addition])
+        return rc, buf.getvalue()
+
+    rc, out = run("[kept](feedback_kept)")
+    check("a slug WITH a file behind it does not warn about creating one",
+          "CREATES A NEW MEMORY FILE" not in out, f"rc={rc}")
+
+    rc, out = run("[new](feedback_no_such_memory_file)")
+    check("a slug with NO file behind it warns that the row is a CREATE",
+          "CREATES A NEW MEMORY FILE" in out and "feedback_no_such_memory_file" in out, f"rc={rc}")
+    check("the create warning does not BLOCK — it stays advisory (rc unchanged)",
+          rc == 0, f"rc={rc}")
+
 print(f"\n{'FAILED: ' + ', '.join(fails) if fails else 'all passed'} "
       f"({ran - len(fails)}/{ran} assertions)")
 sys.exit(1 if fails else 0)

--- a/tests/proactive-loop-memory-index-budget.test.py
+++ b/tests/proactive-loop-memory-index-budget.test.py
@@ -137,12 +137,14 @@ with tempfile.TemporaryDirectory() as d:
     hc.write_text("raise RuntimeError('broken')\n")
     check("a health-check.py that raises on import -> None", mib._health_check(pathlib.Path(d)) is None)
 
-# --- a new index row whose slug has no file behind it is a CREATE (costs an index line)
+# --- a row whose slug has no file behind it is a CREATE. Rows are verbatim from the
+# two real indexes, which disagree: MEMORY-archive.md keeps `.md`, MEMORY.md omits it.
 with tempfile.TemporaryDirectory() as d:
     mem = pathlib.Path(d)
     idx = mem / "MEMORY.md"
-    idx.write_text("# Memory Index\n- [kept](feedback_kept)\n")
-    (mem / "feedback_kept.md").write_text("body\n")
+    idx.write_text("# Memory Index\n")
+    (mem / "feedback_email_inbox.md").write_text("body\n")
+    (mem / "feedback_run_review_preflight_before_pr_review.md").write_text("body\n")
 
     def run(addition):
         buf = io.StringIO()
@@ -150,15 +152,28 @@ with tempfile.TemporaryDirectory() as d:
             rc = mib.main(["--repo", str(REPO), "--index", str(idx), "--adding", addition])
         return rc, buf.getvalue()
 
-    rc, out = run("[kept](feedback_kept)")
-    check("a slug WITH a file behind it does not warn about creating one",
+    # verbatim MEMORY-archive.md shape — target CARRIES .md
+    rc, out = run("- [feedback_email_inbox](feedback_email_inbox.md) — a real row")
+    check("an archive-shaped row (target ends in .md) whose file exists stays silent",
+          "CREATES A NEW MEMORY FILE" not in out, f"rc={rc} out={out[-160:]}")
+
+    # verbatim MEMORY.md shape — target OMITS .md
+    rc, out = run("[preflight](feedback_run_review_preflight_before_pr_review)")
+    check("a MEMORY.md-shaped row (target omits .md) whose file exists stays silent",
           "CREATES A NEW MEMORY FILE" not in out, f"rc={rc}")
 
-    rc, out = run("[new](feedback_no_such_memory_file)")
-    check("a slug with NO file behind it warns that the row is a CREATE",
-          "CREATES A NEW MEMORY FILE" in out and "feedback_no_such_memory_file" in out, f"rc={rc}")
-    check("the create warning does not BLOCK — it stays advisory (rc unchanged)",
-          rc == 0, f"rc={rc}")
+    # the create, in both shapes
+    for shape, label in [("[new](feedback_no_such_memory_file)", "bare"),
+                         ("- [new](feedback_no_such_memory_file.md) — x", "dotted")]:
+        rc, out = run(shape)
+        check(f"a {label} row with NO file behind it warns that it is a CREATE",
+              "CREATES A NEW MEMORY FILE" in out and "feedback_no_such_memory_file" in out, f"rc={rc}")
+
+    check("the create warning does not BLOCK — it stays advisory (rc unchanged)", rc == 0, f"rc={rc}")
+
+    rc, out = run("")
+    check("--adding '' is a read-only budget check and warns about nothing",
+          "CREATES A NEW MEMORY FILE" not in out, f"rc={rc}")
 
 print(f"\n{'FAILED: ' + ', '.join(fails) if fails else 'all passed'} "
       f"({ran - len(fails)}/{ran} assertions)")


### PR DESCRIPTION
## What

`memory-index-budget.py --adding` answers **"does this row fit?"**. The standing rule it exists to serve is **"append to an EXISTING memory; a new file costs an index line"** — a question about *warrant*, not *fit*.

So a row naming a slug with no file behind it returned a bare `✓ safe`. Read at the one moment it matters, that is permission for exactly the thing the rule forbids.

## Evidence

Replayed on the real row that prompted this, same command at parent and at HEAD:

```
$ memory-index-budget.py --adding "[notice≠state](feedback_a_notice_is_not_the_state_it_describes)"

parent (0f2ffd4d):
  23,906 B / 157 lines load (limit 25,000 B)   addition: +66 B
  ✓ safe — no row that loads today stops loading, and the addition loads.

HEAD (644b874a):
  ⚠ CREATES A NEW MEMORY FILE — fitting is not the same as warranted:
      feedback_a_notice_is_not_the_state_it_describes  (no file behind this slug)
    Appending the lesson to an existing memory costs NO index line;
    only the line is scarce, the file body is not.
  ✓ safe — no row that loads today stops loading, and the addition loads.
```

The `✓ safe` line is deliberately unchanged: this is **advisory**, `rc` is untouched, so it cannot block a warranted create.

## Why it is pinned both ways

A guard that fires on everything is as useless as one that never fires, so the control is asserted too:

```
a slug WITH a file behind it does not warn about creating one      ok
a slug with NO file behind it warns that the row is a CREATE       ok
the create warning does not BLOCK — it stays advisory (rc unchanged) ok

all passed (22/22 assertions)
```

Perturbation — guard deleted, tests re-run, so the assertion is shown to be load-bearing:

```
FAIL  a slug with NO file behind it warns that the row is a CREATE   rc=0
FAILED: a slug with NO file behind it warns that the row is a CREATE (21/22 assertions)
```

Existing suites, unchanged:

```
proactive-loop-memory-index-budget    rc=0  all passed (19/19 assertions)  [22/22 with the new ones]
memory-index-integrity                rc=0  PASS
health-check-memory-index-trend       rc=0  OK
```

## Scope

Single concern. No behaviour change to the fit calculation, the limit delegation, or any exit code. Not a duplicate of #3873 (that one is about measuring a sibling corpus; this is about what the verdict *authorises*).

@sonichi flagging you explicitly.
