### PR TITLE
docs(agent-room-ops): steer room reads to the ag2-space MCP tools

### DIFF
--- a/skills/agent-room-ops/SKILL.md
+++ b/skills/agent-room-ops/SKILL.md
@@ -1,10 +1,19 @@
 # room-ops — an agent's room-participation capability collection
 
-> **Room reads: prefer the `ag2-space` MCP tools when they are connected.**
-> `room.list` supersedes `python3 room_ops.py rooms` for "which rooms can I
-> see". This skill remains the path for every write verb (`say`, `react`,
-> `join`, `send`, `doc put`/`rm`, `grant`, `events emit`) and for media
-> `fetch`. With no MCP connected, everything below applies unchanged.
+> **Prefer the `ag2-space` MCP tools when they are connected and the room
+> exposes them** — availability is per-room and per-actor, so check
+> `room.actions.search`. `room.list` supersedes `room_ops.py rooms`;
+> `room.context.read` supersedes `read`; `room.vault.read`/`tree`/`write`/
+> `delete` supersede `doc get`/`put`/`rm`; `room.message.send`/`react`/
+> `unreact` and `room.event.send` supersede `say`/`mention`/`react`/`unreact`/
+> `events emit`. Zero-effect actions run via `room.action.read`, mutations via
+> `room.action.execute`.
+>
+> Still this skill: `fetch`, which downloads media to a local path
+> (`room.media.link` mints an expiring viewer link — a different operation),
+> and `grant`, which has no confirmed equivalent. `join` has no MCP action by
+> design: agents do not self-join. With no MCP connected, everything below
+> applies unchanged.
 
 **One skill, multiple tools.** Everything an agent does in a room beyond its task
 inbox lives here as a tool, so the parity capabilities are self-evidently *one

--- a/skills/agent-room-ops/SKILL.md
+++ b/skills/agent-room-ops/SKILL.md
@@ -1,5 +1,11 @@
 # room-ops — an agent's room-participation capability collection
 
+> **Room reads: prefer the `ag2-space` MCP tools when they are connected.**
+> `room.list` supersedes `python3 room_ops.py rooms` for "which rooms can I
+> see". This skill remains the path for every write verb (`say`, `react`,
+> `join`, `send`, `doc put`/`rm`, `grant`, `events emit`) and for media
+> `fetch`. With no MCP connected, everything below applies unchanged.
+
 **One skill, multiple tools.** Everything an agent does in a room beyond its task
 inbox lives here as a tool, so the parity capabilities are self-evidently *one
 collection* (not N scattered skills). Each tool is a thin **gateway-only** client
@@ -131,11 +137,11 @@ layer (its CLAUDE.md equivalent) at connect time.
   spinning. Task intake (`/v1/tasks`) and room ops fail independently — a
   room-op outage doesn't mean your tasks stopped.
 - `create`/`invite` may be slow. List-before-create is the idempotence rule:
-  `python3 room_ops.py rooms` lists this agent's joined rooms (`rooms.py`,
-  op `joined_rooms`) — check it before creating. Still record created room
-  ids immediately (e.g. in your cron/config entry): the list reflects
-  membership, not purpose, so your own record remains the authoritative
-  "which room is for what" map.
+  `python3 room_ops.py rooms` lists this agent's joined rooms (`rooms.py`, op
+  `joined_rooms`) — prefer MCP `room.list` when connected; check either before
+  creating. Still record created room ids immediately (e.g. in your cron/config
+  entry): the list reflects membership, not purpose, so your own record remains
+  the authoritative "which room is for what" map.
 
 Every tool prints a structured JSON result and **exits 0** for any structured
 result (a graceful `ok:false` "no context / no-op" is not a failed task); usage


### PR DESCRIPTION
## What changed, and why?

With the `ag2-space` MCP connected (9 tools, incl. `room.list`), an agent asked *"what rooms do I have access to"* answered it by shelling out to `room_ops.py rooms` instead. Asked why, it cited **this SKILL.md** — it "explicitly documents a joined-room list" — and conceded MCP `room_list` "is more direct and returns room names."

The skill's own documentation is the attractor, so that is where the steer belongs. Two touch points:

1. A banner under the title.
2. An **inline pointer on the `rooms` line itself** (~line 148). That is the line the agent actually quoted, and `rooms` appears nowhere in the tools table — so a top banner alone leaves the real magnet unannotated 140 lines further down.

## What files / sections should reviewers look at first?

`skills/agent-room-ops/SKILL.md` — 2 hunks, Markdown only.

## What user behavior or bug does this prove?

Not a code bug. It corrects a documentation pull that produced a worse answer than the available tool.

**Mappings are verified, not assumed.** The second commit widens the first after they were confirmed against the live prod action catalog (`room.actions.search` on a real room for a Sutando agent; reads invoked live, mutations read from the catalog rather than executed against a live room):

| skill verb | MCP action |
| --- | --- |
| `rooms` | `room.list` |
| `read` | `room.context.read` — "bounded reverse page of room messages and reactions" |
| `doc get` / `doc ls` | `room.vault.read` / `room.vault.tree` |
| `doc put` / `doc rm` | `room.vault.write` / `room.vault.delete` |
| `react` / `unreact` | `room.message.react` / `room.message.unreact` |
| `say` / `mention` | `room.message.send` |
| `events emit` | `room.event.send` |

Zero-effect actions dispatch via `room.action.read`, mutations via `room.action.execute`. Two near-misses worth recording: `room.inspect` is room metadata, not timeline, and `room.actions.describe` returns an action's *schema* — neither reads history.

**Stays skill-side**, and named in the banner so "prefer MCP" cannot be read as "stop using this skill":

- `fetch` — `room.media.link` mints an expiring viewer link; it is not a download to a local path.
- `grant` — no equivalent confirmed. Left out rather than guessed.
- `join` — no MCP action **by design**: agents must not self-join. The banner says so rather than implying it is merely absent.

Availability is per-room *and* per-actor, so the banner points at `room.actions.search` rather than promising the tools are always present.

## Feature/documentation consistency

N/A — `docs/catalog.json` has no canonical document covering room-ops (checked: 0 room-related entries). The skill's own `SKILL.md` is the canonical surface, and it is what this PR edits.

## Before/after evidence

**Before** (at `origin/main`, the parent commit):

```
$ grep -c -i "mcp" skills/agent-room-ops/SKILL.md
0

$ sed -n '133,135p' skills/agent-room-ops/SKILL.md
- `create`/`invite` may be slow. List-before-create is the idempotence rule:
  `python3 room_ops.py rooms` lists this agent's joined rooms (`rooms.py`,
  op `joined_rooms`) — check it before creating. Still record created room
```

Nothing in the file mentions MCP, and the `rooms` line points only at itself — the state in which the agent read it and chose the skill.

**After** (at HEAD):

```
$ grep -c -i "mcp" skills/agent-room-ops/SKILL.md
4

$ sed -n '1,16p' skills/agent-room-ops/SKILL.md
# room-ops — an agent's room-participation capability collection

> **Prefer the `ag2-space` MCP tools when they are connected and the room
> exposes them** — availability is per-room and per-actor, so check
> `room.actions.search`. `room.list` supersedes `room_ops.py rooms`;
> `room.context.read` supersedes `read`; `room.vault.read`/`tree`/`write`/
> `delete` supersede `doc get`/`put`/`rm`; `room.message.send`/`react`/
> `unreact` and `room.event.send` supersede `say`/`mention`/`react`/`unreact`/
> `events emit`. Zero-effect actions run via `room.action.read`, mutations via
> `room.action.execute`.
>
> Still this skill: `fetch`, which downloads media to a local path
> (`room.media.link` mints an expiring viewer link — a different operation),
> and `grant`, which has no confirmed equivalent. `join` has no MCP action by
> design: agents do not self-join. With no MCP connected, everything below
> applies unchanged.

$ sed -n '148,151p' skills/agent-room-ops/SKILL.md
- `create`/`invite` may be slow. List-before-create is the idempotence rule:
  `python3 room_ops.py rooms` lists this agent's joined rooms (`rooms.py`, op
  `joined_rooms`) — prefer MCP `room.list` when connected; check either before
  creating. Still record created room ids immediately (e.g. in your cron/config
```

## What tests did you run?

```
$ git diff origin/main | bash scripts/review-checks.sh
prose-cap: no in-scope files (exts .py); nothing was scanned
review-checks: PARTIAL (hardcoded-paths + root-artifacts clean; prose-cap had no in-scope files)
```

Hardcoded-path and root-artifact scans clean; `prose-cap` is Python-only, so a Markdown-only change has no in-scope files. No unit tests apply — `room_ops.py` behaviour is untouched, the diff is prose only.

## Touching a live path?

N/A — documentation only. No bridge, network, delivery loop, or startup code is modified, and no restart is needed: the skill file is read at invocation time.

## Not in this PR

`join` is documented as intentionally not an agent capability, but the skill still *exposes* a `join` verb. Whether it should is a behaviour change, not a doc fix, so it is deliberately left alone here.

## Related

Desktop-side counterpart: ag2-space/ag2space-cinny-desktop#529 adds the same steer to `engine/AGENTS.md` + `engine/CLAUDE.md`. That lever is weaker on its own — the engine instruction files cannot durably edit this vendored skill, and the observed failure was the skill's own text winning over the engine directive.
