### PR TITLE
fix(monitor): a refused turn at the idle prompt escalates like a login gate (#4015)

### DIFF
--- a/src/core-input-watch.py
+++ b/src/core-input-watch.py
@@ -143,7 +143,11 @@ _IDLE = re.compile(r"⏵⏵\s*bypass permissions on|for agents\b", re.I)
 # pane returns to the idle footer, so no gate is on screen. Explicit list, extended by hand.
 _REFUSAL = re.compile(
     r"out of usage credits|/usage-credits|hit your (?:session|usage|weekly) limit"
-    r"|Please run /login|OAuth access token has expired|not logged in", re.I)
+    r"|Please run /login|OAuth access token has expired"
+    # "not logged in" is three common words: only the CLI's own line-start form, or
+    # the phrase beside a /login token, is a refusal; a tool result quoting it is not.
+    r"|^⎿?\s*(?:you(?:'re| are) )?not logged in\b|not logged in\b.{0,60}/login\b|/login\b.{0,60}not logged in\b",
+    re.I)
 # The completed-turn line: "✻ Worked for 0s" / "✻ Cooked for 1s · done 12:32 PM". The spinner
 # reuses the glyph ("✻ Perambulating… (1m 46s · …)") and must not match.
 _TURN_DONE = re.compile(

--- a/src/core-input-watch.py
+++ b/src/core-input-watch.py
@@ -35,6 +35,7 @@ idle / wedged":
     unknown (unobserved)    →   unobserved        (probe could not run: hold, never RECOVER)
     (any, + gateway down)   →   gateway-down       (gateway probe is bundled-specific)
     (any, + active gate)    →   blocked-known / blocked-human   (net-new: pane classify)
+    (idle, + refused turn)  →   blocked-human (turn-rejected)   (net-new: refused_turn)
 
 runtime-health.json stays the Console's coarse view (unchanged, its consumers
 untouched); core-supervisor.json is the escalation-facing refinement of the same
@@ -138,10 +139,25 @@ _AWAIT_HINT = re.compile(
     r"|Continuing automatically|❯\s*\d+\.", re.I)
 _IDLE = re.compile(r"⏵⏵\s*bypass permissions on|for agents\b", re.I)
 
+# A turn the CLI refuses outright is a FINISHED turn: the reason is its `⎿` result and the
+# pane returns to the idle footer, so no gate is on screen. Explicit list, extended by hand.
+_REFUSAL = re.compile(
+    r"out of usage credits|/usage-credits|hit your (?:session|usage|weekly) limit"
+    r"|Please run /login|OAuth access token has expired|not logged in", re.I)
+# The completed-turn line: "✻ Worked for 0s" / "✻ Cooked for 1s · done 12:32 PM". The spinner
+# reuses the glyph ("✻ Perambulating… (1m 46s · …)") and must not match.
+_TURN_DONE = re.compile(
+    r"^\s*✻\s+[A-Za-z]+(?:\s+for\s+(?P<dur>\d+[hms](?:\s+\d+[hms])*))?(?:\s*·\s*done\b.*)?\s*$")
+_TURN_SHORT = re.compile(r"[01]s")
+_PROMPT_LINE = re.compile(r"^\s*❯")
+#: Non-empty pane lines searched for the nearest completed turn (a result line may wrap).
+_TURN_WINDOW = 40
+
 # Gates that need a human (can't be auto-answered): login + any unrecognized
 # selection/permission. The rest (trust/bypass/press-enter) are known-safe.
 # session-limit is a spend/wait decision: never auto-answered, never a login.
-_HUMAN_GATES = {"login", "selection", "permission", "session-limit", "fable-limit-unfocused", "unknown"}
+_HUMAN_GATES = {"login", "selection", "permission", "session-limit", "fable-limit-unfocused",
+                "turn-rejected", "unknown"}
 
 # --- M4 AUTO-ANSWER (Layer 2): the safe key per gate; `answer_step` in the loop sends it
 # once per prompt instance (`--no-auto-answer` disables). Unlisted → None → ESCALATE.
@@ -217,6 +233,35 @@ def _is_idle_ready(pane: str) -> bool:
     return bool(_IDLE.search(tail)) and not any(rx.search(tail) for _, rx in _SIGNATURES)
 
 
+def refused_turn(pane: str):
+    """(kind, line) when the pane sits at the idle footer and the nearest completed turn
+    above it was refused: a short turn (≤1s or no duration) whose `⎿` result carries a
+    _REFUSAL line. Else None — a long turn that merely mentions the words, a refusal in
+    scrollback under a later real turn, or a pane not at the footer all stay as they were."""
+    if not _is_idle_ready(pane):
+        return None
+    lines = [ln for ln in pane.splitlines() if ln.strip()][-_TURN_WINDOW:]
+    done = next((i for i in range(len(lines) - 1, -1, -1) if _TURN_DONE.match(lines[i])), None)
+    if done is None:
+        return None
+    dur = _TURN_DONE.match(lines[done]).group("dur")
+    if dur and not _TURN_SHORT.fullmatch(dur):
+        return None
+    start = next((i for i in range(done - 1, -1, -1) if _PROMPT_LINE.match(lines[i])), -1)
+    in_result = False
+    for ln in lines[start + 1:done]:
+        core = ln.strip()
+        # Only the CLI's `⎿` result (and its wrapped continuation) counts; agent output
+        # (`●`) or a tool call (`⏺`) means the turn ran, whatever words it printed.
+        if core.startswith("⎿"):
+            in_result = True
+        elif core[:1] in "●⏺":
+            in_result = False
+        if in_result and _REFUSAL.search(core):
+            return "turn-rejected", core.lstrip("⎿").strip()
+    return None
+
+
 # runtime-health health string → supervisor state, for the non-gate branches.
 _BASE_TO_STATE = {
     "offline": ("crashed", "core process/session not found"),
@@ -254,6 +299,12 @@ def compose_state(pane, base_health, gateway_alive, process=True):
         return "blocked-known", f"at known gate: {kind}", excerpt, kind
     if base_health == "needs_login":
         return "logged-out", _BASE_TO_STATE["needs_login"][1], None, None
+    # A refused turn leaves the core at its idle footer, which every branch below reads
+    # as healthy; the refusal line is the only evidence and it is finished, not a gate.
+    refused = refused_turn(pane) if pane else None
+    if refused:
+        kind, line = refused
+        return "blocked-human", f"awaiting user: {kind}", line, kind
     if not gateway_alive:
         return "gateway-down", "core up but relay gateway not running", None, None
     state, detail = _BASE_TO_STATE.get(base_health, _BASE_TO_STATE["unknown"])

--- a/src/core-input-watch.py
+++ b/src/core-input-watch.py
@@ -234,29 +234,37 @@ def _is_idle_ready(pane: str) -> bool:
 
 
 def refused_turn(pane: str):
-    """(kind, line) when the pane sits at the idle footer and the nearest completed turn
-    above it was refused: a short turn (≤1s or no duration) whose `⎿` result carries a
-    _REFUSAL line. Else None — a long turn that merely mentions the words, a refusal in
-    scrollback under a later real turn, or a pane not at the footer all stay as they were."""
+    """(kind, line) when the pane sits at the idle footer and the turn that ended there —
+    the last completed one, with nothing newer below it — was refused: a short turn (≤1s
+    or no duration) whose only content is a `⎿` result carrying a _REFUSAL line. Else
+    None — a long turn that merely mentions the words, a turn that ran (any `●`/`⏺`
+    line, so a tool result that quoted a refusal stays the tool's), a completion with a
+    newer prompt or active turn below it, or a pane not at the footer all stay as they were."""
     if not _is_idle_ready(pane):
         return None
     lines = [ln for ln in pane.splitlines() if ln.strip()][-_TURN_WINDOW:]
     done = next((i for i in range(len(lines) - 1, -1, -1) if _TURN_DONE.match(lines[i])), None)
     if done is None:
         return None
+    # Only the footer may follow the completion: a typed prompt, a spinner or any turn
+    # glyph below it means a newer turn owns the pane and the old refusal is history.
+    for ln in lines[done + 1:]:
+        core = ln.strip()
+        if core[:1] in "●⏺⎿✻" or (_PROMPT_LINE.match(ln) and core.lstrip("❯").strip()):
+            return None
     dur = _TURN_DONE.match(lines[done]).group("dur")
     if dur and not _TURN_SHORT.fullmatch(dur):
         return None
     start = next((i for i in range(done - 1, -1, -1) if _PROMPT_LINE.match(lines[i])), -1)
+    turn = [ln.strip() for ln in lines[start + 1:done]]
+    # A refused turn prints nothing but its `⎿` result. Agent output (`●`) or a tool call
+    # (`⏺`) means the turn ran, and any `⎿` in it is that tool's result, not the CLI's.
+    if any(core[:1] in "●⏺" for core in turn):
+        return None
     in_result = False
-    for ln in lines[start + 1:done]:
-        core = ln.strip()
-        # Only the CLI's `⎿` result (and its wrapped continuation) counts; agent output
-        # (`●`) or a tool call (`⏺`) means the turn ran, whatever words it printed.
+    for core in turn:
         if core.startswith("⎿"):
             in_result = True
-        elif core[:1] in "●⏺":
-            in_result = False
         if in_result and _REFUSAL.search(core):
             return "turn-rejected", core.lstrip("⎿").strip()
     return None

--- a/src/core-supervisor-relay.py
+++ b/src/core-supervisor-relay.py
@@ -98,7 +98,20 @@ def _is_login_class(signal: dict) -> bool:
     clear them (sonichi#2397). Root cause per #2402: a fresh CLAUDE_CONFIG_DIR
     always requires /login; a locked keychain (SSH spawn) only blocks
     completing it — hence the remedy must run from a GUI context."""
-    return signal.get("state") == "logged-out" or signal.get("kind") == "login"
+    return (signal.get("state") == "logged-out" or signal.get("kind") == "login"
+            or (signal.get("kind") == "turn-rejected"
+                and bool(_REFUSED_LOGIN.search(signal.get("prompt") or ""))))
+
+
+# A refused turn (monitor kind `turn-rejected`) carries the CLI's refusal line as its prompt;
+# the line, not the kind, says whether the remedy is the limit wait or a GUI /login.
+_REFUSED_LIMIT = re.compile(r"usage credits|/usage-credits|hit your (?:session|usage|weekly) limit", re.I)
+_REFUSED_LOGIN = re.compile(r"/login|not logged in|OAuth access token", re.I)
+
+
+def _is_refused_limit(signal: dict) -> bool:
+    return (signal.get("kind") == "turn-rejected"
+            and bool(_REFUSED_LIMIT.search(signal.get("prompt") or "")))
 
 
 _RESET_AT = re.compile(r"resets?\s+(?:at\s+)?(\d{1,2}(?::\d{2})?\s*[ap]m)", re.I)
@@ -190,7 +203,10 @@ def compose_message(signal: dict) -> str:
         # The remedy is the actionable half, so it keeps its length; the prompt
         # echo is what gives way to stay inside the message-length bound.
         msg += f": {excerpt[:110]}"
-    if signal.get("kind") == "session-limit":
+    if kind == "turn-rejected":
+        msg += (" — the core sits at its idle prompt but refuses every turn it is sent; each"
+                " ends in that line, so nothing queued for it runs")
+    if kind == "session-limit" or _is_refused_limit(signal):
         msg += _limit_remedy(signal)
     elif signal.get("kind") == "fable-limit-unfocused":
         msg += (" — Claude Code's Fable weekly-limit dialog is up but the focused option is"

--- a/tests/core-input-watch.test.py
+++ b/tests/core-input-watch.test.py
@@ -382,6 +382,49 @@ class TestRefusedTurn(unittest.TestCase):
         st, *_ = compose_state(pane, "idle", True)
         self.assertEqual(st, "idle-ready")
 
+    def test_a_tool_result_carrying_the_words_is_not_a_refusal(self):
+        # `⎿` is also the tool-result marker. A short turn whose tool READ a refusal line
+        # (and whose agent then answered) ran: the result belongs to the tool, not the CLI.
+        pane = ("❯ check credits\n"
+                "⏺ Bash(cat diagnostic.txt)\n"
+                f"  ⎿  {_REFUSAL_LINE}\n"
+                "● The diagnostic was read successfully.\n"
+                "✻ Worked for 1s\n" + _IDLE_FOOTER)
+        for base in ("idle", "unknown"):
+            st, _d, prompt, kind = compose_state(pane, base, True)
+            self.assertEqual((st, kind), ("idle-ready", None), (base, prompt))
+
+    def test_a_tool_result_alone_in_a_short_turn_is_not_a_refusal(self):
+        # Same ownership, no trailing agent line: the `⏺` header already says the turn ran.
+        pane = ("❯ check credits\n⏺ Bash(cat diagnostic.txt)\n"
+                f"  ⎿  {_REFUSAL_LINE}\n✻ Worked for 0s\n" + _IDLE_FOOTER)
+        st, *_ = compose_state(pane, "idle", True)
+        self.assertEqual(st, "idle-ready")
+
+    def test_a_refused_turn_under_a_newer_active_turn_stays_running(self):
+        # History plus an active turn: the refusal completed, then a newer prompt started
+        # and is still spinning. The old completion must not be reused.
+        pane = (_REFUSED_TURNS
+                + "❯ try again\n"
+                + "● Checking the connection.\n"
+                + "✻ Perambulating… (1m 46s · ↓ 5.9k tokens)\n" + _IDLE_FOOTER)
+        st, _d, prompt, kind = compose_state(pane, "working", True)
+        self.assertEqual((st, kind), ("running", None), prompt)
+
+    def test_a_refused_turn_under_a_newer_typed_prompt_is_not_reused(self):
+        # The owner has typed the next prompt but not sent it: the refusal is history.
+        pane = _REFUSED_TURNS + _IDLE_FOOTER.replace("❯ \n", "❯ try again\n", 1)
+        self.assertIn("❯ try again", pane)
+        st, _d, prompt, kind = compose_state(pane, "idle", True)
+        self.assertEqual((st, kind), ("idle-ready", None), prompt)
+
+    def test_a_short_result_without_the_words_is_not_a_refusal(self):
+        # The CLI's own `⎿` result, ended in 0s, but not one of the refusal lines.
+        pane = ("❯ /nosuch\n  ⎿  Unknown slash command: /nosuch\n"
+                "✻ Worked for 0s\n" + _IDLE_FOOTER)
+        st, *_ = compose_state(pane, "idle", True)
+        self.assertEqual(st, "idle-ready")
+
     def test_the_spinner_is_not_a_completed_turn(self):
         pane = (f"❯ /startup\n  ⎿  {_REFUSAL_LINE}\n"
                 "✻ Perambulating… (1m 46s · ↓ 5.9k tokens)\n" + _IDLE_FOOTER)

--- a/tests/core-input-watch.test.py
+++ b/tests/core-input-watch.test.py
@@ -68,6 +68,22 @@ _FABLE_LIMIT_UNFOCUSED = _FABLE_LIMIT.replace(
     "  ❯ Switch to Opus 5 and continue\n    Continue with Fable 5.1",
     "    Switch to Opus 5 and continue\n  ❯ Continue with Fable 5.1")
 assert _FABLE_LIMIT_UNFOCUSED != _FABLE_LIMIT
+# The core's terminal on 2026-09-07 (#4015): every /startup was refused in 0-1s and the CLI
+# went straight back to its idle footer, so no gate was ever on screen.
+_REFUSAL_LINE = ("You're out of usage credits. Run /usage-credits to keep using Fable 5.1 "
+                 "or /model to switch models.")
+_IDLE_FOOTER = ("────────\n❯ \n────────\n"
+                "  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents")
+_REFUSED_TURNS = ("❯ /startup\n"
+                  f"  ⎿  {_REFUSAL_LINE}\n"
+                  "✻ Cooked for 1s · done 12:32 PM\n"
+                  "❯ /startup\n"
+                  f"  ⎿  {_REFUSAL_LINE}\n"
+                  "✻ Cogitated for 0s · done 12:42 PM\n")
+# A /startup that ran: agent output, a real duration, the same footer.
+_STARTUP_OK_TURN = ("❯ /startup\n"
+                    "● /startup complete: watcher streaming, 3 crons registered.\n"
+                    "✻ Worked for 2m 14s · done 12:55 PM\n")
 
 
 class TestClassify(unittest.TestCase):
@@ -317,6 +333,73 @@ class TestComposeState(unittest.TestCase):
         # detection is preserved.
         st2, *_ = compose_state("Running step 3...\n(no prompt, no footer)", "unknown", True)
         self.assertEqual(st2, "hung")
+
+
+class TestRefusedTurn(unittest.TestCase):
+    """#4015: a turn the CLI refuses is a FINISHED turn at the idle footer — no gate, no
+    affordance — so classify() cannot see it and every base health reads idle-ready.
+    The refused-turn detector must flag it as blocked-human/turn-rejected, carrying the
+    refusal line, and must leave every other idle pane exactly as it was."""
+
+    def test_the_pane_shows_no_gate(self):
+        # The blind spot itself: nothing for the gate classifier to match.
+        self.assertIsNone(classify(_REFUSED_TURNS + _IDLE_FOOTER))
+
+    def test_refused_turns_at_the_idle_footer_are_blocked_human(self):
+        for base in ("idle", "unknown", "working"):
+            st, detail, prompt, kind = compose_state(_REFUSED_TURNS + _IDLE_FOOTER, base, True)
+            self.assertEqual((st, kind), ("blocked-human", "turn-rejected"), base)
+            self.assertEqual(prompt, _REFUSAL_LINE, base)
+            self.assertIn("turn-rejected", detail)
+
+    def test_a_bare_done_line_counts(self):
+        # The captured shape without "· done HH:MM" (tests/runtime-health.test.py).
+        pane = ("❯ /startup\n  ⎿  OAuth access token has expired · Please run /login\n"
+                "✻ Worked for 0s\n" + _IDLE_FOOTER)
+        st, _d, prompt, kind = compose_state(pane, "idle", True)
+        self.assertEqual((st, kind), ("blocked-human", "turn-rejected"))
+        self.assertEqual(prompt, "OAuth access token has expired · Please run /login")
+
+    def test_a_successful_last_turn_stays_idle_ready(self):
+        for base in ("idle", "unknown"):
+            st, *_ = compose_state(_STARTUP_OK_TURN + _IDLE_FOOTER, base, True)
+            self.assertEqual(st, "idle-ready", base)
+
+    def test_a_refusal_in_scrollback_under_a_later_success_stays_idle_ready(self):
+        st, *_ = compose_state(_REFUSED_TURNS + _STARTUP_OK_TURN + _IDLE_FOOTER, "idle", True)
+        self.assertEqual(st, "idle-ready")
+
+    def test_a_long_turn_that_mentions_the_words_is_not_a_refusal(self):
+        for done in ("✻ Worked for 12s · done 1:00 PM", "✻ Worked for 2m 3s · done 1:00 PM"):
+            pane = f"❯ /startup\n  ⎿  {_REFUSAL_LINE}\n{done}\n" + _IDLE_FOOTER
+            st, *_ = compose_state(pane, "idle", True)
+            self.assertEqual(st, "idle-ready", done)
+
+    def test_agent_output_in_a_short_turn_is_not_a_refusal(self):
+        # The words in the agent's own reply (`●`), not in a `⎿` result: the turn ran.
+        pane = ("❯ usage?\n● You are not out of usage credits; /usage-credits shows $12.\n"
+                "✻ Worked for 1s · done 1:00 PM\n" + _IDLE_FOOTER)
+        st, *_ = compose_state(pane, "idle", True)
+        self.assertEqual(st, "idle-ready")
+
+    def test_the_spinner_is_not_a_completed_turn(self):
+        pane = (f"❯ /startup\n  ⎿  {_REFUSAL_LINE}\n"
+                "✻ Perambulating… (1m 46s · ↓ 5.9k tokens)\n" + _IDLE_FOOTER)
+        st, *_ = compose_state(pane, "idle", True)
+        self.assertEqual(st, "idle-ready")
+
+    def test_a_refusal_without_the_idle_footer_is_not_flagged(self):
+        # Mid-render: no footer yet, so no evidence the core came back to rest.
+        st, *_ = compose_state(_REFUSED_TURNS, "working", True)
+        self.assertEqual(st, "running")
+
+    def test_the_footer_alone_stays_idle_ready(self):
+        st, *_ = compose_state(_IDLE, "idle", True)
+        self.assertEqual(st, "idle-ready")
+
+    def test_a_refused_turn_is_never_auto_answered(self):
+        self.assertIsNone(auto_answer("turn-rejected"))
+        self.assertIsNone(_mod.answer_step("blocked-human", "turn-rejected", _REFUSAL_LINE, None))
 
 
 class TestAutoAnswer(unittest.TestCase):

--- a/tests/core-input-watch.test.py
+++ b/tests/core-input-watch.test.py
@@ -394,6 +394,25 @@ class TestRefusedTurn(unittest.TestCase):
             st, _d, prompt, kind = compose_state(pane, base, True)
             self.assertEqual((st, kind), ("idle-ready", None), (base, prompt))
 
+    def test_not_logged_in_inside_ordinary_output_is_not_a_refusal(self):
+        # Three common words: a slash-command result that merely contains them (no ⏺, ≤1s)
+        # must not escalate. Only the CLI's own line-start form or /login adjacency counts.
+        for line in ("gh: not logged in to github.com",
+                     "src/auth.py:42: raise RuntimeError('not logged in')",
+                     "shown to a visitor who is not logged in",
+                     "ok test_errors_when_not_logged_in"):
+            pane = f"❯ /somecommand\n  ⎿  {line}\n✻ Worked for 1s\n" + _IDLE_FOOTER
+            st, _d, prompt, kind = compose_state(pane, "idle", True)
+            self.assertEqual((st, kind), ("idle-ready", None), (line, prompt))
+
+    def test_the_clis_own_not_logged_in_line_is_a_refusal(self):
+        for line in ("Not logged in · Please run /login", "You are not logged in. Run /login",
+                     "not logged in", "Run /login first: not logged in"):
+            pane = f"❯ /startup\n  ⎿  {line}\n✻ Worked for 0s\n" + _IDLE_FOOTER
+            st, _d, prompt, kind = compose_state(pane, "idle", True)
+            self.assertEqual((st, kind), ("blocked-human", "turn-rejected"), line)
+            self.assertEqual(prompt, line)
+
     def test_a_tool_result_alone_in_a_short_turn_is_not_a_refusal(self):
         # Same ownership, no trailing agent line: the `⏺` header already says the turn ran.
         pane = ("❯ check credits\n⏺ Bash(cat diagnostic.txt)\n"

--- a/tests/core-supervisor-relay.test.py
+++ b/tests/core-supervisor-relay.test.py
@@ -43,6 +43,12 @@ _LIMIT = {"state": "blocked-human", "detail": "awaiting user: session-limit",
           "kind": "session-limit"}
 _LOGGED_OUT = {"state": "logged-out", "detail": "core not authenticated (needs /login)",
                "prompt": None, "kind": None}
+# The monitor's refused-turn signal (#4015): the core sits at its idle prompt and every turn
+# it is sent ends in this line. The prompt IS the line, so the remedy is chosen from it.
+_REFUSED_LINE = ("You're out of usage credits. Run /usage-credits to keep using Fable 5.1 "
+                 "or /model to switch models.")
+_REFUSED = {"state": "blocked-human", "detail": "awaiting user: turn-rejected",
+            "prompt": _REFUSED_LINE, "kind": "turn-rejected"}
 _IDLE = {"state": "idle-ready", "detail": "ready for a task", "prompt": None, "kind": None}
 _RUNNING = {"state": "running", "detail": "actively processing", "prompt": None, "kind": None}
 _CRASHED = {"state": "crashed", "detail": "core process/session not found", "prompt": None}
@@ -247,6 +253,34 @@ class TestComposeMessage(unittest.TestCase):
         m = compose_message(sig)
         self.assertIn("when the limit window resets", m)
         self.assertNotIn("/login", m)
+
+    def test_turn_rejected_escalates(self):
+        self.assertTrue(should_escalate(_REFUSED, None)[0])
+
+    def test_turn_rejected_says_every_turn_is_refused_and_names_the_line(self):
+        m = compose_message(_REFUSED)
+        self.assertIn("refuses every turn", m)
+        self.assertIn("out of usage credits", m)
+        # A credit line gets the limit remedy, never the login one.
+        self.assertIn("/usage-credits", m)
+        self.assertIn("not a login problem", m)
+        self.assertNotIn("GUI /login", m)
+        self.assertNotIn("restart.sh", m)
+
+    def test_turn_rejected_login_line_names_gui_login_remedy(self):
+        sig = dict(_REFUSED, prompt="OAuth access token has expired · Please run /login")
+        m = compose_message(sig)
+        self.assertIn("refuses every turn", m)
+        self.assertIn("OAuth access token has expired", m)
+        self.assertIn("GUI /login", m)
+        self.assertNotIn("usage limit", m)
+
+    def test_turn_rejected_unknown_line_falls_back_to_the_terminal(self):
+        sig = dict(_REFUSED, prompt="Something else the CLI refused with")
+        with _no_backend():
+            m = compose_message(sig)
+        self.assertIn("refuses every turn", m)
+        self.assertIn("where the core is running", m)
 
     def test_non_login_blocker_names_the_cli_terminal(self):
         """A `blocked-human` prompt waits on the core's stdin. Neither a chat reply


### PR DESCRIPTION
Slice 1 of #4015 (engine half). Slice 2 — the desktop's `ceremony_health.rs` stopping its `/startup` re-send loop on a refusal — is **not** in this PR.

## What changed, and why

A core that refuses every turn (out of usage credits, an expired OAuth token) prints the refusal as the turn's `⎿` result and returns to the idle footer. No gate is on screen, so `classify()` finds no `_AWAIT_HINT` and `compose_state` reads the positive idle footer as `idle-ready`. On 2026-09-07 the core sat that way for 70 minutes, unseen, while the same monitor escalated the `/login` menu within seconds (issue comment).

- `src/core-input-watch.py` — `refused_turn(pane)`: the pane is at the idle footer (`_is_idle_ready`, unchanged) **and** the nearest completed turn above it (`✻ <Verb> for <dur>`, with or without `· done HH:MM`; the in-progress spinner does not match) is short (`for 0s`/`for 1s`, or no duration) **and** its `⎿` result line(s) — between it and the previous `❯` prompt, not agent `●` output or a `⏺` tool call — carry a line from an explicit signature list (`out of usage credits`, `/usage-credits`, `hit your (session|usage|weekly) limit`, `Please run /login`, `OAuth access token has expired`, `not logged in`). Result: `blocked-human`, kind `turn-rejected`, prompt = the refusal line. `compose_state` consults it after the `needs_login` branch (a pane runtime-health already reads as logged-out keeps that path and its Sign-in card) and before `gateway-down`/idle. `turn-rejected` joins `_HUMAN_GATES`; the auto-answer allowlist is untouched, so it is never typed at. Every other idle case is unchanged.
- `src/core-supervisor-relay.py` — the notice for kind `turn-rejected` says the core sits at its idle prompt but refuses every turn, names the line, and picks the remedy **from the line**: a limit line reuses `_limit_remedy`; a login-class line (`_is_login_class` extended) gets the existing GUI `/login` remedy; anything else falls back to the terminal remedy.

No new plumbing: the existing ESCALATE banner (`blocked-human`), the HITL card (`tui_gate` keeps the no-button blocked card for a non-semantic gate), the relay's `HARD_ESCALATE` + `(state, prompt)` debounce (the line is identical turn after turn → one notice) all fire as-is.

## Where to look first

1. `src/core-input-watch.py` — `_REFUSAL`/`_TURN_DONE` (after `_IDLE`), `refused_turn()` (after `_is_idle_ready`), the 5-line branch in `compose_state`.
2. `src/core-supervisor-relay.py` — `_is_login_class`, `_is_refused_limit`, the `turn-rejected` branch in `compose_message`.
3. `tests/core-input-watch.test.py::TestRefusedTurn` — the issue's pane + the controls.

## What this proves

The issue's pane (verbatim, plus the footer) now classifies `blocked-human`/`turn-rejected` with the refusal line as the prompt; the same footer under a `/startup complete:` turn, under a refusal that sits in scrollback above a later real turn, under a long turn that merely prints the words, under the spinner, and the bare footer all stay `idle-ready`; a refusal without the footer stays `running`. The relay notice for the credit line contains the line, `/usage-credits`, and no `/login`; for `OAuth access token has expired · Please run /login` it contains the GUI `/login` remedy.

## Feature/documentation consistency

N/A — `docs/catalog.json` has no canonical document for the core supervisor's state vocabulary (only `docs/src-map.md`'s one-liner references the file, which is unchanged). The module docstring's state table gains the one new row.

## Before/after evidence

Both test files copied unchanged into a detached worktree at `origin/main` (c28b7e5b) and run there, then at HEAD:

```
===== sutando-4015-main (c28b7e5b) : tests/core-input-watch.test.py
rc=1
FAIL: test_a_bare_done_line_counts (__main__.TestRefusedTurn.test_a_bare_done_line_counts)
FAIL: test_refused_turns_at_the_idle_footer_are_blocked_human (__main__.TestRefusedTurn.test_refused_turns_at_the_idle_footer_are_blocked_human)
Ran 67 tests in 0.659s
FAILED (failures=2)
    AssertionError: Tuples differ: ('idle-ready', None) != ('blocked-human', 'turn-rejected')
===== HEAD : tests/core-input-watch.test.py
rc=0
Ran 67 tests in 0.598s
OK
===== sutando-4015-main (c28b7e5b) : tests/core-supervisor-relay.test.py
rc=1
FAIL: test_turn_rejected_login_line_names_gui_login_remedy (__main__.TestComposeMessage.test_turn_rejected_login_line_names_gui_login_remedy)
FAIL: test_turn_rejected_says_every_turn_is_refused_and_names_the_line (__main__.TestComposeMessage.test_turn_rejected_says_every_turn_is_refused_and_names_the_line)
FAIL: test_turn_rejected_unknown_line_falls_back_to_the_terminal (__main__.TestComposeMessage.test_turn_rejected_unknown_line_falls_back_to_the_terminal)
Ran 73 tests in 0.147s
FAILED (failures=3)
    AssertionError: 'refuses every turn' not found in "⚠️ Agent needs you — awaiting user: turn-rejected: You're out of usage credits. Run /usage-credits to keep using Fable 5.1 or /model to switch models. — answer it where the core is running on <host>. A chat reply can't answer it."
===== HEAD : tests/core-supervisor-relay.test.py
rc=0
Ran 73 tests in 0.128s
OK
```

The control tests (successful last turn, refusal in scrollback, long turn, spinner, no footer, bare footer) pass at main too — they pin that nothing else moved.

The relay notice at HEAD for the issue's line (from `compose_message`, 578 chars):

> ⚠️ Agent needs you — awaiting user: turn-rejected: You're out of usage credits. Run /usage-credits to keep using Fable 5.1 or /model to switch models. — the core sits at its idle prompt but refuses every turn it is sent; each ends in that line, so nothing queued for it runs — the core hit its Claude usage limit, not a login problem; it resumes on its own when the limit window resets. Nothing to do unless you want it sooner: at the core's terminal, /usage-credits spends credits now, signing in under a different subscription starts a fresh allowance, and Esc stops the wait.

## Tests run

```
python3 tests/core-input-watch.test.py            rc=0  Ran 67 tests  OK
python3 tests/core-supervisor-relay.test.py       rc=0  Ran 73 tests  OK
python3 tests/core-input-watch-chat-escalation.test.py   rc=0  Ran 40 tests  OK
python3 tests/core-input-watch-gateway-probe.test.py     rc=0  "Gateway-probe invariants hold." (13 cases)
python3 tests/core-supervisor-gate.test.py        rc=0  Ran 27 tests  OK
python3 tests/health-check-core-supervisor.test.py rc=0  Ran 9 tests   OK
python3 tests/hitl-supervisor.test.py             rc=0  Ran 5 tests   OK
python3 tests/hitl-tui-gate.test.py               rc=0  Ran 21 tests  OK
python3 tests/runtime-health.test.py              rc=0  42 ok lines

bash scripts/review-checks.sh --diff <(git diff origin/main...HEAD)
  review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)   rc=0

coverage run (the two suites) → coverage combine → coverage xml →
diff-cover coverage.xml --compare-branch=origin/main --fail-under=95
  src/core-input-watch.py (100%)   src/core-supervisor-relay.py (100%)
  Total: 39 lines  Missing: 0 lines  Coverage: 100%   rc=0
```

The diff-coverage number above is from the two changed files' own suites, not the full 855-file `scripts/coverage-gate.sh` run; the gate reports only on changed lines, and no other suite would lower it.

## Not covered / not verified

- **Slice 2** (desktop `ceremony_health.rs`: stop re-sending `/startup` on a refusal, raise the Action-needed surface) is separate.
- **No live round trip.** The monitor is a pane classifier, not a bridge or delivery loop, and reproducing the state means exhausting the host's credits; the pane text in the fixture is the owner's screenshot verbatim. The `stable`-tick debounce in `main()` and the relay's one-notice-per-line behaviour are exercised by the existing wiring tests, not by a refusing core.
- The bare `✻ Worked for 0s` done-line shape comes from the captured pane in `tests/runtime-health.test.py`; a CLI version that renders the completed-turn line differently would not match and the pane would stay `idle-ready` (the pre-PR behaviour, never a false escalation).
- Stacked PR: N/A. Hardcoded paths: none added (scanner PASS above).

Refs #4015

— sutando-qingyun-air

🤖 Generated with [Claude Code](https://claude.com/claude-code)
