### PR TITLE
fix(stop-hook): an empty result file is silence, not a reply

### DIFF
--- a/src/check-pending-tasks.sh
+++ b/src/check-pending-tasks.sh
@@ -19,6 +19,12 @@ WORKSPACE="$(bash "$REPO_DIR/scripts/sutando-config.sh" workspace 2>/dev/null)"
 # re-disabling the hook the way the old path did.
 [ -n "$WORKSPACE" ] || WORKSPACE="$REPO_DIR/workspace"
 
+# Resolve the interpreter through the repo's contract: a bare `python3` is absent
+# or wrong on installs using a configured or bundled Python, and the hook would
+# then emit nothing for a nonempty queue — a guard that silently cannot fire.
+PYBIN="$(bash "$REPO_DIR/scripts/sutando-config.sh" python-bin 2>/dev/null)"
+[ -n "$PYBIN" ] && [ -x "$PYBIN" ] || PYBIN="python3"
+
 TASKS_DIR="$WORKSPACE/tasks"
 RESULTS_DIR="$WORKSPACE/results"
 
@@ -38,7 +44,7 @@ if [ -n "$UNPROCESSED" ]; then
   # Encode with a real JSON encoder. Hand-rolled escaping emitted this format
   # string's own \n as a raw newline inside a JSON string value, which is
   # illegal, so every block decision was unparseable and the guard never fired.
-  SUTANDO_HOOK_BODY="$UNPROCESSED" python3 -c 'import json,os,sys; sys.stdout.write(json.dumps({"decision":"block","reason":"Unprocessed tasks in tasks/","additionalContext":"UNPROCESSED TASKS — process these NOW:\n"+os.environ.get("SUTANDO_HOOK_BODY","")}, separators=(",",":"), ensure_ascii=False))'
+  SUTANDO_HOOK_BODY="$UNPROCESSED" "$PYBIN" -c 'import json,os,sys; sys.stdout.write(json.dumps({"decision":"block","reason":"Unprocessed tasks in tasks/","additionalContext":"UNPROCESSED TASKS — process these NOW:\n"+os.environ.get("SUTANDO_HOOK_BODY","")}, separators=(",",":"), ensure_ascii=False))'
 else
   echo '{}'
 fi

--- a/src/check-pending-tasks.sh
+++ b/src/check-pending-tasks.sh
@@ -28,11 +28,17 @@ for f in "$TASKS_DIR"/*.txt; do
   BASENAME=$(basename "$f")
   # Skip if result already exists
   [ -f "$RESULTS_DIR/$BASENAME" ] && continue
-  UNPROCESSED+="--- $BASENAME ---\n$(cat "$f")\n\n"
+  UNPROCESSED+="--- $BASENAME ---
+$(cat "$f")
+
+"
 done
 
 if [ -n "$UNPROCESSED" ]; then
-  printf '{"decision":"block","reason":"Unprocessed tasks in tasks/","additionalContext":"UNPROCESSED TASKS — process these NOW:\n%s"}' "$(echo -e "$UNPROCESSED" | sed 's/"/\\"/g' | tr '\n' ' ')"
+  # Encode with a real JSON encoder. Hand-rolled escaping emitted this format
+  # string's own \n as a raw newline inside a JSON string value, which is
+  # illegal, so every block decision was unparseable and the guard never fired.
+  SUTANDO_HOOK_BODY="$UNPROCESSED" python3 -c 'import json,os,sys; sys.stdout.write(json.dumps({"decision":"block","reason":"Unprocessed tasks in tasks/","additionalContext":"UNPROCESSED TASKS — process these NOW:\n"+os.environ.get("SUTANDO_HOOK_BODY","")}))'
 else
   echo '{}'
 fi

--- a/src/check-pending-tasks.sh
+++ b/src/check-pending-tasks.sh
@@ -26,8 +26,15 @@ UNPROCESSED=""
 shopt -s nullglob 2>/dev/null
 for f in "$TASKS_DIR"/*.txt; do
   BASENAME=$(basename "$f")
-  # Skip if result already exists
-  [ -f "$RESULTS_DIR/$BASENAME" ] && continue
+  # A result must carry something. An empty (or whitespace-only) file satisfied the
+  # existence check while delivering silence, which is the failure this hook exists to catch.
+  if [ -f "$RESULTS_DIR/$BASENAME" ]; then
+    if [ -n "$(tr -d '[:space:]' < "$RESULTS_DIR/$BASENAME" 2>/dev/null)" ]; then continue; fi
+    UNPROCESSED+="--- $BASENAME (result file is EMPTY — it delivers nothing; write a real reply) ---
+
+"
+    continue
+  fi
   UNPROCESSED+="--- $BASENAME ---
 $(cat "$f")
 

--- a/src/check-pending-tasks.sh
+++ b/src/check-pending-tasks.sh
@@ -19,11 +19,12 @@ WORKSPACE="$(bash "$REPO_DIR/scripts/sutando-config.sh" workspace 2>/dev/null)"
 # re-disabling the hook the way the old path did.
 [ -n "$WORKSPACE" ] || WORKSPACE="$REPO_DIR/workspace"
 
-# Resolve the interpreter through the repo's contract: a bare `python3` is absent
-# or wrong on installs using a configured or bundled Python, and the hook would
-# then emit nothing for a nonempty queue — a guard that silently cannot fire.
-PYBIN="$(bash "$REPO_DIR/scripts/sutando-config.sh" python-bin 2>/dev/null)"
-[ -n "$PYBIN" ] && [ -x "$PYBIN" ] || PYBIN="python3"
+# The resolver owns which interpreter is usable; a bare `python3` is wrong on a
+# configured install and re-enters the CLT stub it refused, so a refusal stands.
+if ! PYBIN="$(bash "$REPO_DIR/scripts/sutando-config.sh" python-bin 2>/dev/null)" \
+   || [ -z "$PYBIN" ] || [ ! -x "$PYBIN" ]; then
+  PYBIN=""
+fi
 
 TASKS_DIR="$WORKSPACE/tasks"
 RESULTS_DIR="$WORKSPACE/results"
@@ -40,10 +41,14 @@ $(cat "$f")
 "
 done
 
-if [ -n "$UNPROCESSED" ]; then
-  # Encode with a real JSON encoder. Hand-rolled escaping emitted this format
-  # string's own \n as a raw newline inside a JSON string value, which is
-  # illegal, so every block decision was unparseable and the guard never fired.
+if [ -n "$UNPROCESSED" ] && [ -z "$PYBIN" ]; then
+  # Encoding needs an interpreter the resolver would not supply. Say so on stderr
+  # and allow the stop: a hand-rolled JSON block is what made this guard unparseable.
+  echo "check-pending-tasks: no usable interpreter; queue not reported" >&2
+  echo '{}'
+elif [ -n "$UNPROCESSED" ]; then
+  # A real JSON encoder: hand-rolled escaping put a raw newline inside a string
+  # value, so every block decision was unparseable and the guard never fired.
   SUTANDO_HOOK_BODY="$UNPROCESSED" "$PYBIN" -c 'import json,os,sys; sys.stdout.write(json.dumps({"decision":"block","reason":"Unprocessed tasks in tasks/","additionalContext":"UNPROCESSED TASKS — process these NOW:\n"+os.environ.get("SUTANDO_HOOK_BODY","")}, separators=(",",":"), ensure_ascii=False))'
 else
   echo '{}'

--- a/src/check-pending-tasks.sh
+++ b/src/check-pending-tasks.sh
@@ -38,7 +38,7 @@ if [ -n "$UNPROCESSED" ]; then
   # Encode with a real JSON encoder. Hand-rolled escaping emitted this format
   # string's own \n as a raw newline inside a JSON string value, which is
   # illegal, so every block decision was unparseable and the guard never fired.
-  SUTANDO_HOOK_BODY="$UNPROCESSED" python3 -c 'import json,os,sys; sys.stdout.write(json.dumps({"decision":"block","reason":"Unprocessed tasks in tasks/","additionalContext":"UNPROCESSED TASKS — process these NOW:\n"+os.environ.get("SUTANDO_HOOK_BODY","")}))'
+  SUTANDO_HOOK_BODY="$UNPROCESSED" python3 -c 'import json,os,sys; sys.stdout.write(json.dumps({"decision":"block","reason":"Unprocessed tasks in tasks/","additionalContext":"UNPROCESSED TASKS — process these NOW:\n"+os.environ.get("SUTANDO_HOOK_BODY","")}, separators=(",",":"), ensure_ascii=False))'
 else
   echo '{}'
 fi

--- a/src/check-pending-tasks.sh
+++ b/src/check-pending-tasks.sh
@@ -32,10 +32,10 @@ UNPROCESSED=""
 shopt -s nullglob 2>/dev/null
 for f in "$TASKS_DIR"/*.txt; do
   BASENAME=$(basename "$f")
-  # A result must carry something. An empty (or whitespace-only) file satisfied the
-  # existence check while delivering silence, which is the failure this hook exists to catch.
+  # Readiness is owned by src/delivery/readiness.py, the same policy every delivery
+  # consumer uses; a local re-implementation drifts from what will actually be sent.
   if [ -f "$RESULTS_DIR/$BASENAME" ]; then
-    if [ -n "$(tr -d '[:space:]' < "$RESULTS_DIR/$BASENAME" 2>/dev/null)" ]; then continue; fi
+    if SUTANDO_SRC="$REPO_DIR/src" SUTANDO_RESULT="$RESULTS_DIR/$BASENAME" "$PYBIN" -c 'import os,sys; sys.path.insert(0, os.environ["SUTANDO_SRC"]); from delivery.readiness import read_ready_result; sys.exit(0 if read_ready_result(os.environ["SUTANDO_RESULT"]) is not None else 1)'; then continue; fi
     UNPROCESSED+="--- $BASENAME (result file is EMPTY — it delivers nothing; write a real reply) ---
 
 "

--- a/tests/check-pending-tasks-workspace.test.sh
+++ b/tests/check-pending-tasks-workspace.test.sh
@@ -123,5 +123,29 @@ case "$OUT" in
   *) bad "empty queue emits {}" "got: ${OUT:0:120}" ;;
 esac
 
+# 6. THE REJECTION PATH. When the resolver refuses an interpreter the hook must
+# not execute a bare `python3` — that is the CLT stub the resolver just declined.
+REJ="$(mktemp -d)"
+mkdir -p "$REJ/scripts" "$REJ/src" "$REJ/workspace/tasks" "$REJ/workspace/results"
+printf '#!/bin/bash\n[ "$1" = "workspace" ] && { echo "%s/workspace"; exit 0; }\nexit 1\n' "$REJ" \
+  > "$REJ/scripts/sutando-config.sh"
+chmod +x "$REJ/scripts/sutando-config.sh"
+cp "$HOOK" "$REJ/src/"
+printf 'id: probe\ntask: rejected-interpreter\n' > "$REJ/workspace/tasks/$PROBE"
+# A recording shim: if the hook falls back to PATH python this fires.
+printf '#!/bin/bash\necho FALLBACK_INVOKED >&2\nexit 79\n' > "$REJ/python3"
+chmod +x "$REJ/python3"
+REJ_ERR="$(PATH="$REJ:$PATH" bash "$REJ/src/$(basename "$HOOK")" 2>&1 >/dev/null)"
+REJ_OUT="$(PATH="$REJ:$PATH" bash "$REJ/src/$(basename "$HOOK")" 2>/dev/null)"
+case "$REJ_ERR" in
+  *FALLBACK_INVOKED*) bad "a refused interpreter is not worked around" "the bare python3 fallback ran" ;;
+  *) ok "a refused interpreter is not worked around" ;;
+esac
+case "$REJ_OUT" in
+  '{}') ok "a refused interpreter still emits valid JSON" ;;
+  *) bad "a refused interpreter still emits valid JSON" "got: ${REJ_OUT:0:120}" ;;
+esac
+rm -rf "$REJ"
+
 if [ "$FAILED" -eq 0 ]; then echo "PASS"; else echo "FAIL"; fi
 exit "$FAILED"

--- a/tests/stop-hook-emits-valid-json.test.py
+++ b/tests/stop-hook-emits-valid-json.test.py
@@ -17,6 +17,11 @@ Also pins body fidelity. The old escaping ran `sed 's/"/\\"/g' | tr '\n' ' '`,
 which left backslashes unescaped — a task body containing one would break the
 JSON again by a different route.
 
+This asserts the SEMANTICS (the response parses). `check-pending-tasks-workspace.test.sh`
+asserts the WIRE SHAPE, matching the literal `"decision":"block"` — so the encoder must keep
+compact separators and `ensure_ascii=False`. Both properties are required; neither implies
+the other, and a first pass at this fix passed here while breaking that sibling suite.
+
 Run: python3 tests/stop-hook-emits-valid-json.test.py
 """
 from __future__ import annotations

--- a/tests/stop-hook-emits-valid-json.test.py
+++ b/tests/stop-hook-emits-valid-json.test.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""The Stop hook's block decision must be parseable JSON.
+
+`src/check-pending-tasks.sh` built its response by hand, and the `\n` in the
+printf FORMAT string was emitted as a raw newline inside a JSON string value.
+Raw control characters are illegal there, so the client could not parse the
+response and printed `stop hook error` instead. The guard exists to stop the
+agent going idle with unanswered tasks; because every block decision was
+unparseable, it had never once fired.
+
+The empty-queue path returns `{}` and always parsed, which is why nothing
+caught this: the failure appears ONLY when the hook has something to say. So
+this asserts against a NON-EMPTY queue, and pins that the block actually fires
+(a fixture that produced `{}` would pass while proving nothing).
+
+Also pins body fidelity. The old escaping ran `sed 's/"/\\"/g' | tr '\n' ' '`,
+which left backslashes unescaped — a task body containing one would break the
+JSON again by a different route.
+
+Run: python3 tests/stop-hook-emits-valid-json.test.py
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import tempfile
+
+HOOK = pathlib.Path(__file__).resolve().parent.parent / "src" / "check-pending-tasks.sh"
+RESOLVE = 'WORKSPACE="$(bash "$REPO_DIR/scripts/sutando-config.sh" workspace 2>/dev/null)"'
+
+BODY = 'a body with "quotes", a backslash \\ and\na second line\n'
+
+
+def _run(workspace: pathlib.Path) -> str:
+    """Run the real hook against `workspace`, pinning its resolver to it."""
+    src = HOOK.read_text()
+    assert RESOLVE in src, "workspace resolution line moved; update this test"
+    stub = workspace / "hook.sh"
+    stub.write_text(src.replace(RESOLVE, f'WORKSPACE="{workspace}"'))
+    out = subprocess.run(
+        ["bash", str(stub)], capture_output=True, text=True, stdin=subprocess.DEVNULL
+    )
+    assert out.returncode == 0, f"hook exited {out.returncode}: {out.stderr}"
+    return out.stdout
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = pathlib.Path(tmp)
+        (ws / "tasks").mkdir()
+        (ws / "results").mkdir()
+
+        # Empty queue: the path that always parsed, kept so a regression here is visible too.
+        assert json.loads(_run(ws)) == {}, "empty queue must emit {}"
+
+        (ws / "tasks" / "task-1.txt").write_text(f"id: task-1\ntask: {BODY}")
+        raw = _run(ws)
+
+        decision = json.loads(raw)  # the assertion: unparseable output fails here
+        assert decision["decision"] == "block", (
+            f"fixture did not make the guard fire: {decision!r}"
+        )
+
+        ctx = decision["additionalContext"]
+        for label, needle in (("quotes", '"quotes"'), ("backslash", "\\"), ("newline", "\n")):
+            assert needle in ctx, f"task body lost its {label}"
+
+    print("stop-hook-emits-valid-json: PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/stop-hook-emits-valid-json.test.py
+++ b/tests/stop-hook-emits-valid-json.test.py
@@ -71,6 +71,16 @@ def main() -> None:
         for label, needle in (("quotes", '"quotes"'), ("backslash", "\\"), ("newline", "\n")):
             assert needle in ctx, f"task body lost its {label}"
 
+        # An empty result satisfied the old existence check while delivering silence.
+        # `[no-send]` must keep passing: it is deliberate protocol, not an absent reply.
+        for body, should_block in (("", True), ("  \n\t\n", True),
+                                   ("[no-send]\n", False), ("a real answer\n", False)):
+            (ws / "results" / "task-1.txt").write_text(body)
+            blocked = json.loads(_run(ws)) != {}
+            assert blocked is should_block, (
+                f"result {body!r}: blocked={blocked}, expected {should_block}"
+            )
+
     print("stop-hook-emits-valid-json: PASS")
 
 

--- a/tests/stop-hook-emits-valid-json.test.py
+++ b/tests/stop-hook-emits-valid-json.test.py
@@ -27,22 +27,39 @@ Run: python3 tests/stop-hook-emits-valid-json.test.py
 from __future__ import annotations
 
 import json
+import os
 import pathlib
 import subprocess
+import sys
 import tempfile
 
 HOOK = pathlib.Path(__file__).resolve().parent.parent / "src" / "check-pending-tasks.sh"
 RESOLVE = 'WORKSPACE="$(bash "$REPO_DIR/scripts/sutando-config.sh" workspace 2>/dev/null)"'
+REPO_LINE = 'REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"'
+REPO = HOOK.resolve().parent.parent
+
+
+def _stub(ws: pathlib.Path) -> pathlib.Path:
+    """The hook, pinned to this repo and the given workspace.
+
+    REPO_DIR must be pinned too: run from a temp dir, `dirname $0/..` points
+    outside the repo, so `sutando-config.sh` is never found and the interpreter
+    cascade silently falls back to PATH — the test would then measure the
+    fallback rather than the contract.
+    """
+    src = HOOK.read_text()
+    assert RESOLVE in src and REPO_LINE in src, "hook layout moved; update this test"
+    src = src.replace(REPO_LINE, f'REPO_DIR="{REPO}"').replace(RESOLVE, f'WORKSPACE="{ws}"')
+    stub = ws / "hook.sh"
+    stub.write_text(src)
+    return stub
 
 BODY = 'a body with "quotes", a backslash \\ and\na second line\n'
 
 
 def _run(workspace: pathlib.Path) -> str:
     """Run the real hook against `workspace`, pinning its resolver to it."""
-    src = HOOK.read_text()
-    assert RESOLVE in src, "workspace resolution line moved; update this test"
-    stub = workspace / "hook.sh"
-    stub.write_text(src.replace(RESOLVE, f'WORKSPACE="{workspace}"'))
+    stub = _stub(workspace)
     out = subprocess.run(
         ["bash", str(stub)], capture_output=True, text=True, stdin=subprocess.DEVNULL
     )
@@ -71,7 +88,46 @@ def main() -> None:
         for label, needle in (("quotes", '"quotes"'), ("backslash", "\\"), ("newline", "\n")):
             assert needle in ctx, f"task body lost its {label}"
 
+    _test_broken_path_still_blocks()
     print("stop-hook-emits-valid-json: PASS")
+
+
+def _test_broken_path_still_blocks() -> None:
+    """A configured interpreter must win over a broken `python3` on PATH.
+
+    `scripts/python-binary.sh` resolves $SUTANDO_PY, then the bundled runtime,
+    then PATH — so an install with a configured Python must not be defeated by
+    whatever `python3` happens to resolve to. A bare `python3` in the hook
+    ignored that cascade and emitted nothing for a nonempty queue.
+
+    PATH is shadowed, not emptied: emptying removes `cat` and the config helper,
+    so the hook would fail for reasons unrelated to the contract under test.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = pathlib.Path(tmp)
+        (ws / "tasks").mkdir()
+        (ws / "results").mkdir()
+        (ws / "tasks" / "task-1.txt").write_text("id: task-1\ntask: answer me\n")
+
+        stub = _stub(ws)
+
+        shim = ws / "bin"
+        shim.mkdir()
+        broken = shim / "python3"
+        broken.write_text("#!/bin/sh\necho 'wrong interpreter' >&2\nexit 127\n")
+        broken.chmod(0o755)
+
+        env = dict(
+            os.environ,
+            PATH=f"{shim}:{os.environ.get('PATH', '')}",
+            SUTANDO_PY=sys.executable,
+        )
+        out = subprocess.run(["/bin/bash", str(stub)], capture_output=True, text=True,
+                             stdin=subprocess.DEVNULL, env=env)
+        assert out.returncode == 0, f"hook exited {out.returncode}: {out.stderr}"
+        assert json.loads(out.stdout)["decision"] == "block", (
+            f"a broken python3 on PATH defeated the configured interpreter: {out.stdout!r}"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/stop-hook-emits-valid-json.test.py
+++ b/tests/stop-hook-emits-valid-json.test.py
@@ -89,6 +89,7 @@ def main() -> None:
             assert needle in ctx, f"task body lost its {label}"
 
     _test_broken_path_still_blocks()
+    _test_result_readiness_matches_the_delivery_owner()
     print("stop-hook-emits-valid-json: PASS")
 
 
@@ -128,6 +129,45 @@ def _test_broken_path_still_blocks() -> None:
         assert json.loads(out.stdout)["decision"] == "block", (
             f"a broken python3 on PATH defeated the configured interpreter: {out.stdout!r}"
         )
+
+
+def _test_result_readiness_matches_the_delivery_owner() -> None:
+    """Readiness is owned by src/delivery/readiness.py, the policy every delivery
+    consumer uses. A local `tr -d '[:space:]'` diverges from it under LC_ALL=C:
+    NBSP/EM SPACE and undecodable bytes read as content, so Stop succeeds on a
+    result no consumer will ever send.
+
+    LC_ALL=C is set deliberately. Under a UTF-8 locale BSD tr yields empty for
+    these inputs and coincides with the helper, so the cases cannot tell the two
+    apart — an earlier version of this test inherited UTF-8 and passed against
+    the very implementation it was written to reject.
+
+    `[no-send]` must stay ready: deliberate protocol, not an absent reply.
+    """
+    env = dict(os.environ, LC_ALL="C", LANG="C")
+    cases = [
+        (b"", True, "empty"),
+        (b"  \n\t\n", True, "ascii whitespace"),
+        ("\u00a0\u2003\n".encode(), True, "NBSP + EM SPACE"),
+        (b"\xff\xfe\n", True, "undecodable bytes"),
+        (b"[no-send]\n", False, "no-send protocol"),
+        (b"a real answer\n", False, "real reply"),
+    ]
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = pathlib.Path(tmp)
+        (ws / "tasks").mkdir()
+        (ws / "results").mkdir()
+        (ws / "tasks" / "task-1.txt").write_text("id: task-1\ntask: answer me\n")
+        stub = _stub(ws)
+        for body, should_block, label in cases:
+            (ws / "results" / "task-1.txt").write_bytes(body)
+            out = subprocess.run(["/bin/bash", str(stub)], capture_output=True,
+                                 text=True, stdin=subprocess.DEVNULL, env=env)
+            assert out.returncode == 0, f"{label}: hook exited {out.returncode}"
+            blocked = json.loads(out.stdout or "{}") != {}
+            assert blocked is should_block, (
+                f"{label}: blocked={blocked}, expected {should_block}"
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

The guard skipped a task whenever `results/<id>.txt` existed — whatever it contained. So an **empty file bought a clean stop while delivering silence**: the exact failure the hook exists to catch, wearing the shape of an answer.

The owner found this by asking the right question — whether the hook ensures he is actually replied to, since he does not read the terminal. It does not, and this closes the part that is closable at stop time.

## Behaviour, measured

| result file | before | after |
|---|---|---|
| absent | blocks | blocks |
| empty | **satisfied** | **blocks** |
| whitespace only | **satisfied** | **blocks** |
| `[no-send]` | satisfied | satisfied |
| real reply | satisfied | satisfied |

`[no-send]` and channel redirects must keep passing — they are deliberate protocol with real content, not an absent reply.

## What this deliberately does NOT do

It does not verify the reply reached the right channel, and it cannot verify delivery at all: the send happens later in a separate process, so nothing evaluated at stop time can know the outcome. This is a floor against silence, not a guarantee of service. A delivery check is a different mechanism and is not attempted here.

## Test

Extends `tests/stop-hook-emits-valid-json.test.py` with the table above, mutation-checked:

```
$ # with the parent commit's version of the hook
AssertionError: result '': blocked=False, expected True

$ # with this change
stop-hook-emits-valid-json: PASS
```

`tests/check-pending-tasks-workspace.test.sh` (the sibling that pins the wire shape) also passes, and `scripts/review-checks.sh` is clean on the staged diff.

## Stacked

Parent: #4024 (`fix/stop-hook-emits-invalid-json`). **Merge #4024 first**; I will rebase and rerun checks here after it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
