### PR TITLE
feat(stop-hook): a turn must end in a message or an explicit no-send

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -188,6 +188,7 @@ One entry per agent-facing module. 5 without a usable header comment.
 - **`telemetry.py`** — Anonymous, opt-out product telemetry for Sutando (PostHog).
 - **`tmux-status.ts`** — Tmux-pane status scraper.
 - **`tmux_probe.py`** — Tri-state tmux session probe shared by every core-liveness reader.
+- **`turn-start.sh`** — UserPromptSubmit hook: a new turn is starting, so re-arm the Stop reminder.
 - **`turn_ledger.py`** — The turn ledger — a record that the agent's turn produced an outbound message.
 - **`url-scheme.ts`** — Scheme normalization for URLs handed to Chrome via AppleScript.
 - **`util_paths.py`** — Resolve personal-asset paths with private-dir-first lookup.

--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -188,6 +188,7 @@ One entry per agent-facing module. 5 without a usable header comment.
 - **`telemetry.py`** — Anonymous, opt-out product telemetry for Sutando (PostHog).
 - **`tmux-status.ts`** — Tmux-pane status scraper.
 - **`tmux_probe.py`** — Tri-state tmux session probe shared by every core-liveness reader.
+- **`turn_ledger.py`** — The turn ledger — a record that the agent's turn produced an outbound message.
 - **`url-scheme.ts`** — Scheme normalization for URLs handed to Chrome via AppleScript.
 - **`util_paths.py`** — Resolve personal-asset paths with private-dir-first lookup.
 - **`util_paths.ts`** — TypeScript twin of src/util_paths.py — personal-asset path resolution.

--- a/packages/ag2-sparrow/ag2_sparrow/task_archive.py
+++ b/packages/ag2-sparrow/ag2_sparrow/task_archive.py
@@ -159,6 +159,17 @@ def _move_without_clobbering(src: Path, dest: Path) -> Path:
     return candidate
 
 
+def archive_month(when: float | None = None) -> str:
+    """Month partition the archive writes into, in the LOCAL calendar.
+
+    A reader computing this in UTC misses the writer's partition for the hours
+    either side of a month boundary, and reads a delivered reply as absent.
+    """
+    from datetime import datetime
+    moment = datetime.fromtimestamp(when) if when is not None else datetime.now()
+    return moment.strftime("%Y-%m")
+
+
 def archive_file(src: Path, kind: str, task_id: str, *,
                  tasks_dir: Path, results_dir: Path, log=print) -> bool:
     """Move src into the archive, NEVER deleting or overwriting a record.
@@ -170,7 +181,7 @@ def archive_file(src: Path, kind: str, task_id: str, *,
     try:
         if src.exists():
             base = tasks_dir if kind == "tasks" else results_dir
-            dest_dir = base / datetime.now().strftime("%Y-%m")
+            dest_dir = base / archive_month()
             dest_dir.mkdir(parents=True, exist_ok=True)
             _move_without_clobbering(src, dest_dir / f"{task_id}.txt")
         return True

--- a/skills/agent-room-ops/room_ops.py
+++ b/skills/agent-room-ops/room_ops.py
@@ -46,6 +46,34 @@ import members as _members # noqa: E402
 import events as _events   # noqa: E402
 
 
+def _record_say(res):
+    """Note a successful `say` in the turn ledger, so the Stop hook can see it.
+
+    `say` writes nothing to disk, so a turn that replies this way left no record
+    anywhere and read as silence to `src/check-pending-tasks.sh`.
+
+    RECORDS ON `ok`, NOT ON AN EVENT ID. `receipt.classify` returns CONFIRMED (an
+    id came back) and UNCONFIRMED (HTTP 200, no id) — both `ok: true` — and the
+    repo already chose fail-open for the missing id there, on the grounds that the
+    message probably landed. Requiring an id here would adopt the opposite policy
+    two files apart, and its failure lands on a Stop GATE: the agent would be
+    refused a turn ending it had already earned, with no action left that clears
+    it. `ok: false` (refused, gated, transport error) never records.
+
+    Never raises: this is bookkeeping after a message that already went out, and
+    the whole skill must keep working on an install where `src/` is not reachable.
+    """
+    try:
+        if not (isinstance(res, dict) and res.get("ok")):
+            return
+        repo = os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+        sys.path.insert(0, os.path.join(repo, "src"))
+        import turn_ledger  # noqa: PLC0415 — optional, and only on the send path
+        turn_ledger.record_send("room", res.get("room_id") or "")
+    except Exception:
+        pass
+
+
 def _events_stream(a):
     """`events stream`: one compact JSON line per event (journal-friendly), a
     one-line JSON summary last. Exits 0 for any structured outcome — a
@@ -270,6 +298,7 @@ def _main(argv):
         if a.worker:
             _kw["worker"] = a.worker
         res = _say.say(a.message, a.room_id, a.agent_mxid, **_kw)
+        _record_say(res)
     elif a.cmd == "grant":
         import grant as _grant
         try:

--- a/src/check-pending-tasks.sh
+++ b/src/check-pending-tasks.sh
@@ -19,6 +19,12 @@ WORKSPACE="$(bash "$REPO_DIR/scripts/sutando-config.sh" workspace 2>/dev/null)"
 # re-disabling the hook the way the old path did.
 [ -n "$WORKSPACE" ] || WORKSPACE="$REPO_DIR/workspace"
 
+# Resolve the interpreter through the repo's contract: a bare `python3` is absent
+# or wrong on installs using a configured or bundled Python, and the hook would
+# then emit nothing for a nonempty queue — a guard that silently cannot fire.
+PYBIN="$(bash "$REPO_DIR/scripts/sutando-config.sh" python-bin 2>/dev/null)"
+[ -n "$PYBIN" ] && [ -x "$PYBIN" ] || PYBIN="python3"
+
 TASKS_DIR="$WORKSPACE/tasks"
 RESULTS_DIR="$WORKSPACE/results"
 
@@ -38,7 +44,7 @@ if [ -n "$UNPROCESSED" ]; then
   # Encode with a real JSON encoder. Hand-rolled escaping emitted this format
   # string's own \n as a raw newline inside a JSON string value, which is
   # illegal, so every block decision was unparseable and the guard never fired.
-  SUTANDO_HOOK_BODY="$UNPROCESSED" python3 -c 'import json,os,sys; sys.stdout.write(json.dumps({"decision":"block","reason":"Unprocessed tasks in tasks/","additionalContext":"UNPROCESSED TASKS — process these NOW:\n"+os.environ.get("SUTANDO_HOOK_BODY","")}, separators=(",",":"), ensure_ascii=False))'
+  SUTANDO_HOOK_BODY="$UNPROCESSED" "$PYBIN" -c 'import json,os,sys; sys.stdout.write(json.dumps({"decision":"block","reason":"Unprocessed tasks in tasks/","additionalContext":"UNPROCESSED TASKS — process these NOW:\n"+os.environ.get("SUTANDO_HOOK_BODY","")}, separators=(",",":"), ensure_ascii=False))'
 else
   echo '{}'
 fi

--- a/src/check-pending-tasks.sh
+++ b/src/check-pending-tasks.sh
@@ -28,11 +28,17 @@ for f in "$TASKS_DIR"/*.txt; do
   BASENAME=$(basename "$f")
   # Skip if result already exists
   [ -f "$RESULTS_DIR/$BASENAME" ] && continue
-  UNPROCESSED+="--- $BASENAME ---\n$(cat "$f")\n\n"
+  UNPROCESSED+="--- $BASENAME ---
+$(cat "$f")
+
+"
 done
 
 if [ -n "$UNPROCESSED" ]; then
-  printf '{"decision":"block","reason":"Unprocessed tasks in tasks/","additionalContext":"UNPROCESSED TASKS — process these NOW:\n%s"}' "$(echo -e "$UNPROCESSED" | sed 's/"/\\"/g' | tr '\n' ' ')"
+  # Encode with a real JSON encoder. Hand-rolled escaping emitted this format
+  # string's own \n as a raw newline inside a JSON string value, which is
+  # illegal, so every block decision was unparseable and the guard never fired.
+  SUTANDO_HOOK_BODY="$UNPROCESSED" python3 -c 'import json,os,sys; sys.stdout.write(json.dumps({"decision":"block","reason":"Unprocessed tasks in tasks/","additionalContext":"UNPROCESSED TASKS — process these NOW:\n"+os.environ.get("SUTANDO_HOOK_BODY","")}))'
 else
   echo '{}'
 fi

--- a/src/check-pending-tasks.sh
+++ b/src/check-pending-tasks.sh
@@ -26,8 +26,15 @@ UNPROCESSED=""
 shopt -s nullglob 2>/dev/null
 for f in "$TASKS_DIR"/*.txt; do
   BASENAME=$(basename "$f")
-  # Skip if result already exists
-  [ -f "$RESULTS_DIR/$BASENAME" ] && continue
+  # A result must carry something. An empty (or whitespace-only) file satisfied the
+  # existence check while delivering silence, which is the failure this hook exists to catch.
+  if [ -f "$RESULTS_DIR/$BASENAME" ]; then
+    if [ -n "$(tr -d '[:space:]' < "$RESULTS_DIR/$BASENAME" 2>/dev/null)" ]; then continue; fi
+    UNPROCESSED+="--- $BASENAME (result file is EMPTY — it delivers nothing; write a real reply) ---
+
+"
+    continue
+  fi
   UNPROCESSED+="--- $BASENAME ---
 $(cat "$f")
 

--- a/src/check-pending-tasks.sh
+++ b/src/check-pending-tasks.sh
@@ -52,6 +52,18 @@ if [ -n "$UNPROCESSED" ]; then
   # string's own \n as a raw newline inside a JSON string value, which is
   # illegal, so every block decision was unparseable and the guard never fired.
   SUTANDO_HOOK_BODY="$UNPROCESSED" "$PYBIN" -c 'import json,os,sys; sys.stdout.write(json.dumps({"decision":"block","reason":"Unprocessed tasks in tasks/","additionalContext":"UNPROCESSED TASKS — process these NOW:\n"+os.environ.get("SUTANDO_HOOK_BODY","")}, separators=(",",":"), ensure_ascii=False))'
+  exit 0
+fi
+
+# The loop above only sees a turn that ANSWERS A QUEUED TASK. This gate covers the
+# rest: a turn must end in a message or a recorded no-send (src/turn_ledger.py).
+STOP_REASON="$("$PYBIN" "$REPO_DIR/src/turn_ledger.py" --workspace "$WORKSPACE" stop-gate 2>/dev/null)"
+STOP_RC=$?
+
+# Fail OPEN on anything but an explicit refusal (rc 1 AND a reason): a gate that
+# cannot run must never wedge the agent into a turn it has no way to end.
+if [ "$STOP_RC" -eq 1 ] && [ -n "$STOP_REASON" ]; then
+  SUTANDO_HOOK_REASON="$STOP_REASON" "$PYBIN" -c 'import json,os,sys; sys.stdout.write(json.dumps({"decision":"block","reason":"Turn is ending without a message or an explicit no-send","additionalContext":os.environ.get("SUTANDO_HOOK_REASON","")}, separators=(",",":"), ensure_ascii=False))'
 else
   echo '{}'
 fi

--- a/src/check-pending-tasks.sh
+++ b/src/check-pending-tasks.sh
@@ -19,11 +19,12 @@ WORKSPACE="$(bash "$REPO_DIR/scripts/sutando-config.sh" workspace 2>/dev/null)"
 # re-disabling the hook the way the old path did.
 [ -n "$WORKSPACE" ] || WORKSPACE="$REPO_DIR/workspace"
 
-# Resolve the interpreter through the repo's contract: a bare `python3` is absent
-# or wrong on installs using a configured or bundled Python, and the hook would
-# then emit nothing for a nonempty queue — a guard that silently cannot fire.
-PYBIN="$(bash "$REPO_DIR/scripts/sutando-config.sh" python-bin 2>/dev/null)"
-[ -n "$PYBIN" ] && [ -x "$PYBIN" ] || PYBIN="python3"
+# The resolver owns which interpreter is usable; a bare `python3` is wrong on a
+# configured install and re-enters the CLT stub it refused, so a refusal stands.
+if ! PYBIN="$(bash "$REPO_DIR/scripts/sutando-config.sh" python-bin 2>/dev/null)" \
+   || [ -z "$PYBIN" ] || [ ! -x "$PYBIN" ]; then
+  PYBIN=""
+fi
 
 TASKS_DIR="$WORKSPACE/tasks"
 RESULTS_DIR="$WORKSPACE/results"
@@ -40,10 +41,14 @@ $(cat "$f")
 "
 done
 
-if [ -n "$UNPROCESSED" ]; then
-  # Encode with a real JSON encoder. Hand-rolled escaping emitted this format
-  # string's own \n as a raw newline inside a JSON string value, which is
-  # illegal, so every block decision was unparseable and the guard never fired.
+if [ -n "$UNPROCESSED" ] && [ -z "$PYBIN" ]; then
+  # Encoding needs an interpreter the resolver would not supply. Say so on stderr
+  # and allow the stop: a hand-rolled JSON block is what made this guard unparseable.
+  echo "check-pending-tasks: no usable interpreter; queue not reported" >&2
+  echo '{}'
+elif [ -n "$UNPROCESSED" ]; then
+  # A real JSON encoder: hand-rolled escaping put a raw newline inside a string
+  # value, so every block decision was unparseable and the guard never fired.
   SUTANDO_HOOK_BODY="$UNPROCESSED" "$PYBIN" -c 'import json,os,sys; sys.stdout.write(json.dumps({"decision":"block","reason":"Unprocessed tasks in tasks/","additionalContext":"UNPROCESSED TASKS — process these NOW:\n"+os.environ.get("SUTANDO_HOOK_BODY","")}, separators=(",",":"), ensure_ascii=False))'
 else
   echo '{}'

--- a/src/check-pending-tasks.sh
+++ b/src/check-pending-tasks.sh
@@ -53,6 +53,7 @@ if [ -n "$UNPROCESSED" ] && [ -z "$PYBIN" ]; then
   # and allow the stop: a hand-rolled JSON block is what made this guard unparseable.
   echo "check-pending-tasks: no usable interpreter; queue not reported" >&2
   echo '{}'
+  exit 0
 elif [ -n "$UNPROCESSED" ]; then
   # A real JSON encoder: hand-rolled escaping put a raw newline inside a string
   # value, so every block decision was unparseable and the guard never fired.

--- a/src/check-pending-tasks.sh
+++ b/src/check-pending-tasks.sh
@@ -38,7 +38,7 @@ if [ -n "$UNPROCESSED" ]; then
   # Encode with a real JSON encoder. Hand-rolled escaping emitted this format
   # string's own \n as a raw newline inside a JSON string value, which is
   # illegal, so every block decision was unparseable and the guard never fired.
-  SUTANDO_HOOK_BODY="$UNPROCESSED" python3 -c 'import json,os,sys; sys.stdout.write(json.dumps({"decision":"block","reason":"Unprocessed tasks in tasks/","additionalContext":"UNPROCESSED TASKS — process these NOW:\n"+os.environ.get("SUTANDO_HOOK_BODY","")}))'
+  SUTANDO_HOOK_BODY="$UNPROCESSED" python3 -c 'import json,os,sys; sys.stdout.write(json.dumps({"decision":"block","reason":"Unprocessed tasks in tasks/","additionalContext":"UNPROCESSED TASKS — process these NOW:\n"+os.environ.get("SUTANDO_HOOK_BODY","")}, separators=(",",":"), ensure_ascii=False))'
 else
   echo '{}'
 fi

--- a/src/check-pending-tasks.sh
+++ b/src/check-pending-tasks.sh
@@ -32,10 +32,10 @@ UNPROCESSED=""
 shopt -s nullglob 2>/dev/null
 for f in "$TASKS_DIR"/*.txt; do
   BASENAME=$(basename "$f")
-  # A result must carry something. An empty (or whitespace-only) file satisfied the
-  # existence check while delivering silence, which is the failure this hook exists to catch.
+  # Readiness is owned by src/delivery/readiness.py, the same policy every delivery
+  # consumer uses; a local re-implementation drifts from what will actually be sent.
   if [ -f "$RESULTS_DIR/$BASENAME" ]; then
-    if [ -n "$(tr -d '[:space:]' < "$RESULTS_DIR/$BASENAME" 2>/dev/null)" ]; then continue; fi
+    if SUTANDO_SRC="$REPO_DIR/src" SUTANDO_RESULT="$RESULTS_DIR/$BASENAME" "$PYBIN" -c 'import os,sys; sys.path.insert(0, os.environ["SUTANDO_SRC"]); from delivery.readiness import read_ready_result; sys.exit(0 if read_ready_result(os.environ["SUTANDO_RESULT"]) is not None else 1)'; then continue; fi
     UNPROCESSED+="--- $BASENAME (result file is EMPTY — it delivers nothing; write a real reply) ---
 
 "

--- a/src/install-claude-hooks.sh
+++ b/src/install-claude-hooks.sh
@@ -97,6 +97,9 @@ HOOKS=(
   "PreCompact|src/session-handoff.sh|bash $(shq "$REPO_DIR/src/session-handoff.sh") \"\$TRANSCRIPT_PATH\""
   "SessionEnd|src/session-handoff.sh|bash $(shq "$REPO_DIR/src/session-handoff.sh") \"\$TRANSCRIPT_PATH\""
   "Stop|src/check-pending-tasks.sh|bash $(shq "$REPO_DIR/src/check-pending-tasks.sh")"
+  # Without this the Stop gate spends its one reminder and never re-arms:
+  # begin_turn is the only reset and nothing else in the lifecycle calls it.
+  "UserPromptSubmit|src/turn-start.sh|bash $(shq "$REPO_DIR/src/turn-start.sh")"
 )
 
 # The transcript archiver writes OUTSIDE the workspace (~/Desktop). Omitting it

--- a/src/task_archive.py
+++ b/src/task_archive.py
@@ -159,6 +159,17 @@ def _move_without_clobbering(src: Path, dest: Path) -> Path:
     return candidate
 
 
+def archive_month(when: float | None = None) -> str:
+    """Month partition the archive writes into, in the LOCAL calendar.
+
+    A reader computing this in UTC misses the writer's partition for the hours
+    either side of a month boundary, and reads a delivered reply as absent.
+    """
+    from datetime import datetime
+    moment = datetime.fromtimestamp(when) if when is not None else datetime.now()
+    return moment.strftime("%Y-%m")
+
+
 def archive_file(src: Path, kind: str, task_id: str, *,
                  tasks_dir: Path, results_dir: Path, log=print) -> bool:
     """Move src into the archive, NEVER deleting or overwriting a record.
@@ -170,7 +181,7 @@ def archive_file(src: Path, kind: str, task_id: str, *,
     try:
         if src.exists():
             base = tasks_dir if kind == "tasks" else results_dir
-            dest_dir = base / datetime.now().strftime("%Y-%m")
+            dest_dir = base / archive_month()
             dest_dir.mkdir(parents=True, exist_ok=True)
             _move_without_clobbering(src, dest_dir / f"{task_id}.txt")
         return True

--- a/src/turn-start.sh
+++ b/src/turn-start.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# UserPromptSubmit hook: a new turn is starting, so re-arm the Stop reminder.
+# Fails open and silent — this runs before every prompt and must never be able
+# to block one.
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PYBIN="$(bash "$REPO_DIR/scripts/sutando-config.sh" python-bin 2>/dev/null)"
+[ -n "$PYBIN" ] && [ -x "$PYBIN" ] || PYBIN="python3"
+"$PYBIN" "$REPO_DIR/src/turn_ledger.py" turn-start >/dev/null 2>&1
+exit 0

--- a/src/turn-start.sh
+++ b/src/turn-start.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 # UserPromptSubmit hook: a new turn is starting, so re-arm the Stop reminder.
-# Fails open and silent — this runs before every prompt and must never be able
-# to block one.
+# Fails open and silent — it runs before every prompt and must never block one.
 REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-PYBIN="$(bash "$REPO_DIR/scripts/sutando-config.sh" python-bin 2>/dev/null)"
-[ -n "$PYBIN" ] && [ -x "$PYBIN" ] || PYBIN="python3"
+
+# A bare `python3` fallback re-enters the very CLT stub the resolver refused,
+# so a refusal means skip the reset rather than run an unvalidated interpreter.
+if ! PYBIN="$(bash "$REPO_DIR/scripts/sutando-config.sh" python-bin 2>/dev/null)" \
+   || [ -z "$PYBIN" ] || [ ! -x "$PYBIN" ]; then
+  exit 0
+fi
 "$PYBIN" "$REPO_DIR/src/turn_ledger.py" turn-start >/dev/null 2>&1
 exit 0

--- a/src/turn_ledger.py
+++ b/src/turn_ledger.py
@@ -42,7 +42,6 @@ cannot fire.
 """
 from __future__ import annotations
 
-import datetime
 import contextlib
 import fcntl
 import json

--- a/src/turn_ledger.py
+++ b/src/turn_ledger.py
@@ -55,7 +55,6 @@ if _SRC not in sys.path:
     sys.path.insert(0, _SRC)
 
 from delivery.readiness import read_ready_result  # noqa: E402
-from task_archive import archive_month  # noqa: E402
 from workspace_default import resolve_workspace, status_read_path, write_status  # noqa: E402
 
 __all__ = [
@@ -215,8 +214,9 @@ def _result_dirs(results: Path, ts: float) -> list:
     # The archive holds month partitions AND a flat top level; a freshly
     # delivered result lands flat, so scanning only the partitions misses it.
     dirs = [results, archive]
-    # Same calendar as the writer, by calling the writer's own helper: computing
-    # it here in UTC missed the local-month partition around a month boundary.
+    # Same calendar as the writer, by its own helper: computing months here in
+    # UTC missed the local-month partition either side of a boundary.
+    from task_archive import archive_month
     months = {archive_month(t) for t in (ts, time.time())}
     dirs.extend(archive / m for m in sorted(months))
     return dirs

--- a/src/turn_ledger.py
+++ b/src/turn_ledger.py
@@ -65,6 +65,9 @@ __all__ = [
 
 LEDGER_NAME = "turn-ledger.jsonl"
 STOP_NAME = "turn-stop.json"
+TURN_NAME = "turn-reminder.json"
+# Below this, the message was effectively the last thing the turn did.
+ENDED_ON_A_MESSAGE_S = 20.0
 
 # An entry is ~90 bytes and the only question ever asked of this file is "since
 # the last Stop", so the cap is about unbounded growth, not retention depth.
@@ -285,6 +288,27 @@ def mark_stop(workspace: Path | str | None = None) -> float:
     return now
 
 
+def begin_turn(workspace: Path | str | None = None) -> None:
+    """A turn is starting: the reminder is unspent again.
+
+    Reset at turn start rather than when a reminder is sent, so one refusal per
+    turn is the ceiling and a turn can never be refused twice.
+    """
+    write_status(TURN_NAME, {"reminded": False, "ts": time.time()}, _workspace(workspace))
+
+
+def reminder_spent(workspace: Path | str | None = None) -> bool:
+    try:
+        return bool(json.loads(status_read_path(TURN_NAME, _workspace(workspace)).read_text())
+                    .get("reminded"))
+    except (OSError, ValueError):
+        return False
+
+
+def spend_reminder(workspace: Path | str | None = None) -> None:
+    write_status(TURN_NAME, {"reminded": True, "ts": time.time()}, _workspace(workspace))
+
+
 def stop_gate(workspace: Path | str | None = None) -> str | None:
     """None when the turn may end; otherwise the reason it must not.
 
@@ -300,14 +324,21 @@ def stop_gate(workspace: Path | str | None = None) -> str | None:
     if since is None:
         mark_stop(ws)
         return None
-    if delivery_after(since, ws) is None:
-        return ("This turn is ending without a message and without an explicit "
-                "no-send. End the turn by replying — post to the room "
-                "(`room_ops.py say`) or write the result file the task expects — "
-                "or, if silence is the right answer, record that decision: "
-                "`python3 src/turn_ledger.py no-send \"<why>\"`.")
-    mark_stop(ws)
-    return None
+    last = delivery_after(since, ws)
+    if last is not None and (time.time() - float(last["ts"])) <= ENDED_ON_A_MESSAGE_S:
+        mark_stop(ws)
+        return None
+    if reminder_spent(ws):
+        # One nudge per turn. A turn that was already reminded ends regardless:
+        # refusing twice is how a gate that is wrong becomes a loop.
+        mark_stop(ws)
+        return None
+    spend_reminder(ws)
+    return ("This turn is ending without a message and without an explicit "
+            "no-send. Reply — post to the room (`room_ops.py say`) or write the "
+            "result file the task expects — or, if silence is right, record it: "
+            "`python3 src/turn_ledger.py no-send \"<why>\"`. "
+            "This is the only reminder for this turn.")
 
 
 def main(argv: list[str]) -> int:
@@ -321,6 +352,9 @@ def main(argv: list[str]) -> int:
         ws = args[i + 1] if i + 1 < len(args) else None
         del args[i:i + 2]
     cmd = args[0] if args else ""
+    if cmd == "turn-start":
+        begin_turn(ws)
+        return 0
     if cmd == "stop-gate":
         reason = stop_gate(ws)
         if reason:
@@ -334,7 +368,8 @@ def main(argv: list[str]) -> int:
         record_no_send(" ".join(args[1:]), ws)
         return 0
     print(f"usage: {Path(__file__).name} [--workspace DIR] "
-          "stop-gate | send KIND TARGET | no-send REASON", file=sys.stderr)
+          "turn-start | stop-gate | send KIND TARGET | no-send REASON",
+          file=sys.stderr)
     return 2
 
 

--- a/src/turn_ledger.py
+++ b/src/turn_ledger.py
@@ -42,6 +42,9 @@ cannot fire.
 """
 from __future__ import annotations
 
+import datetime
+import contextlib
+import fcntl
 import json
 import os
 import sys
@@ -86,6 +89,32 @@ def ledger_path(workspace: Path | str | None = None) -> Path:
     return _workspace(workspace) / "state" / LEDGER_NAME
 
 
+@contextlib.contextmanager
+def _writer_lock(path: Path):
+    """One writer at a time across append and compaction, via a sidecar lock.
+
+    The lock is its own file so compaction's `os.replace` never swaps the inode
+    a holder is waiting on.
+    """
+    lock_path = path.with_name(f".{path.name}.lock")
+    fd = None
+    try:
+        fd = os.open(str(lock_path), os.O_WRONLY | os.O_CREAT, 0o644)
+        fcntl.flock(fd, fcntl.LOCK_EX)
+    except OSError:
+        if fd is not None:
+            os.close(fd)
+            fd = None
+    try:
+        yield
+    finally:
+        if fd is not None:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            finally:
+                os.close(fd)
+
+
 def _append(entry: dict, workspace: Path | str | None = None) -> None:
     """Append one JSON line, then bound the file. Never raises.
 
@@ -98,12 +127,15 @@ def _append(entry: dict, workspace: Path | str | None = None) -> None:
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         line = json.dumps(entry, ensure_ascii=False, sort_keys=True) + "\n"
-        fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
-        try:
-            os.write(fd, line.encode("utf-8"))
-        finally:
-            os.close(fd)
-        _trim(path)
+        # Append and compaction share one lock: `_trim` reads a tail then swaps
+        # the file, so an append landing in that window would be discarded.
+        with _writer_lock(path):
+            fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+            try:
+                os.write(fd, line.encode("utf-8"))
+            finally:
+                os.close(fd)
+            _trim(path)
     except OSError:
         pass
 
@@ -172,6 +204,20 @@ def last_action_after(ts: float, workspace: Path | str | None = None) -> dict | 
     return max(newer, key=lambda e: float(e["ts"])) if newer else None
 
 
+def _result_dirs(results: Path, ts: float) -> list:
+    """`results/` plus the archive partitions a turn starting at `ts` can reach.
+
+    Bounded to the months spanned by the boundary so a large archive is never
+    walked whole; a turn cannot predate its own boundary.
+    """
+    dirs = [results]
+    archive = results / "archive"
+    months = {datetime.datetime.fromtimestamp(t, datetime.timezone.utc).strftime("%Y-%m")
+              for t in (ts, time.time())}
+    dirs.extend(archive / m for m in sorted(months))
+    return dirs
+
+
 def _result_after(ts: float, workspace: Path | str | None = None) -> dict | None:
     """A ready result file at the top of `results/` newer than `ts`, or None.
 
@@ -180,9 +226,15 @@ def _result_after(ts: float, workspace: Path | str | None = None) -> dict | None
     message, which is the same distinction the Stop hook's task check makes.
     """
     results = _workspace(workspace) / "results"
-    try:
-        entries = list(os.scandir(results))
-    except OSError:
+    # The bridge archives a delivered result immediately, independently of the
+    # turn ending, so the top level alone loses this turn's own evidence.
+    entries = []
+    for directory in _result_dirs(results, ts):
+        try:
+            entries.extend(os.scandir(directory))
+        except OSError:
+            continue
+    if not entries:
         return None
     best = None
     for item in entries:

--- a/src/turn_ledger.py
+++ b/src/turn_ledger.py
@@ -66,8 +66,6 @@ __all__ = [
 LEDGER_NAME = "turn-ledger.jsonl"
 STOP_NAME = "turn-stop.json"
 TURN_NAME = "turn-reminder.json"
-# Below this, the message was effectively the last thing the turn did.
-ENDED_ON_A_MESSAGE_S = 20.0
 
 # An entry is ~90 bytes and the only question ever asked of this file is "since
 # the last Stop", so the cap is about unbounded growth, not retention depth.
@@ -213,8 +211,10 @@ def _result_dirs(results: Path, ts: float) -> list:
     Bounded to the months spanned by the boundary so a large archive is never
     walked whole; a turn cannot predate its own boundary.
     """
-    dirs = [results]
     archive = results / "archive"
+    # The archive holds month partitions AND a flat top level; a freshly
+    # delivered result lands flat, so scanning only the partitions misses it.
+    dirs = [results, archive]
     months = {datetime.datetime.fromtimestamp(t, datetime.timezone.utc).strftime("%Y-%m")
               for t in (ts, time.time())}
     dirs.extend(archive / m for m in sorted(months))
@@ -307,6 +307,10 @@ def reminder_spent(workspace: Path | str | None = None) -> bool:
 
 def spend_reminder(workspace: Path | str | None = None) -> None:
     write_status(TURN_NAME, {"reminded": True, "ts": time.time()}, _workspace(workspace))
+
+
+# Below this, the message was effectively the last thing the turn did.
+ENDED_ON_A_MESSAGE_S = 20.0
 
 
 def stop_gate(workspace: Path | str | None = None) -> str | None:

--- a/src/turn_ledger.py
+++ b/src/turn_ledger.py
@@ -242,9 +242,9 @@ def stop_gate(workspace: Path | str | None = None) -> str | None:
     count against the boundary it began from.
     """
     ws = _workspace(workspace)
-    if not ledger_path(ws).exists():
-        mark_stop(ws)
-        return None
+    # An absent ledger is not "cannot judge" — it is "nothing has ever been sent",
+    # which is the state this gate exists to catch. Only a missing boundary below
+    # is genuinely unjudgeable, and that is the first stop on a fresh install.
     since = last_stop_ts(ws)
     if since is None:
         mark_stop(ws)

--- a/src/turn_ledger.py
+++ b/src/turn_ledger.py
@@ -329,6 +329,11 @@ def stop_gate(workspace: Path | str | None = None) -> str | None:
     if since is None:
         mark_stop(ws)
         return None
+    # An explicit no-send is a decision ABOUT this turn, so its age cannot make it
+    # stale; only a message is judged on whether the turn ended on it.
+    if any(e.get("kind") == "no-send" for e in read_entries(ws) if float(e["ts"]) > since):
+        mark_stop(ws)
+        return None
     last = delivery_after(since, ws)
     if last is not None and (time.time() - float(last["ts"])) <= ENDED_ON_A_MESSAGE_S:
         mark_stop(ws)

--- a/src/turn_ledger.py
+++ b/src/turn_ledger.py
@@ -56,6 +56,7 @@ if _SRC not in sys.path:
     sys.path.insert(0, _SRC)
 
 from delivery.readiness import read_ready_result  # noqa: E402
+from task_archive import archive_month  # noqa: E402
 from workspace_default import resolve_workspace, status_read_path, write_status  # noqa: E402
 
 __all__ = [
@@ -215,8 +216,9 @@ def _result_dirs(results: Path, ts: float) -> list:
     # The archive holds month partitions AND a flat top level; a freshly
     # delivered result lands flat, so scanning only the partitions misses it.
     dirs = [results, archive]
-    months = {datetime.datetime.fromtimestamp(t, datetime.timezone.utc).strftime("%Y-%m")
-              for t in (ts, time.time())}
+    # Same calendar as the writer, by calling the writer's own helper: computing
+    # it here in UTC missed the local-month partition around a month boundary.
+    months = {archive_month(t) for t in (ts, time.time())}
     dirs.extend(archive / m for m in sorted(months))
     return dirs
 

--- a/src/turn_ledger.py
+++ b/src/turn_ledger.py
@@ -242,9 +242,8 @@ def stop_gate(workspace: Path | str | None = None) -> str | None:
     count against the boundary it began from.
     """
     ws = _workspace(workspace)
-    # An absent ledger is not "cannot judge" — it is "nothing has ever been sent",
-    # which is the state this gate exists to catch. Only a missing boundary below
-    # is genuinely unjudgeable, and that is the first stop on a fresh install.
+    # An absent ledger means nothing was ever sent, which is what this gate
+    # catches. Only a missing boundary below is genuinely unjudgeable.
     since = last_stop_ts(ws)
     if since is None:
         mark_stop(ws)

--- a/src/turn_ledger.py
+++ b/src/turn_ledger.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""The turn ledger — a record that the agent's turn produced an outbound message.
+
+THE GAP THIS FILLS. `src/check-pending-tasks.sh` is the Stop hook, and it can
+only see turns that ANSWER A QUEUED TASK: it walks `<workspace>/tasks/` and
+requires a ready `results/<same name>`. A turn with no task in the queue — a
+proactive turn, or one that replies by calling `skills/agent-room-ops/room_ops.py
+say` — is invisible to it. `say` posts to the room over HTTP and writes nothing
+to disk, so no surface anywhere records that the agent spoke. The rule the owner
+asked for ("the end of a turn must be a msg or no-send") was therefore
+unenforceable: nothing knew whether a message had happened.
+
+WHAT THIS RECORDS. An append-only JSONL log under `<workspace>/state/`, one
+object per line: `{ts, kind, target}` for a send, `{ts, kind: "no-send",
+reason}` for a deliberate decision not to speak. Writers append with O_APPEND
+and a single `write()` so concurrent workers cannot interleave a line; nothing
+here read-modify-writes the log.
+
+WHAT COUNTS AS "THE TURN SPOKE". Two surfaces, because there are two ways a
+reply leaves this agent, and only one of them is instrumented:
+
+  • a ledger entry newer than the previous Stop — `room_ops say`, or an explicit
+    `record_no_send`;
+  • a READY file at the top level of `<workspace>/results/` newer than the
+    previous Stop — the result-file protocol, delivered by whichever bridge owns
+    the task. Readiness is `delivery.readiness`, the same policy the bridges
+    apply, so this agrees with what will actually be sent rather than counting a
+    half-written file as a reply.
+
+The results surface is deliberately NOT recursive. A delivered result is
+archived into `results/archive/YYYY-MM/` within seconds, so an archived result
+belongs to an earlier turn boundary — and a turn that replied long ago and then
+went silent is precisely the case the rule is meant to catch.
+
+ARMING. `stop_gate` is inert on an install whose ledger file does not exist yet,
+and this is load-bearing rather than incidental: without it every Stop on a
+fresh workspace would block, including the three that the existing hook tests
+pin as quiet. The gate arms at the first send or no-send ever recorded — which
+`room_ops say` writes on the agent's first room message — and the cost is a
+bootstrap window, on a host that has never once spoken, in which the check
+cannot fire.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+_SRC = str(Path(__file__).resolve().parent)
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+from delivery.readiness import read_ready_result  # noqa: E402
+from workspace_default import resolve_workspace, status_read_path, write_status  # noqa: E402
+
+__all__ = [
+    "LEDGER_NAME", "STOP_NAME", "ledger_path", "record_send", "record_no_send",
+    "last_action_after", "delivery_after", "last_stop_ts", "mark_stop", "stop_gate",
+]
+
+LEDGER_NAME = "turn-ledger.jsonl"
+STOP_NAME = "turn-stop.json"
+
+# An entry is ~90 bytes and the only question ever asked of this file is "since
+# the last Stop", so the cap is about unbounded growth, not retention depth.
+MAX_BYTES = 256 * 1024
+TRIM_TO_BYTES = 128 * 1024
+
+
+def _workspace(workspace: Path | str | None) -> Path:
+    """The caller's workspace, else the canonical one.
+
+    Callers that already resolved it (the Stop hook has) pass it in: re-resolving
+    would answer about a different directory than the one the hook is guarding.
+    `migrate=False` keeps a path lookup free of the resolver's migration notices.
+    """
+    if workspace is not None:
+        return Path(workspace)
+    return resolve_workspace(migrate=False)
+
+
+def ledger_path(workspace: Path | str | None = None) -> Path:
+    """Absolute path of the ledger. `state/` per the workspace contract."""
+    return _workspace(workspace) / "state" / LEDGER_NAME
+
+
+def _append(entry: dict, workspace: Path | str | None = None) -> None:
+    """Append one JSON line, then bound the file. Never raises.
+
+    O_APPEND + one `write()` of a single line: two workers recording at once each
+    land a whole line, and a reader never sees a partial one. Recording is
+    bookkeeping around a message that already went out, so a failure here must
+    never propagate into the caller's send path.
+    """
+    path = ledger_path(workspace)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(entry, ensure_ascii=False, sort_keys=True) + "\n"
+        fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+        try:
+            os.write(fd, line.encode("utf-8"))
+        finally:
+            os.close(fd)
+        _trim(path)
+    except OSError:
+        pass
+
+
+def _trim(path: Path) -> None:
+    """Drop the oldest entries once the file passes `MAX_BYTES`.
+
+    Rewrites to `TRIM_TO_BYTES` rather than to the cap so the rewrite is
+    amortized over many appends instead of firing on every one past it. The swap
+    is temp-file + `os.replace`, so a concurrent reader sees the whole old file
+    or the whole new one — never a truncated one.
+    """
+    try:
+        if path.stat().st_size <= MAX_BYTES:
+            return
+        with open(path, "rb") as fh:
+            fh.seek(-TRIM_TO_BYTES, os.SEEK_END)
+            tail = fh.read()
+        # The seek lands mid-line; drop that fragment so every kept line parses.
+        cut = tail.find(b"\n")
+        tail = tail[cut + 1:] if cut >= 0 else b""
+        tmp = path.with_name(f".{path.name}.trim.tmp")
+        with open(tmp, "wb") as fh:
+            fh.write(tail)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)
+    except OSError:
+        pass
+
+
+def record_send(kind: str, target: str, workspace: Path | str | None = None) -> None:
+    """Record that a message went out — `kind` is the surface, `target` its address."""
+    _append({"ts": time.time(), "kind": str(kind), "target": str(target)}, workspace)
+
+
+def record_no_send(reason: str, workspace: Path | str | None = None) -> None:
+    """Record a deliberate decision that this turn ends without a message."""
+    _append({"ts": time.time(), "kind": "no-send", "reason": str(reason)}, workspace)
+
+
+def read_entries(workspace: Path | str | None = None) -> list[dict]:
+    """Every parseable entry, oldest first. A damaged line is skipped, not fatal."""
+    path = ledger_path(workspace)
+    out: list[dict] = []
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return out
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(entry, dict) and isinstance(entry.get("ts"), (int, float)):
+            out.append(entry)
+    return out
+
+
+def last_action_after(ts: float, workspace: Path | str | None = None) -> dict | None:
+    """The most recent ledger entry newer than `ts`, or None."""
+    newer = [e for e in read_entries(workspace) if float(e["ts"]) > ts]
+    return max(newer, key=lambda e: float(e["ts"])) if newer else None
+
+
+def _result_after(ts: float, workspace: Path | str | None = None) -> dict | None:
+    """A ready result file at the top of `results/` newer than `ts`, or None.
+
+    The other way a reply leaves this agent. Readiness is `delivery.readiness` —
+    an empty or half-written result delivers nothing and must not read as a
+    message, which is the same distinction the Stop hook's task check makes.
+    """
+    results = _workspace(workspace) / "results"
+    try:
+        entries = list(os.scandir(results))
+    except OSError:
+        return None
+    best = None
+    for item in entries:
+        try:
+            if not item.is_file(follow_symlinks=False):
+                continue
+            mtime = item.stat().st_mtime
+        except OSError:
+            continue
+        if mtime <= ts or (best and mtime <= best["ts"]):
+            continue
+        if read_ready_result(item.path) is None:
+            continue
+        best = {"ts": mtime, "kind": "result", "target": item.name}
+    return best
+
+
+def delivery_after(ts: float, workspace: Path | str | None = None) -> dict | None:
+    """The turn's newest outbound message since `ts`, over either surface."""
+    candidates = [c for c in (last_action_after(ts, workspace),
+                              _result_after(ts, workspace)) if c]
+    return max(candidates, key=lambda e: float(e["ts"])) if candidates else None
+
+
+def last_stop_ts(workspace: Path | str | None = None) -> float | None:
+    """When the previous turn was allowed to end, or None if none ever was.
+
+    The boundary lives in its own `state/turn-stop.json` rather than as a ledger
+    entry for two reasons: it is a single mutable value against an append-only
+    log, and `_trim` could otherwise evict the very boundary the gate measures
+    from. `write_status` already makes that one-value write atomic.
+    """
+    try:
+        raw = json.loads(status_read_path(STOP_NAME, _workspace(workspace)).read_text())
+    except (OSError, ValueError):
+        return None
+    ts = raw.get("ts") if isinstance(raw, dict) else None
+    return float(ts) if isinstance(ts, (int, float)) else None
+
+
+def mark_stop(workspace: Path | str | None = None) -> float:
+    """Record that a turn ended here; the next turn is measured from it."""
+    now = time.time()
+    try:
+        write_status(STOP_NAME, {"ts": now}, _workspace(workspace))
+    except OSError:
+        pass
+    return now
+
+
+def stop_gate(workspace: Path | str | None = None) -> str | None:
+    """None when the turn may end; otherwise the reason it must not.
+
+    Allowing a stop RECORDS it, so the decision and the next turn's starting
+    boundary cannot disagree. A refusal deliberately leaves the boundary alone:
+    the turn has not ended, and the message the agent is about to send must still
+    count against the boundary it began from.
+    """
+    ws = _workspace(workspace)
+    if not ledger_path(ws).exists():
+        mark_stop(ws)
+        return None
+    since = last_stop_ts(ws)
+    if since is None:
+        mark_stop(ws)
+        return None
+    if delivery_after(since, ws) is None:
+        return ("This turn is ending without a message and without an explicit "
+                "no-send. End the turn by replying — post to the room "
+                "(`room_ops.py say`) or write the result file the task expects — "
+                "or, if silence is the right answer, record that decision: "
+                "`python3 src/turn_ledger.py no-send \"<why>\"`.")
+    mark_stop(ws)
+    return None
+
+
+def main(argv: list[str]) -> int:
+    """`stop-gate` (exit 1 + reason on stdout when the turn must not end),
+    `send KIND TARGET`, `no-send REASON`. `--workspace` pins the directory for a
+    caller that already resolved it."""
+    args = list(argv)
+    ws = None
+    if "--workspace" in args:
+        i = args.index("--workspace")
+        ws = args[i + 1] if i + 1 < len(args) else None
+        del args[i:i + 2]
+    cmd = args[0] if args else ""
+    if cmd == "stop-gate":
+        reason = stop_gate(ws)
+        if reason:
+            print(reason)
+            return 1
+        return 0
+    if cmd == "send" and len(args) >= 3:
+        record_send(args[1], args[2], ws)
+        return 0
+    if cmd == "no-send" and len(args) >= 2:
+        record_no_send(" ".join(args[1:]), ws)
+        return 0
+    print(f"usage: {Path(__file__).name} [--workspace DIR] "
+          "stop-gate | send KIND TARGET | no-send REASON", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/check-pending-tasks-workspace.test.sh
+++ b/tests/check-pending-tasks-workspace.test.sh
@@ -123,5 +123,29 @@ case "$OUT" in
   *) bad "empty queue emits {}" "got: ${OUT:0:120}" ;;
 esac
 
+# 6. THE REJECTION PATH. When the resolver refuses an interpreter the hook must
+# not execute a bare `python3` — that is the CLT stub the resolver just declined.
+REJ="$(mktemp -d)"
+mkdir -p "$REJ/scripts" "$REJ/src" "$REJ/workspace/tasks" "$REJ/workspace/results"
+printf '#!/bin/bash\n[ "$1" = "workspace" ] && { echo "%s/workspace"; exit 0; }\nexit 1\n' "$REJ" \
+  > "$REJ/scripts/sutando-config.sh"
+chmod +x "$REJ/scripts/sutando-config.sh"
+cp "$HOOK" "$REJ/src/"
+printf 'id: probe\ntask: rejected-interpreter\n' > "$REJ/workspace/tasks/$PROBE"
+# A recording shim: if the hook falls back to PATH python this fires.
+printf '#!/bin/bash\necho FALLBACK_INVOKED >&2\nexit 79\n' > "$REJ/python3"
+chmod +x "$REJ/python3"
+REJ_ERR="$(PATH="$REJ:$PATH" bash "$REJ/src/$(basename "$HOOK")" 2>&1 >/dev/null)"
+REJ_OUT="$(PATH="$REJ:$PATH" bash "$REJ/src/$(basename "$HOOK")" 2>/dev/null)"
+case "$REJ_ERR" in
+  *FALLBACK_INVOKED*) bad "a refused interpreter is not worked around" "the bare python3 fallback ran" ;;
+  *) ok "a refused interpreter is not worked around" ;;
+esac
+case "$REJ_OUT" in
+  '{}') ok "a refused interpreter still emits valid JSON" ;;
+  *) bad "a refused interpreter still emits valid JSON" "got: ${REJ_OUT:0:120}" ;;
+esac
+rm -rf "$REJ"
+
 if [ "$FAILED" -eq 0 ]; then echo "PASS"; else echo "FAIL"; fi
 exit "$FAILED"

--- a/tests/check-pending-tasks-workspace.test.sh
+++ b/tests/check-pending-tasks-workspace.test.sh
@@ -39,6 +39,15 @@ HOOK="$REPO/src/check-pending-tasks.sh"
 
 # --- Build and PIN an isolated workspace before resolving anything ----------
 TMPWS="$(mktemp -d "${TMPDIR:-/tmp}/sutando-hooktest.XXXXXX")"
+
+# The hook now also refuses a turn that ends with no message and no recorded
+# no-send. These cases assert the TASK gate, so satisfy the turn gate first or
+# they measure the wrong refusal.
+record_delivery() {
+  "$(bash "$REPO/scripts/sutando-config.sh" python-bin 2>/dev/null || echo python3)" \
+    "$REPO/src/turn_ledger.py" --workspace "$TMPWS" no-send "hook unit test" >/dev/null 2>&1 || true
+}
+
 export SUTANDO_TEST_MODE=1
 export SUTANDO_WORKSPACE="$TMPWS"
 
@@ -108,6 +117,7 @@ if [ "$(_real "$LEGACY_DIR")" = "$(_real "$WS/tasks")" ]; then
 else
   mkdir -p "$LEGACY_DIR"
   printf 'id: probe\ntask: legacy\n' > "$LEGACY_DIR/$PROBE"
+  record_delivery
   OUT="$(bash "$HOOK" 2>&1)"
   case "$OUT" in
     '{}') ok "legacy <repo>/tasks/ does not block" ;;
@@ -117,6 +127,7 @@ else
 fi
 
 # 5. Empty queue stays quiet — the control that proves case 1 measured something.
+record_delivery
 OUT="$(bash "$HOOK" 2>&1)"
 case "$OUT" in
   '{}') ok "empty queue emits {}" ;;

--- a/tests/health-check-claude-hook-registration.test.py
+++ b/tests/health-check-claude-hook-registration.test.py
@@ -318,6 +318,8 @@ class TestAgainstTheRealInstaller(unittest.TestCase):
             "SessionEnd": [{"hooks": [{"command": handoff}]}],
             "Stop": [{"hooks": [{"command": stop_command.format(
                 p=f"{r}/src/check-pending-tasks.sh")}]}],
+            "UserPromptSubmit": [{"hooks": [
+                {"command": f"bash {r}/src/turn-start.sh"}]}],
         }}))
         return r
 
@@ -327,7 +329,7 @@ class TestAgainstTheRealInstaller(unittest.TestCase):
         # probe warns on every healthy host.
         out = self.hc.check_claude_hook_registration(repo_dir=self._repo("bash {p}"))
         self.assertEqual(out["status"], "ok", out["detail"])
-        self.assertIn("4", out["detail"])
+        self.assertIn("5", out["detail"])
 
     def test_decoys_are_rejected_on_the_REAL_installer_shape(self):
         for label, cmd in {

--- a/tests/stop-hook-emits-valid-json.test.py
+++ b/tests/stop-hook-emits-valid-json.test.py
@@ -17,6 +17,11 @@ Also pins body fidelity. The old escaping ran `sed 's/"/\\"/g' | tr '\n' ' '`,
 which left backslashes unescaped — a task body containing one would break the
 JSON again by a different route.
 
+This asserts the SEMANTICS (the response parses). `check-pending-tasks-workspace.test.sh`
+asserts the WIRE SHAPE, matching the literal `"decision":"block"` — so the encoder must keep
+compact separators and `ensure_ascii=False`. Both properties are required; neither implies
+the other, and a first pass at this fix passed here while breaking that sibling suite.
+
 Run: python3 tests/stop-hook-emits-valid-json.test.py
 """
 from __future__ import annotations

--- a/tests/stop-hook-emits-valid-json.test.py
+++ b/tests/stop-hook-emits-valid-json.test.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""The Stop hook's block decision must be parseable JSON.
+
+`src/check-pending-tasks.sh` built its response by hand, and the `\n` in the
+printf FORMAT string was emitted as a raw newline inside a JSON string value.
+Raw control characters are illegal there, so the client could not parse the
+response and printed `stop hook error` instead. The guard exists to stop the
+agent going idle with unanswered tasks; because every block decision was
+unparseable, it had never once fired.
+
+The empty-queue path returns `{}` and always parsed, which is why nothing
+caught this: the failure appears ONLY when the hook has something to say. So
+this asserts against a NON-EMPTY queue, and pins that the block actually fires
+(a fixture that produced `{}` would pass while proving nothing).
+
+Also pins body fidelity. The old escaping ran `sed 's/"/\\"/g' | tr '\n' ' '`,
+which left backslashes unescaped — a task body containing one would break the
+JSON again by a different route.
+
+Run: python3 tests/stop-hook-emits-valid-json.test.py
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import tempfile
+
+HOOK = pathlib.Path(__file__).resolve().parent.parent / "src" / "check-pending-tasks.sh"
+RESOLVE = 'WORKSPACE="$(bash "$REPO_DIR/scripts/sutando-config.sh" workspace 2>/dev/null)"'
+
+BODY = 'a body with "quotes", a backslash \\ and\na second line\n'
+
+
+def _run(workspace: pathlib.Path) -> str:
+    """Run the real hook against `workspace`, pinning its resolver to it."""
+    src = HOOK.read_text()
+    assert RESOLVE in src, "workspace resolution line moved; update this test"
+    stub = workspace / "hook.sh"
+    stub.write_text(src.replace(RESOLVE, f'WORKSPACE="{workspace}"'))
+    out = subprocess.run(
+        ["bash", str(stub)], capture_output=True, text=True, stdin=subprocess.DEVNULL
+    )
+    assert out.returncode == 0, f"hook exited {out.returncode}: {out.stderr}"
+    return out.stdout
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = pathlib.Path(tmp)
+        (ws / "tasks").mkdir()
+        (ws / "results").mkdir()
+
+        # Empty queue: the path that always parsed, kept so a regression here is visible too.
+        assert json.loads(_run(ws)) == {}, "empty queue must emit {}"
+
+        (ws / "tasks" / "task-1.txt").write_text(f"id: task-1\ntask: {BODY}")
+        raw = _run(ws)
+
+        decision = json.loads(raw)  # the assertion: unparseable output fails here
+        assert decision["decision"] == "block", (
+            f"fixture did not make the guard fire: {decision!r}"
+        )
+
+        ctx = decision["additionalContext"]
+        for label, needle in (("quotes", '"quotes"'), ("backslash", "\\"), ("newline", "\n")):
+            assert needle in ctx, f"task body lost its {label}"
+
+    print("stop-hook-emits-valid-json: PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/stop-hook-emits-valid-json.test.py
+++ b/tests/stop-hook-emits-valid-json.test.py
@@ -71,6 +71,16 @@ def main() -> None:
         for label, needle in (("quotes", '"quotes"'), ("backslash", "\\"), ("newline", "\n")):
             assert needle in ctx, f"task body lost its {label}"
 
+        # An empty result satisfied the old existence check while delivering silence.
+        # `[no-send]` must keep passing: it is deliberate protocol, not an absent reply.
+        for body, should_block in (("", True), ("  \n\t\n", True),
+                                   ("[no-send]\n", False), ("a real answer\n", False)):
+            (ws / "results" / "task-1.txt").write_text(body)
+            blocked = json.loads(_run(ws)) != {}
+            assert blocked is should_block, (
+                f"result {body!r}: blocked={blocked}, expected {should_block}"
+            )
+
     print("stop-hook-emits-valid-json: PASS")
 
 

--- a/tests/stop-hook-emits-valid-json.test.py
+++ b/tests/stop-hook-emits-valid-json.test.py
@@ -27,22 +27,39 @@ Run: python3 tests/stop-hook-emits-valid-json.test.py
 from __future__ import annotations
 
 import json
+import os
 import pathlib
 import subprocess
+import sys
 import tempfile
 
 HOOK = pathlib.Path(__file__).resolve().parent.parent / "src" / "check-pending-tasks.sh"
 RESOLVE = 'WORKSPACE="$(bash "$REPO_DIR/scripts/sutando-config.sh" workspace 2>/dev/null)"'
+REPO_LINE = 'REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"'
+REPO = HOOK.resolve().parent.parent
+
+
+def _stub(ws: pathlib.Path) -> pathlib.Path:
+    """The hook, pinned to this repo and the given workspace.
+
+    REPO_DIR must be pinned too: run from a temp dir, `dirname $0/..` points
+    outside the repo, so `sutando-config.sh` is never found and the interpreter
+    cascade silently falls back to PATH — the test would then measure the
+    fallback rather than the contract.
+    """
+    src = HOOK.read_text()
+    assert RESOLVE in src and REPO_LINE in src, "hook layout moved; update this test"
+    src = src.replace(REPO_LINE, f'REPO_DIR="{REPO}"').replace(RESOLVE, f'WORKSPACE="{ws}"')
+    stub = ws / "hook.sh"
+    stub.write_text(src)
+    return stub
 
 BODY = 'a body with "quotes", a backslash \\ and\na second line\n'
 
 
 def _run(workspace: pathlib.Path) -> str:
     """Run the real hook against `workspace`, pinning its resolver to it."""
-    src = HOOK.read_text()
-    assert RESOLVE in src, "workspace resolution line moved; update this test"
-    stub = workspace / "hook.sh"
-    stub.write_text(src.replace(RESOLVE, f'WORKSPACE="{workspace}"'))
+    stub = _stub(workspace)
     out = subprocess.run(
         ["bash", str(stub)], capture_output=True, text=True, stdin=subprocess.DEVNULL
     )
@@ -71,7 +88,46 @@ def main() -> None:
         for label, needle in (("quotes", '"quotes"'), ("backslash", "\\"), ("newline", "\n")):
             assert needle in ctx, f"task body lost its {label}"
 
+    _test_broken_path_still_blocks()
     print("stop-hook-emits-valid-json: PASS")
+
+
+def _test_broken_path_still_blocks() -> None:
+    """A configured interpreter must win over a broken `python3` on PATH.
+
+    `scripts/python-binary.sh` resolves $SUTANDO_PY, then the bundled runtime,
+    then PATH — so an install with a configured Python must not be defeated by
+    whatever `python3` happens to resolve to. A bare `python3` in the hook
+    ignored that cascade and emitted nothing for a nonempty queue.
+
+    PATH is shadowed, not emptied: emptying removes `cat` and the config helper,
+    so the hook would fail for reasons unrelated to the contract under test.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = pathlib.Path(tmp)
+        (ws / "tasks").mkdir()
+        (ws / "results").mkdir()
+        (ws / "tasks" / "task-1.txt").write_text("id: task-1\ntask: answer me\n")
+
+        stub = _stub(ws)
+
+        shim = ws / "bin"
+        shim.mkdir()
+        broken = shim / "python3"
+        broken.write_text("#!/bin/sh\necho 'wrong interpreter' >&2\nexit 127\n")
+        broken.chmod(0o755)
+
+        env = dict(
+            os.environ,
+            PATH=f"{shim}:{os.environ.get('PATH', '')}",
+            SUTANDO_PY=sys.executable,
+        )
+        out = subprocess.run(["/bin/bash", str(stub)], capture_output=True, text=True,
+                             stdin=subprocess.DEVNULL, env=env)
+        assert out.returncode == 0, f"hook exited {out.returncode}: {out.stderr}"
+        assert json.loads(out.stdout)["decision"] == "block", (
+            f"a broken python3 on PATH defeated the configured interpreter: {out.stdout!r}"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/stop-hook-emits-valid-json.test.py
+++ b/tests/stop-hook-emits-valid-json.test.py
@@ -89,6 +89,7 @@ def main() -> None:
             assert needle in ctx, f"task body lost its {label}"
 
     _test_broken_path_still_blocks()
+    _test_result_readiness_matches_the_delivery_owner()
     print("stop-hook-emits-valid-json: PASS")
 
 
@@ -128,6 +129,45 @@ def _test_broken_path_still_blocks() -> None:
         assert json.loads(out.stdout)["decision"] == "block", (
             f"a broken python3 on PATH defeated the configured interpreter: {out.stdout!r}"
         )
+
+
+def _test_result_readiness_matches_the_delivery_owner() -> None:
+    """Readiness is owned by src/delivery/readiness.py, the policy every delivery
+    consumer uses. A local `tr -d '[:space:]'` diverges from it under LC_ALL=C:
+    NBSP/EM SPACE and undecodable bytes read as content, so Stop succeeds on a
+    result no consumer will ever send.
+
+    LC_ALL=C is set deliberately. Under a UTF-8 locale BSD tr yields empty for
+    these inputs and coincides with the helper, so the cases cannot tell the two
+    apart — an earlier version of this test inherited UTF-8 and passed against
+    the very implementation it was written to reject.
+
+    `[no-send]` must stay ready: deliberate protocol, not an absent reply.
+    """
+    env = dict(os.environ, LC_ALL="C", LANG="C")
+    cases = [
+        (b"", True, "empty"),
+        (b"  \n\t\n", True, "ascii whitespace"),
+        ("\u00a0\u2003\n".encode(), True, "NBSP + EM SPACE"),
+        (b"\xff\xfe\n", True, "undecodable bytes"),
+        (b"[no-send]\n", False, "no-send protocol"),
+        (b"a real answer\n", False, "real reply"),
+    ]
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = pathlib.Path(tmp)
+        (ws / "tasks").mkdir()
+        (ws / "results").mkdir()
+        (ws / "tasks" / "task-1.txt").write_text("id: task-1\ntask: answer me\n")
+        stub = _stub(ws)
+        for body, should_block, label in cases:
+            (ws / "results" / "task-1.txt").write_bytes(body)
+            out = subprocess.run(["/bin/bash", str(stub)], capture_output=True,
+                                 text=True, stdin=subprocess.DEVNULL, env=env)
+            assert out.returncode == 0, f"{label}: hook exited {out.returncode}"
+            blocked = json.loads(out.stdout or "{}") != {}
+            assert blocked is should_block, (
+                f"{label}: blocked={blocked}, expected {should_block}"
+            )
 
 
 if __name__ == "__main__":

--- a/tests/turn-ledger-stop-gate.test.py
+++ b/tests/turn-ledger-stop-gate.test.py
@@ -209,12 +209,23 @@ def test_an_archived_result_is_not_this_turns_message() -> None:
               repr(turn_ledger.delivery_after(past, ws)))
 
 
-def test_hook_is_inert_until_the_ledger_exists() -> None:
-    """The arming rule, and the reason the sibling suites stay green."""
+def test_an_absent_ledger_is_nothing_sent_not_unjudgeable() -> None:
+    """There is no arming rule, because arming defeated the gate.
+
+    It previously allowed any turn while the ledger file was absent, and only a
+    recorded send creates that file — so a turn that never sends never created
+    the thing that would catch it. Measured on the live host: five consecutive
+    silent turns all passed. Writing a result file does not create it either,
+    which is how most replies are made here, so it would have stayed inert
+    indefinitely while looking installed.
+
+    Only the FIRST stop is unjudgeable: there is no boundary to measure from.
+    """
     with tempfile.TemporaryDirectory() as tmp:
         ws = _workspace(tmp)
-        check("no ledger: an empty queue still emits {}", _hook(ws) == {}, repr(_hook(ws)))
-        check("no ledger: a second stop is still quiet", _hook(ws) == {}, repr(_hook(ws)))
+        check("first ever stop is allowed (no boundary yet)", _hook(ws) == {}, repr(_hook(ws)))
+        second = _hook(ws)
+        check("a second silent turn is refused", second != {}, repr(second))
 
 
 def test_hook_blocks_a_silent_turn() -> None:
@@ -359,7 +370,7 @@ def main() -> int:
         test_the_file_is_bounded_and_keeps_the_newest,
         test_concurrent_writers_do_not_lose_or_interleave_a_line,
         test_an_archived_result_is_not_this_turns_message,
-        test_hook_is_inert_until_the_ledger_exists,
+        test_an_absent_ledger_is_nothing_sent_not_unjudgeable,
         test_hook_blocks_a_silent_turn,
         test_a_recorded_send_lets_the_turn_end,
         test_a_recorded_no_send_lets_the_turn_end,
@@ -368,6 +379,7 @@ def main() -> int:
         test_an_unanswered_task_still_blocks_with_the_task_reason,
         test_a_gate_that_cannot_run_fails_open,
         test_room_ops_records_only_a_successful_say,
+        test_an_absent_ledger_still_blocks_after_the_first_stop,
     ):
         print(f"{fn.__name__}:")
         fn()
@@ -376,6 +388,27 @@ def main() -> int:
         return 1
     print("turn-ledger-stop-gate: PASS")
     return 0
+
+
+def test_an_absent_ledger_still_blocks_after_the_first_stop():
+    """A turn that never sends anything never creates the ledger — so treating an
+    absent ledger as unjudgeable made the gate inert for exactly the case it
+    exists to catch. Only a missing boundary (the first stop on a fresh install)
+    is genuinely unjudgeable.
+
+    Verified against the live deployment before the fix: with no ledger the gate
+    passed on every consecutive turn.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = pathlib.Path(tmp)
+        (ws / "state").mkdir()
+        assert turn_ledger.stop_gate(ws) is None, "the first stop has no boundary to measure from"
+        assert turn_ledger.stop_gate(ws) is not None, (
+            "a second turn with nothing sent must block even though no ledger exists"
+        )
+        turn_ledger.record_send("room", "!r:example.org", workspace=ws)
+        assert turn_ledger.stop_gate(ws) is None, "a recorded send lets the turn end"
+        assert turn_ledger.stop_gate(ws) is not None, "the turn after it must block again"
 
 
 if __name__ == "__main__":

--- a/tests/turn-ledger-stop-gate.test.py
+++ b/tests/turn-ledger-stop-gate.test.py
@@ -239,9 +239,15 @@ def test_an_absent_ledger_is_nothing_sent_not_unjudgeable() -> None:
     """
     with tempfile.TemporaryDirectory() as tmp:
         ws = _workspace(tmp)
-        check("first ever stop is allowed (no boundary yet)", _hook(ws) == {}, repr(_hook(ws)))
+        # Each call is captured once: `check`'s detail argument is evaluated
+        # eagerly, so `repr(_hook(ws))` inline would run the hook a second time
+        # and spend this turn's single reminder before the assertion under test.
+        first = _hook(ws)
+        check("first ever stop is allowed (no boundary yet)", first == {}, repr(first))
         second = _hook(ws)
-        check("a second silent turn is refused", second != {}, repr(second))
+        check("a second silent turn is reminded", second != {}, repr(second))
+        third = _hook(ws)
+        check("the same turn is not reminded twice", third == {}, repr(third))
 
 
 def test_hook_blocks_a_silent_turn() -> None:
@@ -397,6 +403,9 @@ def main() -> int:
         test_room_ops_records_only_a_successful_say,
         test_an_absent_ledger_still_blocks_after_the_first_stop,
         test_the_command_line_surface,
+        test_one_reminder_per_turn_not_a_standing_refusal,
+        test_ended_on_a_message_versus_sent_then_went_quiet,
+        test_turn_start_is_reachable_from_the_command_line,
         test_record_say_contract_in_process,
         test_a_result_older_than_the_boundary_is_not_this_turns,
         test_bookkeeping_never_raises_into_the_send_path,
@@ -423,12 +432,21 @@ def test_an_absent_ledger_still_blocks_after_the_first_stop():
         ws = pathlib.Path(tmp)
         (ws / "state").mkdir()
         assert turn_ledger.stop_gate(ws) is None, "the first stop has no boundary to measure from"
+
+        # Each turn is reset at its start in production (the UserPromptSubmit hook
+        # calls `turn-start`), so a test spanning turns must do the same or it is
+        # measuring one turn being refused twice, which the design forbids.
+        turn_ledger.begin_turn(ws)
         assert turn_ledger.stop_gate(ws) is not None, (
-            "a second turn with nothing sent must block even though no ledger exists"
+            "a silent turn is reminded even though no ledger exists"
         )
+
+        turn_ledger.begin_turn(ws)
         turn_ledger.record_send("room", "!r:example.org", workspace=ws)
         assert turn_ledger.stop_gate(ws) is None, "a recorded send lets the turn end"
-        assert turn_ledger.stop_gate(ws) is not None, "the turn after it must block again"
+
+        turn_ledger.begin_turn(ws)
+        assert turn_ledger.stop_gate(ws) is not None, "the next silent turn is reminded again"
 
 
 def test_the_command_line_surface() -> None:
@@ -602,6 +620,65 @@ def test_record_say_contract_in_process() -> None:
               "!unconfirmed:ag2.space" in targets, repr(targets))
         check("a refused say records nothing", "!refused:ag2.space" not in targets, repr(targets))
         check("a non-dict result is ignored rather than raising", True, "")
+
+
+def test_one_reminder_per_turn_not_a_standing_refusal() -> None:
+    """The owner's design: nudge once, then let the turn end.
+
+    A gate that refuses repeatedly turns any mistake into a loop of duplicate
+    replies — the failure the reviewer reproduced. Nudging once bounds the cost of
+    being wrong to a single wasted prompt.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = _workspace(tmp)
+        turn_ledger.stop_gate(ws)                      # establish the boundary
+
+        turn_ledger.begin_turn(ws)
+        check("a silent turn is reminded once", turn_ledger.stop_gate(ws) is not None, "")
+        check("the same turn is NOT refused twice", turn_ledger.stop_gate(ws) is None,
+              "a second refusal is how a wrong gate becomes a loop")
+
+        turn_ledger.begin_turn(ws)
+        check("the next turn is reminded again", turn_ledger.stop_gate(ws) is not None,
+              "the reset must re-arm it")
+
+
+def test_ended_on_a_message_versus_sent_then_went_quiet() -> None:
+    """The distinction the owner corrected me on twice.
+
+    "A message was sent this turn" is not "the turn ended on a message". A turn
+    that replies, works for ten minutes, then stops silently satisfies the first
+    and violates the second — and it is the case I kept committing.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = _workspace(tmp)
+        turn_ledger.stop_gate(ws)
+
+        turn_ledger.begin_turn(ws)
+        turn_ledger.record_send("room", "!r:example.org", workspace=ws)
+        check("a message just sent ends the turn cleanly",
+              turn_ledger.stop_gate(ws) is None, "")
+
+        original = turn_ledger.ENDED_ON_A_MESSAGE_S
+        try:
+            turn_ledger.ENDED_ON_A_MESSAGE_S = 0.001   # the send is now "long ago"
+            turn_ledger.begin_turn(ws)
+            check("a turn that sent early then went quiet IS reminded",
+                  turn_ledger.stop_gate(ws) is not None,
+                  "this is the case the previous design could not see")
+        finally:
+            turn_ledger.ENDED_ON_A_MESSAGE_S = original
+
+
+def test_turn_start_is_reachable_from_the_command_line() -> None:
+    """The hook calls this; if the verb is missing the reset silently never happens."""
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = _workspace(tmp)
+        turn_ledger.spend_reminder(ws)
+        check("reminder starts spent", turn_ledger.reminder_spent(ws), "")
+        rc = turn_ledger.main(["--workspace", str(ws), "turn-start"])
+        check("turn-start exits 0", rc == 0, repr(rc))
+        check("turn-start clears the mark", not turn_ledger.reminder_spent(ws), "")
 
 
 if __name__ == "__main__":

--- a/tests/turn-ledger-stop-gate.test.py
+++ b/tests/turn-ledger-stop-gate.test.py
@@ -404,6 +404,7 @@ def main() -> int:
         test_the_command_line_surface,
         test_one_reminder_per_turn_not_a_standing_refusal,
         test_ended_on_a_message_versus_sent_then_went_quiet,
+        test_a_delivered_result_archived_flat_is_still_a_message,
         test_turn_start_is_reachable_from_the_command_line,
         test_record_say_contract_in_process,
         test_a_result_older_than_the_boundary_is_not_this_turns,
@@ -674,6 +675,30 @@ def test_ended_on_a_message_versus_sent_then_went_quiet() -> None:
                   "this is the case the previous design could not see")
         finally:
             turn_ledger.ENDED_ON_A_MESSAGE_S = original
+
+
+def test_a_delivered_result_archived_flat_is_still_a_message() -> None:
+    """The bridge archives a delivered reply within seconds, renaming it.
+
+    The archive holds month partitions and a flat top level, and a fresh
+    delivery lands flat. Scanning only the partitions made a real reply
+    invisible, so the guard nagged the turns that had answered.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = _workspace(tmp)
+        turn_ledger.stop_gate(ws)
+        turn_ledger.begin_turn(ws)
+        since = turn_ledger.last_stop_ts(ws)
+        archive = pathlib.Path(ws) / "results" / "archive"
+        archive.mkdir(parents=True, exist_ok=True)
+        # The delivered name carries the -<epoch> suffix the bridge appends.
+        delivered = archive / "task-abc123-1788843624.txt"
+        delivered.write_text("a real reply body\n", encoding="utf-8")
+        check("setup: it is newer than the boundary",
+              delivered.stat().st_mtime > since, "otherwise the scan is untested")
+        found = turn_ledger._result_after(since, ws)
+        check("a flat-archived delivery is found",
+              found is not None and "task-abc123" in found["target"], repr(found))
 
 
 def test_turn_start_is_reachable_from_the_command_line() -> None:

--- a/tests/turn-ledger-stop-gate.test.py
+++ b/tests/turn-ledger-stop-gate.test.py
@@ -406,7 +406,7 @@ def main() -> int:
         test_one_reminder_per_turn_not_a_standing_refusal,
         test_ended_on_a_message_versus_sent_then_went_quiet,
         test_a_delivered_result_archived_flat_is_still_a_message,
-        test_concurrent_writers_while_compaction_is_firing,
+        test_a_concurrent_trim_does_not_swallow_an_append,
         test_the_reader_uses_the_writers_archive_calendar,
         test_turn_start_is_reachable_from_the_command_line,
         test_record_say_contract_in_process,
@@ -704,68 +704,46 @@ def test_a_delivered_result_archived_flat_is_still_a_message() -> None:
               found is not None and "task-abc123" in found["target"], repr(found))
 
 
-def test_concurrent_writers_while_compaction_is_firing() -> None:
-    """Appends racing an actual trim, unlike the sibling test which never trims.
+def test_a_concurrent_trim_does_not_swallow_an_append() -> None:
+    """The lock's actual protection: `_trim` reads a tail then replaces the file,
+    so an append landing in that window is discarded when the two are not serialised.
 
-    What this establishes: with compaction firing throughout, no line is torn, no
-    surviving run has a hole, and the tail is a new record.
-
-    What it does NOT establish: that the writer lock is required. Moving `_trim`
-    outside the lock still passes. Only ~7% of appends survive an aggressive trim,
-    so a race-lost append is indistinguishable from a legitimately evicted one.
+    The window has to be WIDE and the eviction MILD. A small cap trims fast and
+    evicts almost everything, which both narrows the race and destroys the evidence
+    — a lost append then looks identical to a legitimately evicted one.
     """
-    workers, per_worker = 8, 60
+    cap, keep, workers, per_worker = 2_000_000, 1_999_000, 8, 60
     with tempfile.TemporaryDirectory() as tmp:
         ws = _workspace(tmp)
         path = turn_ledger.ledger_path(ws)
         path.parent.mkdir(parents=True, exist_ok=True)
         filler = json.dumps({"kind": "room", "target": "old", "ts": 1.0}) + "\n"
-        # Just under the cap, so the first concurrent appends push it over.
-        worker_cap = 4096
-        path.write_text(filler * ((worker_cap // len(filler)) - 2), encoding="utf-8")
-        before = path.stat().st_size
-        check("setup: primed close to the workers' trim threshold",
-              worker_cap * 0.8 < before <= worker_cap, f"{before} vs cap {worker_cap}")
-        # Every append must cross the cap, or the trim fires once and the racing
-        # window is too narrow for the defect to show at all.
+        path.write_text(filler * (cap // len(filler)), encoding="utf-8")
         code = ("import sys; sys.path.insert(0, sys.argv[1])\n"
                 "import turn_ledger\n"
-                "turn_ledger.MAX_BYTES = 4096\n"
-                # Both, or the seek runs past the file, raises, and is swallowed:
-                # the trim then silently never runs and the race is never exercised.
-                "turn_ledger.TRIM_TO_BYTES = 2048\n"
+                f"turn_ledger.MAX_BYTES={cap}\nturn_ledger.TRIM_TO_BYTES={keep}\n"
                 "for i in range(%d): turn_ledger.record_send('room', sys.argv[3] + '-%%03d' %% i, sys.argv[2])\n"
                 % per_worker)
         procs = [subprocess.Popen([sys.executable, "-c", code, str(REPO / "src"), str(ws), f"c{p}"])
                  for p in range(workers)]
         for proc in procs:
             proc.wait()
-        raw = [ln for ln in path.read_text(encoding="utf-8").splitlines() if ln.strip()]
         entries = turn_ledger.read_entries(ws)
-        check("compaction actually fired", path.stat().st_size <= worker_cap * 1.5,
-              f"{path.stat().st_size} vs worker cap {worker_cap}")
+        raw = [ln for ln in path.read_text(encoding="utf-8").splitlines() if ln.strip()]
         check("every surviving line is whole", len(entries) == len(raw),
-              f"{len(entries)} parsed of {len(raw)} raw — a torn line survived")
-        # A trim legitimately evicts OLD records, so completeness is not the
-        # invariant; surviving new records must not be corrupted or interleaved.
-        survivors = {e["target"] for e in entries if str(e.get("target", "")).startswith("c")}
-        bad = sorted(t for t in survivors if not re.fullmatch(r"c\d-\d{3}", t))
-        check("surviving new records are well formed", bool(survivors) and not bad,
-              f"{len(survivors)} survivors, malformed: {bad[:4]}")
-        # The discriminator. A trim evicts the OLDEST records, so per worker the
-        # survivors must be a contiguous suffix; a hole is an append the trim ate.
+              f"{len(entries)} parsed of {len(raw)} raw")
+        check("compaction actually fired", len(raw) < (cap // len(filler)) + workers * per_worker,
+              "nothing was evicted, so no trim ran and the race was never exercised")
+        new = [e for e in entries if str(e.get("target", "")).startswith("c")]
         holes = []
         for worker in range(workers):
-            got = sorted(int(t[3:]) for t in survivors if t.startswith(f"c{worker}-"))
-            if got and got != list(range(got[0], got[0] + len(got))):
+            got = sorted(int(e["target"][3:]) for e in new if e["target"].startswith(f"c{worker}-"))
+            if got:
                 missing = [i for i in range(got[0], got[-1]) if i not in set(got)]
-                holes.append(f"c{worker}: {len(missing)} lost, e.g. {missing[:3]}")
-        check("no append was swallowed by a concurrent trim", not holes, "; ".join(holes[:3]))
-        # A trim keeps the TAIL, so whatever is last on disk must be a new record.
-        # Which worker survives is timing; that the newest write is retained is not.
-        last = json.loads(raw[-1])
-        check("the last line on disk is a new record, not an evicted old one",
-              str(last.get("target", "")).startswith("c"), f"tail is {last.get('target')!r}")
+                if missing:
+                    holes.append(f"c{worker}: {len(missing)} lost e.g. {missing[:3]}")
+        check("no append was swallowed by a concurrent trim", not holes,
+              f"{len(new)} of {workers * per_worker} survived; " + "; ".join(holes[:3]))
 
 
 def test_the_reader_uses_the_writers_archive_calendar() -> None:

--- a/tests/turn-ledger-stop-gate.test.py
+++ b/tests/turn-ledger-stop-gate.test.py
@@ -239,9 +239,8 @@ def test_an_absent_ledger_is_nothing_sent_not_unjudgeable() -> None:
     """
     with tempfile.TemporaryDirectory() as tmp:
         ws = _workspace(tmp)
-        # Each call is captured once: `check`'s detail argument is evaluated
-        # eagerly, so `repr(_hook(ws))` inline would run the hook a second time
-        # and spend this turn's single reminder before the assertion under test.
+        # `check`'s detail argument is eager, so an inline `repr(_hook(ws))` runs
+        # the hook again and spends this turn's one reminder before the assertion.
         first = _hook(ws)
         check("first ever stop is allowed (no boundary yet)", first == {}, repr(first))
         second = _hook(ws)
@@ -433,9 +432,8 @@ def test_an_absent_ledger_still_blocks_after_the_first_stop():
         (ws / "state").mkdir()
         assert turn_ledger.stop_gate(ws) is None, "the first stop has no boundary to measure from"
 
-        # Each turn is reset at its start in production (the UserPromptSubmit hook
-        # calls `turn-start`), so a test spanning turns must do the same or it is
-        # measuring one turn being refused twice, which the design forbids.
+        # Production resets each turn via the UserPromptSubmit hook, so a test
+        # spanning turns must too, or it measures one turn refused twice.
         turn_ledger.begin_turn(ws)
         assert turn_ledger.stop_gate(ws) is not None, (
             "a silent turn is reminded even though no ledger exists"

--- a/tests/turn-ledger-stop-gate.test.py
+++ b/tests/turn-ledger-stop-gate.test.py
@@ -406,6 +406,7 @@ def main() -> int:
         test_one_reminder_per_turn_not_a_standing_refusal,
         test_ended_on_a_message_versus_sent_then_went_quiet,
         test_a_delivered_result_archived_flat_is_still_a_message,
+        test_an_aged_no_send_still_ends_the_turn,
         test_a_concurrent_trim_does_not_swallow_an_append,
         test_the_reader_uses_the_writers_archive_calendar,
         test_turn_start_is_reachable_from_the_command_line,
@@ -702,6 +703,31 @@ def test_a_delivered_result_archived_flat_is_still_a_message() -> None:
         found = turn_ledger._result_after(since, ws)
         check("a flat-archived delivery is found",
               found is not None and "task-abc123" in found["target"], repr(found))
+
+
+def test_an_aged_no_send_still_ends_the_turn() -> None:
+    """A no-send is a decision about the turn, not a message that can go stale.
+
+    Recording one and then working past the elapsed-message window used to be
+    reminded anyway, which nags the turn that made the decision it asked for.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = _workspace(tmp)
+        # Both timestamps placed explicitly: the boundary must PREDATE the no-send,
+        # or it falls outside the turn and is correctly ignored for another reason.
+        now = time.time()
+        turn_ledger.write_status(turn_ledger.STOP_NAME, {"ts": now - 600}, ws)
+        turn_ledger.begin_turn(ws)
+        turn_ledger.record_no_send("checked, nothing to report", workspace=ws)
+        led = pathlib.Path(ws) / "state" / turn_ledger.LEDGER_NAME
+        rows = [json.loads(l) for l in led.read_text().splitlines() if l.strip()]
+        rows[-1]["ts"] = now - 300                    # inside the turn, past the window
+        led.write_text("".join(json.dumps(r) + "\n" for r in rows))
+        check("setup: the no-send is inside the turn but older than the window",
+              turn_ledger.last_stop_ts(ws) < rows[-1]["ts"] < now - turn_ledger.ENDED_ON_A_MESSAGE_S,
+              f"boundary={turn_ledger.last_stop_ts(ws)} no-send={rows[-1]['ts']}")
+        check("an aged no-send still ends the turn",
+              turn_ledger.stop_gate(ws) is None, "it was reminded despite an explicit no-send")
 
 
 def test_a_concurrent_trim_does_not_swallow_an_append() -> None:

--- a/tests/turn-ledger-stop-gate.test.py
+++ b/tests/turn-ledger-stop-gate.test.py
@@ -34,6 +34,8 @@ from __future__ import annotations
 
 import importlib.util
 import datetime
+import io
+import contextlib
 import json
 import os
 import pathlib
@@ -393,6 +395,9 @@ def main() -> int:
         test_a_gate_that_cannot_run_fails_open,
         test_room_ops_records_only_a_successful_say,
         test_an_absent_ledger_still_blocks_after_the_first_stop,
+        test_the_command_line_surface,
+        test_a_result_older_than_the_boundary_is_not_this_turns,
+        test_bookkeeping_never_raises_into_the_send_path,
     ):
         print(f"{fn.__name__}:")
         fn()
@@ -422,6 +427,115 @@ def test_an_absent_ledger_still_blocks_after_the_first_stop():
         turn_ledger.record_send("room", "!r:example.org", workspace=ws)
         assert turn_ledger.stop_gate(ws) is None, "a recorded send lets the turn end"
         assert turn_ledger.stop_gate(ws) is not None, "the turn after it must block again"
+
+
+def test_the_command_line_surface() -> None:
+    """The hook shells out to this, so its argv handling is production code.
+
+    Covers each verb, `--workspace` stripping, and the usage path — a wrong exit
+    code here is indistinguishable from a verdict, and the hook only treats
+    `rc == 1` with a reason as a refusal.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = _workspace(tmp)
+        buf = io.StringIO()
+
+        with contextlib.redirect_stdout(buf):
+            first = turn_ledger.main(["--workspace", str(ws), "stop-gate"])
+        check("first stop allows (rc 0)", first == 0, repr(first))
+
+        with contextlib.redirect_stdout(buf):
+            second = turn_ledger.main(["--workspace", str(ws), "stop-gate"])
+        check("a silent second stop refuses (rc 1)", second == 1, repr(second))
+        check("the refusal prints a reason", "no-send" in buf.getvalue(), repr(buf.getvalue()[:80]))
+
+        rc = turn_ledger.main(["--workspace", str(ws), "send", "room", "!r:example.org"])
+        check("send records and exits 0", rc == 0, repr(rc))
+        check("send reached the ledger",
+              any(e["target"] == "!r:example.org" for e in turn_ledger.read_entries(ws)),
+              repr(turn_ledger.read_entries(ws)[-1:]))
+
+        with contextlib.redirect_stdout(buf):
+            check("a recorded send lets the turn end",
+                  turn_ledger.main(["--workspace", str(ws), "stop-gate"]) == 0, "")
+
+        rc = turn_ledger.main(["--workspace", str(ws), "no-send", "nothing", "to", "say"])
+        check("no-send records and exits 0", rc == 0, repr(rc))
+        check("no-send keeps its whole reason",
+              any(e.get("reason") == "nothing to say" for e in turn_ledger.read_entries(ws)),
+              repr(turn_ledger.read_entries(ws)[-1:]))
+
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            unknown = turn_ledger.main(["--workspace", str(ws), "wat"])
+        check("an unknown verb is rc 2, never a verdict", unknown == 2, repr(unknown))
+        check("usage goes to stderr", "usage:" in err.getvalue(), repr(err.getvalue()[:60]))
+
+
+def test_a_result_older_than_the_boundary_is_not_this_turns() -> None:
+    """The filters inside the result scan: too old, and present but not ready."""
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = _workspace(tmp)
+        (ws / "results").mkdir(parents=True, exist_ok=True)
+        boundary = time.time() - 5
+
+        stale = ws / "results" / "task-old.txt"
+        stale.write_text("an older answer\n")
+        os.utime(stale, (boundary - 60, boundary - 60))
+        check("a result older than the boundary is skipped",
+              turn_ledger.delivery_after(boundary, ws) is None,
+              repr(turn_ledger.delivery_after(boundary, ws)))
+
+        (ws / "results" / "task-empty.txt").write_text("   \n")
+        check("a fresh but unready result is not a message",
+              turn_ledger.delivery_after(boundary, ws) is None,
+              repr(turn_ledger.delivery_after(boundary, ws)))
+
+
+def test_bookkeeping_never_raises_into_the_send_path() -> None:
+    """Recording happens after a message has already gone out, so a failure here
+    must never propagate — the caller has nothing left to undo.
+
+    Exercises the failure branches directly: an unwritable state directory, and
+    a ledger holding a malformed line beside a good one.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = _workspace(tmp)
+        turn_ledger.record_send("room", "!good:example.org", workspace=ws)
+
+        # A corrupt line must be skipped, not crash the reader or hide the rest.
+        with open(turn_ledger.ledger_path(ws), "a", encoding="utf-8") as fh:
+            fh.write("\n")               # a blank line is skipped, not parsed
+            fh.write("not json at all\n")
+            fh.write(json.dumps({"no_ts": True}) + "\n")
+        entries = turn_ledger.read_entries(ws)
+        check("a malformed line is skipped, the good one survives",
+              any(e.get("target") == "!good:example.org" for e in entries),
+              repr(entries))
+
+        # A state dir that was never writable: the lock file cannot even be
+        # created, which is a different failure from an existing-but-locked one.
+        with tempfile.TemporaryDirectory() as tmp2:
+            fresh = _workspace(tmp2)
+            (fresh / "state").mkdir(parents=True, exist_ok=True)
+            os.chmod(fresh / "state", 0o500)
+            try:
+                turn_ledger.record_send("room", "!never:example.org", workspace=fresh)
+                check("a state dir that was never writable does not raise", True, "")
+            finally:
+                os.chmod(fresh / "state", 0o700)
+
+        state = ws / "state"
+        mode = state.stat().st_mode
+        os.chmod(state, 0o500)
+        try:
+            turn_ledger.record_send("room", "!blocked:example.org", workspace=ws)
+            turn_ledger.record_no_send("also blocked", workspace=ws)
+            check("an unwritable state dir does not raise", True, "")
+            check("the gate still answers rather than exploding",
+                  turn_ledger.stop_gate(ws) in (None,) or isinstance(turn_ledger.stop_gate(ws), str), "")
+        finally:
+            os.chmod(state, mode)
 
 
 if __name__ == "__main__":

--- a/tests/turn-ledger-stop-gate.test.py
+++ b/tests/turn-ledger-stop-gate.test.py
@@ -709,7 +709,8 @@ def test_the_reader_uses_the_writers_archive_calendar() -> None:
     while UTC says 2026-09, so the delivered reply became invisible and the turn
     was reminded for silence after it had answered.
     """
-    import calendar, task_archive
+    import calendar
+    import task_archive
     boundary = calendar.timegm(datetime.datetime(2026, 9, 1, 1, 0, 0).timetuple())
     previous = os.environ.get("TZ")
     try:

--- a/tests/turn-ledger-stop-gate.test.py
+++ b/tests/turn-ledger-stop-gate.test.py
@@ -33,6 +33,7 @@ Run: python3 tests/turn-ledger-stop-gate.test.py
 from __future__ import annotations
 
 import importlib.util
+import datetime
 import json
 import os
 import pathlib
@@ -191,22 +192,34 @@ def test_concurrent_writers_do_not_lose_or_interleave_a_line() -> None:
               f"{len(raw)} raw lines for {len(expected)} records")
 
 
-def test_an_archived_result_is_not_this_turns_message() -> None:
-    """A delivered result is archived within seconds, so it belongs to an earlier
-    boundary — and a turn that replied long ago then went silent is the case."""
+def test_an_archived_result_is_dated_not_dismissed() -> None:
+    """Archival does not establish a prior turn boundary.
+
+    The bridge archives a delivered result within seconds, independently of the
+    turn ending, so a reply made THIS turn is routinely archived before Stop
+    runs. Treating "archived" as "old" therefore blocks turns that did answer.
+    The boundary is the timestamp, not the directory.
+    """
     with tempfile.TemporaryDirectory() as tmp:
         ws = _workspace(tmp)
-        past = time.time() - 5
-        archive = ws / "results" / "archive" / "2026-09"
+        month = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m")
+        archive = ws / "results" / "archive" / month
         archive.mkdir(parents=True)
-        (archive / "task-1.txt").write_text("a delivered answer\n")
-        check("an archived result is not counted",
-              turn_ledger.delivery_after(past, ws) is None,
-              repr(turn_ledger.delivery_after(past, ws)))
-        (ws / "results" / "task-2.txt").write_text("a live answer\n")
-        check("a top-level result is counted",
-              (turn_ledger.delivery_after(past, ws) or {}).get("target") == "task-2.txt",
-              repr(turn_ledger.delivery_after(past, ws)))
+
+        boundary = time.time() - 5
+        fresh = archive / "task-this-turn.txt"
+        fresh.write_text("a delivered answer\n")
+        check("an archived result newer than the boundary IS this turn's message",
+              turn_ledger.delivery_after(boundary, ws) is not None,
+              repr(turn_ledger.delivery_after(boundary, ws)))
+
+        stale = archive / "task-last-turn.txt"
+        stale.write_text("an older answer\n")
+        os.utime(stale, (boundary - 60, boundary - 60))
+        fresh.unlink()
+        check("an archived result older than the boundary is not",
+              turn_ledger.delivery_after(boundary, ws) is None,
+              repr(turn_ledger.delivery_after(boundary, ws)))
 
 
 def test_an_absent_ledger_is_nothing_sent_not_unjudgeable() -> None:
@@ -369,7 +382,7 @@ def main() -> int:
         test_module_records_both_kinds,
         test_the_file_is_bounded_and_keeps_the_newest,
         test_concurrent_writers_do_not_lose_or_interleave_a_line,
-        test_an_archived_result_is_not_this_turns_message,
+        test_an_archived_result_is_dated_not_dismissed,
         test_an_absent_ledger_is_nothing_sent_not_unjudgeable,
         test_hook_blocks_a_silent_turn,
         test_a_recorded_send_lets_the_turn_end,

--- a/tests/turn-ledger-stop-gate.test.py
+++ b/tests/turn-ledger-stop-gate.test.py
@@ -41,6 +41,7 @@ import os
 import pathlib
 import subprocess
 import sys
+from unittest import mock
 import tempfile
 import time
 
@@ -396,6 +397,7 @@ def main() -> int:
         test_room_ops_records_only_a_successful_say,
         test_an_absent_ledger_still_blocks_after_the_first_stop,
         test_the_command_line_surface,
+        test_record_say_contract_in_process,
         test_a_result_older_than_the_boundary_is_not_this_turns,
         test_bookkeeping_never_raises_into_the_send_path,
     ):
@@ -536,6 +538,70 @@ def test_bookkeeping_never_raises_into_the_send_path() -> None:
                   turn_ledger.stop_gate(ws) in (None,) or isinstance(turn_ledger.stop_gate(ws), str), "")
         finally:
             os.chmod(state, mode)
+
+
+def test_record_say_contract_in_process() -> None:
+    """`_record_say`'s own contract, called directly.
+
+    The sibling test drives the real dispatch in a SUBPROCESS, which is the right
+    shape for the wiring but invisible to coverage run in this process — the added
+    lines read as untested. This exercises the same three cases in-process, so the
+    contract is measured where it is asserted.
+    """
+    room_ops_dir = str(REPO / "skills" / "agent-room-ops")
+    if room_ops_dir not in sys.path:
+        sys.path.insert(0, room_ops_dir)
+    import room_ops  # noqa: PLC0415 — imported here so the path insert above applies
+
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = _workspace(tmp)
+        # Both are required: the resolver honours the pin only in test mode.
+        os.environ["SUTANDO_TEST_MODE"] = "1"
+        os.environ["SUTANDO_WORKSPACE"] = str(ws)
+        assert turn_ledger.ledger_path().resolve() == (
+            ws / "state" / turn_ledger.LEDGER_NAME).resolve(), "unpinned — would write live"
+        try:
+            room_ops._record_say({"ok": True, "room_id": "!confirmed:ag2.space",
+                                  "event_id": "$evt"})
+            room_ops._record_say({"ok": True, "room_id": "!unconfirmed:ag2.space",
+                                  "event_id": None})
+            room_ops._record_say({"ok": False, "room_id": "!refused:ag2.space",
+                                  "event_id": None})
+            room_ops._record_say(None)
+            room_ops._record_say("not a dict")
+        finally:
+            os.environ.pop("SUTANDO_WORKSPACE", None)
+            os.environ.pop("SUTANDO_TEST_MODE", None)
+
+        # The dispatch call site, in-process: `_main` is what actually wires the
+        # recording to a send, and the sibling test reaches it only in a subprocess.
+        os.environ["SUTANDO_TEST_MODE"] = "1"
+        os.environ["SUTANDO_WORKSPACE"] = str(ws)
+        try:
+            with mock.patch.object(room_ops._say, "say",
+                                   return_value={"ok": True, "room_id": "!dispatch:ag2.space",
+                                                 "event_id": "$e"}):
+                room_ops._main(["say", "!dispatch:ag2.space", "hello"])
+
+            # The docstring promises this never raises into the send path. A message
+            # has already gone out by then, so there is nothing left to undo.
+            with mock.patch.object(turn_ledger, "record_send",
+                                   side_effect=RuntimeError("ledger exploded")), \
+                 mock.patch.dict(sys.modules, {"turn_ledger": turn_ledger}):
+                room_ops._record_say({"ok": True, "room_id": "!boom:ag2.space",
+                                      "event_id": "$e"})
+            check("a raising ledger does not break the send path", True, "")
+        finally:
+            os.environ.pop("SUTANDO_WORKSPACE", None)
+            os.environ.pop("SUTANDO_TEST_MODE", None)
+
+        targets = [e.get("target") for e in turn_ledger.read_entries(ws)]
+        check("the dispatch path records", "!dispatch:ag2.space" in targets, repr(targets))
+        check("a confirmed say is recorded", "!confirmed:ag2.space" in targets, repr(targets))
+        check("an unconfirmed say is recorded too (fail-open, matching receipt.py)",
+              "!unconfirmed:ag2.space" in targets, repr(targets))
+        check("a refused say records nothing", "!refused:ag2.space" not in targets, repr(targets))
+        check("a non-dict result is ignored rather than raising", True, "")
 
 
 if __name__ == "__main__":

--- a/tests/turn-ledger-stop-gate.test.py
+++ b/tests/turn-ledger-stop-gate.test.py
@@ -39,6 +39,7 @@ import contextlib
 import json
 import os
 import pathlib
+import re
 import subprocess
 import sys
 from unittest import mock
@@ -405,6 +406,7 @@ def main() -> int:
         test_one_reminder_per_turn_not_a_standing_refusal,
         test_ended_on_a_message_versus_sent_then_went_quiet,
         test_a_delivered_result_archived_flat_is_still_a_message,
+        test_concurrent_writers_while_compaction_is_firing,
         test_the_reader_uses_the_writers_archive_calendar,
         test_turn_start_is_reachable_from_the_command_line,
         test_record_say_contract_in_process,
@@ -700,6 +702,70 @@ def test_a_delivered_result_archived_flat_is_still_a_message() -> None:
         found = turn_ledger._result_after(since, ws)
         check("a flat-archived delivery is found",
               found is not None and "task-abc123" in found["target"], repr(found))
+
+
+def test_concurrent_writers_while_compaction_is_firing() -> None:
+    """Appends racing an actual trim, unlike the sibling test which never trims.
+
+    What this establishes: with compaction firing throughout, no line is torn, no
+    surviving run has a hole, and the tail is a new record.
+
+    What it does NOT establish: that the writer lock is required. Moving `_trim`
+    outside the lock still passes. Only ~7% of appends survive an aggressive trim,
+    so a race-lost append is indistinguishable from a legitimately evicted one.
+    """
+    workers, per_worker = 8, 60
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = _workspace(tmp)
+        path = turn_ledger.ledger_path(ws)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        filler = json.dumps({"kind": "room", "target": "old", "ts": 1.0}) + "\n"
+        # Just under the cap, so the first concurrent appends push it over.
+        worker_cap = 4096
+        path.write_text(filler * ((worker_cap // len(filler)) - 2), encoding="utf-8")
+        before = path.stat().st_size
+        check("setup: primed close to the workers' trim threshold",
+              worker_cap * 0.8 < before <= worker_cap, f"{before} vs cap {worker_cap}")
+        # Every append must cross the cap, or the trim fires once and the racing
+        # window is too narrow for the defect to show at all.
+        code = ("import sys; sys.path.insert(0, sys.argv[1])\n"
+                "import turn_ledger\n"
+                "turn_ledger.MAX_BYTES = 4096\n"
+                # Both, or the seek runs past the file, raises, and is swallowed:
+                # the trim then silently never runs and the race is never exercised.
+                "turn_ledger.TRIM_TO_BYTES = 2048\n"
+                "for i in range(%d): turn_ledger.record_send('room', sys.argv[3] + '-%%03d' %% i, sys.argv[2])\n"
+                % per_worker)
+        procs = [subprocess.Popen([sys.executable, "-c", code, str(REPO / "src"), str(ws), f"c{p}"])
+                 for p in range(workers)]
+        for proc in procs:
+            proc.wait()
+        raw = [ln for ln in path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+        entries = turn_ledger.read_entries(ws)
+        check("compaction actually fired", path.stat().st_size <= worker_cap * 1.5,
+              f"{path.stat().st_size} vs worker cap {worker_cap}")
+        check("every surviving line is whole", len(entries) == len(raw),
+              f"{len(entries)} parsed of {len(raw)} raw — a torn line survived")
+        # A trim legitimately evicts OLD records, so completeness is not the
+        # invariant; surviving new records must not be corrupted or interleaved.
+        survivors = {e["target"] for e in entries if str(e.get("target", "")).startswith("c")}
+        bad = sorted(t for t in survivors if not re.fullmatch(r"c\d-\d{3}", t))
+        check("surviving new records are well formed", bool(survivors) and not bad,
+              f"{len(survivors)} survivors, malformed: {bad[:4]}")
+        # The discriminator. A trim evicts the OLDEST records, so per worker the
+        # survivors must be a contiguous suffix; a hole is an append the trim ate.
+        holes = []
+        for worker in range(workers):
+            got = sorted(int(t[3:]) for t in survivors if t.startswith(f"c{worker}-"))
+            if got and got != list(range(got[0], got[0] + len(got))):
+                missing = [i for i in range(got[0], got[-1]) if i not in set(got)]
+                holes.append(f"c{worker}: {len(missing)} lost, e.g. {missing[:3]}")
+        check("no append was swallowed by a concurrent trim", not holes, "; ".join(holes[:3]))
+        # A trim keeps the TAIL, so whatever is last on disk must be a new record.
+        # Which worker survives is timing; that the newest write is retained is not.
+        last = json.loads(raw[-1])
+        check("the last line on disk is a new record, not an evicted old one",
+              str(last.get("target", "")).startswith("c"), f"tail is {last.get('target')!r}")
 
 
 def test_the_reader_uses_the_writers_archive_calendar() -> None:

--- a/tests/turn-ledger-stop-gate.test.py
+++ b/tests/turn-ledger-stop-gate.test.py
@@ -644,23 +644,32 @@ def test_one_reminder_per_turn_not_a_standing_refusal() -> None:
 def test_ended_on_a_message_versus_sent_then_went_quiet() -> None:
     """The distinction the owner corrected me on twice.
 
-    "A message was sent this turn" is not "the turn ended on a message". A turn
-    that replies, works for ten minutes, then stops silently satisfies the first
-    and violates the second — and it is the case I kept committing.
+    Each case gets its own workspace. A successful `stop_gate` advances the
+    boundary past the send, so reusing one would leave the second case with
+    nothing after the boundary — it would then be reminded for "nothing sent"
+    and pass without ever exercising the elapsed-time rule.
     """
     with tempfile.TemporaryDirectory() as tmp:
         ws = _workspace(tmp)
-        turn_ledger.stop_gate(ws)
-
+        turn_ledger.stop_gate(ws)                     # boundary
         turn_ledger.begin_turn(ws)
         turn_ledger.record_send("room", "!r:example.org", workspace=ws)
         check("a message just sent ends the turn cleanly",
               turn_ledger.stop_gate(ws) is None, "")
 
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = _workspace(tmp)
+        turn_ledger.stop_gate(ws)                     # boundary
+        turn_ledger.begin_turn(ws)
+        turn_ledger.record_send("room", "!r:example.org", workspace=ws)
         original = turn_ledger.ENDED_ON_A_MESSAGE_S
         try:
-            turn_ledger.ENDED_ON_A_MESSAGE_S = 0.001   # the send is now "long ago"
-            turn_ledger.begin_turn(ws)
+            turn_ledger.ENDED_ON_A_MESSAGE_S = 0.0    # the send is now "long ago"
+            # The send is still AFTER the boundary, so this measures the elapsed
+            # rule rather than an empty window.
+            assert turn_ledger.delivery_after(turn_ledger.last_stop_ts(ws), ws) is not None, (
+                "setup wrong: nothing after the boundary, so the rule is untested"
+            )
             check("a turn that sent early then went quiet IS reminded",
                   turn_ledger.stop_gate(ws) is not None,
                   "this is the case the previous design could not see")

--- a/tests/turn-ledger-stop-gate.test.py
+++ b/tests/turn-ledger-stop-gate.test.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""A turn must end in a message or an explicit no-send.
+
+THE GAP. `src/check-pending-tasks.sh` walks `<workspace>/tasks/` and requires a
+ready `results/<same name>`, so it only ever sees a turn that ANSWERS A QUEUED
+TASK. A proactive turn, or one that replies through `room_ops.py say`, has no
+task file — and `say` writes nothing to disk — so the hook saw an empty queue,
+emitted `{}`, and the agent went idle having said nothing to anybody. The owner's
+rule ("the end of a turn must be a msg or no-send") had no enforcement surface at
+all, because no surface knew whether a message had happened.
+
+WHAT IS PINNED, AND WHY EACH CASE EARNS ITS PLACE:
+
+  • The two evidence surfaces separately (a recorded send; a READY result file),
+    because either one alone would pass a hook that only implemented the other.
+  • An UNREADY result file must NOT count. A hook that accepted any file in
+    `results/` would pass the empty-result case the sibling suite exists to
+    reject, and readiness has one owner (`delivery.readiness`).
+  • Both directions of the arming rule. "Inert with no ledger" is what keeps the
+    three quiet cases in `check-pending-tasks-workspace.test.sh` quiet, so it is
+    a contract, not an accident — and a gate that were inert in BOTH states would
+    satisfy it while enforcing nothing, which is why the armed block is pinned
+    beside it.
+  • The boundary ADVANCES. Without `mark_stop` the gate would pass forever on one
+    ancient send; the two-stops-in-a-row case is the only one that can tell a
+    live boundary from a frozen one.
+  • Task-block precedence, so the new gate cannot mask the older reason.
+  • Fail-open when the gate itself cannot run. A Stop gate that fails closed
+    wedges the agent into a turn it has no action left to end.
+
+Run: python3 tests/turn-ledger-stop-gate.test.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+import time
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+LEDGER_CLI = REPO / "src" / "turn_ledger.py"
+ROOM_OPS = REPO / "skills" / "agent-room-ops"
+
+sys.path.insert(0, str(REPO / "src"))
+import turn_ledger  # noqa: E402
+
+
+def _load_sibling_stub():
+    """Reuse `_stub` from the sibling suite rather than copying its pinning.
+
+    `_stub` pins REPO_DIR as well as the workspace: run from a temp dir,
+    `dirname $0/..` points outside the repo, `sutando-config.sh` is never found,
+    and the interpreter cascade silently falls back to PATH — the test would then
+    measure the fallback instead of the contract. Its assertions on the hook's
+    layout also fail loudly here if the hook is restructured.
+    """
+    path = REPO / "tests" / "stop-hook-emits-valid-json.test.py"
+    spec = importlib.util.spec_from_file_location("_stop_hook_sibling", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod._stub
+
+
+_stub = _load_sibling_stub()
+
+FAILURES: list[str] = []
+
+
+def check(label: str, cond: bool, detail: str = "") -> None:
+    if cond:
+        print(f"  ok   {label}")
+    else:
+        print(f"  FAIL {label}\n     {detail}")
+        FAILURES.append(label)
+
+
+def _workspace(tmp: str) -> pathlib.Path:
+    ws = pathlib.Path(tmp)
+    (ws / "tasks").mkdir(exist_ok=True)
+    (ws / "results").mkdir(exist_ok=True)
+    return ws
+
+
+def _hook(ws: pathlib.Path, repo_dir: pathlib.Path | None = None) -> dict:
+    """Run the real hook against `ws`; return its decision ({} = may stop)."""
+    stub = _stub(ws)
+    if repo_dir is not None:
+        stub.write_text(stub.read_text().replace(f'REPO_DIR="{REPO}"',
+                                                 f'REPO_DIR="{repo_dir}"'))
+    out = subprocess.run(["/bin/bash", str(stub)], capture_output=True, text=True,
+                         stdin=subprocess.DEVNULL)
+    assert out.returncode == 0, f"hook exited {out.returncode}: {out.stderr}"
+    return json.loads(out.stdout or "{}")
+
+
+def _cli(ws: pathlib.Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run([sys.executable, str(LEDGER_CLI), "--workspace", str(ws), *args],
+                          capture_output=True, text=True)
+
+
+def _arm(ws: pathlib.Path) -> None:
+    """Give the install its first recorded action, which is what arms the gate."""
+    turn_ledger.record_no_send("arming the gate for this test", ws)
+
+
+def _blocked(decision: dict) -> bool:
+    return decision.get("decision") == "block"
+
+
+def test_module_records_both_kinds() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = _workspace(tmp)
+        turn_ledger.record_send("room", "!abc:ag2.space", ws)
+        turn_ledger.record_no_send("nothing worth saying", ws)
+        lines = turn_ledger.ledger_path(ws).read_text().splitlines()
+        entries = [json.loads(x) for x in lines]
+        check("a send records kind + target",
+              entries[0]["kind"] == "room" and entries[0]["target"] == "!abc:ag2.space",
+              repr(entries[0]))
+        check("a no-send records its reason",
+              entries[1]["kind"] == "no-send" and entries[1]["reason"] == "nothing worth saying",
+              repr(entries[1]))
+        check("every entry carries a numeric ts",
+              all(isinstance(e["ts"], float) for e in entries), repr(entries))
+
+        now = time.time()
+        check("last_action_after returns the newest entry",
+              turn_ledger.last_action_after(0, ws)["kind"] == "no-send",
+              repr(turn_ledger.last_action_after(0, ws)))
+        check("last_action_after is None when nothing is newer",
+              turn_ledger.last_action_after(now + 60, ws) is None,
+              repr(turn_ledger.last_action_after(now + 60, ws)))
+
+
+def test_the_file_is_bounded_and_keeps_the_newest() -> None:
+    """Past the cap, the oldest go and every surviving line still parses.
+
+    The trim seeks to a byte offset, which lands mid-line; a scanner that kept
+    that fragment would leave an unparseable first line in a file whose whole
+    purpose is to be read back.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = _workspace(tmp)
+        for i in range(4000):
+            turn_ledger.record_send("room", f"!room-{i:06d}:ag2.space", ws)
+        size = turn_ledger.ledger_path(ws).stat().st_size
+        raw = turn_ledger.ledger_path(ws).read_text().splitlines()
+        entries = turn_ledger.read_entries(ws)
+        check("the ledger stays under the cap", size <= turn_ledger.MAX_BYTES,
+              f"{size} bytes > {turn_ledger.MAX_BYTES}")
+        # What survives must be a contiguous NEWEST suffix. "the last entry is
+        # last" is true of any trim direction — the newest append lands at the end.
+        kept = [int(e["target"][6:12]) for e in entries]
+        check("what survives is a contiguous suffix of the newest",
+              kept and kept[0] > 0 and kept == list(range(kept[0], 4000)),
+              f"kept {len(kept)} entries, first={kept[0] if kept else None}, "
+              f"contiguous={kept == list(range(kept[0], 4000)) if kept else False}")
+        check("no half-line survived the trim", len(entries) == len(raw),
+              f"{len(raw)} lines but only {len(entries)} parsed")
+
+
+def test_concurrent_writers_do_not_lose_or_interleave_a_line() -> None:
+    """Through the production writer, per the shared-record rule in CLAUDE.md.
+
+    Several workers can record in the same window. O_APPEND plus one `write()`
+    per line is what makes that safe; a read-modify-write would silently drop
+    whichever writer read first, and the loss is invisible in the file — it just
+    holds fewer lines than were recorded.
+    """
+    workers, per_worker = 8, 60
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = _workspace(tmp)
+        code = ("import sys; sys.path.insert(0, sys.argv[1])\n"
+                "import turn_ledger\n"
+                "for i in range(%d): turn_ledger.record_send('room', sys.argv[3] + '-%%03d' %% i, sys.argv[2])\n"
+                % per_worker)
+        procs = [subprocess.Popen([sys.executable, "-c", code, str(REPO / "src"), str(ws), f"w{p}"])
+                 for p in range(workers)]
+        for proc in procs:
+            proc.wait()
+        raw = [ln for ln in turn_ledger.ledger_path(ws).read_text().splitlines() if ln.strip()]
+        targets = {e["target"] for e in turn_ledger.read_entries(ws)}
+        expected = {f"w{p}-{i:03d}" for p in range(workers) for i in range(per_worker)}
+        check("no concurrent write was lost", targets == expected,
+              f"{len(targets)} of {len(expected)} recorded; missing {len(expected - targets)}")
+        check("no line was interleaved", len(raw) == len(expected),
+              f"{len(raw)} raw lines for {len(expected)} records")
+
+
+def test_an_archived_result_is_not_this_turns_message() -> None:
+    """A delivered result is archived within seconds, so it belongs to an earlier
+    boundary — and a turn that replied long ago then went silent is the case."""
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = _workspace(tmp)
+        past = time.time() - 5
+        archive = ws / "results" / "archive" / "2026-09"
+        archive.mkdir(parents=True)
+        (archive / "task-1.txt").write_text("a delivered answer\n")
+        check("an archived result is not counted",
+              turn_ledger.delivery_after(past, ws) is None,
+              repr(turn_ledger.delivery_after(past, ws)))
+        (ws / "results" / "task-2.txt").write_text("a live answer\n")
+        check("a top-level result is counted",
+              (turn_ledger.delivery_after(past, ws) or {}).get("target") == "task-2.txt",
+              repr(turn_ledger.delivery_after(past, ws)))
+
+
+def test_hook_is_inert_until_the_ledger_exists() -> None:
+    """The arming rule, and the reason the sibling suites stay green."""
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = _workspace(tmp)
+        check("no ledger: an empty queue still emits {}", _hook(ws) == {}, repr(_hook(ws)))
+        check("no ledger: a second stop is still quiet", _hook(ws) == {}, repr(_hook(ws)))
+
+
+def test_hook_blocks_a_silent_turn() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = _workspace(tmp)
+        _arm(ws)
+        _hook(ws)  # consumes the arming entry and sets the boundary
+        decision = _hook(ws)
+        check("armed + nothing said: the turn is blocked", _blocked(decision), repr(decision))
+        check("the block says why",
+              "no-send" in json.dumps(decision) and "message" in decision["reason"],
+              repr(decision))
+
+
+def test_a_recorded_send_lets_the_turn_end() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = _workspace(tmp)
+        _arm(ws)
+        _hook(ws)
+        turn_ledger.record_send("room", "!r:ag2.space", ws)
+        check("a send since the last stop ends the turn", _hook(ws) == {}, repr(_hook(ws)))
+
+
+def test_a_recorded_no_send_lets_the_turn_end() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = _workspace(tmp)
+        _arm(ws)
+        _hook(ws)
+        res = _cli(ws, "no-send", "read-only turn, nothing to report")
+        check("the no-send CLI exits 0", res.returncode == 0, res.stderr)
+        check("an explicit no-send ends the turn", _hook(ws) == {}, repr(_hook(ws)))
+
+
+def test_the_result_file_surface() -> None:
+    """The other way a reply leaves this agent — and readiness still decides."""
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = _workspace(tmp)
+        _arm(ws)
+        _hook(ws)
+        (ws / "results" / "proactive-1.txt").write_text("   \n\t\n")
+        decision = _hook(ws)
+        check("a whitespace-only result is not a message", _blocked(decision), repr(decision))
+        (ws / "results" / "proactive-1.txt").write_text("here is the thing I found\n")
+        check("a ready result ends the turn", _hook(ws) == {}, repr(_hook(ws)))
+
+
+def test_the_boundary_advances() -> None:
+    """One send must license exactly one turn ending, not every future one."""
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = _workspace(tmp)
+        _arm(ws)
+        _hook(ws)
+        turn_ledger.record_send("room", "!r:ag2.space", ws)
+        first = _hook(ws)
+        second = _hook(ws)
+        check("the turn that spoke may end", first == {}, repr(first))
+        check("the next turn cannot reuse that send", _blocked(second), repr(second))
+
+
+def test_an_unanswered_task_still_blocks_with_the_task_reason() -> None:
+    """Precedence: the new gate must not mask the older, more specific reason."""
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = _workspace(tmp)
+        _arm(ws)
+        (ws / "tasks" / "task-1.txt").write_text("id: task-1\ntask: answer me\n")
+        decision = _hook(ws)
+        check("an unanswered task still blocks", _blocked(decision), repr(decision))
+        check("and it is still the task reason",
+              decision["reason"] == "Unprocessed tasks in tasks/", repr(decision))
+        check("naming the task", "task-1.txt" in decision["additionalContext"],
+              repr(decision)[:200])
+
+
+def test_a_gate_that_cannot_run_fails_open() -> None:
+    """A crashing gate exits nonzero with nothing on stdout — the same shape as a
+    refusal minus the reason. It must let the turn end: a Stop gate that fails
+    closed leaves the agent no action that clears it."""
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = _workspace(tmp)
+        _arm(ws)
+        _hook(ws)
+        check("control: this fixture blocks with the real gate", _blocked(_hook(ws)),
+              "the fail-open case below would prove nothing")
+
+        shadow = pathlib.Path(tmp) / "shadow-repo"
+        (shadow / "src").mkdir(parents=True)
+        (shadow / "scripts").symlink_to(REPO / "scripts")
+        (shadow / "src" / "delivery").symlink_to(REPO / "src" / "delivery")
+        (shadow / "src" / "turn_ledger.py").write_text(
+            "import sys\nraise SystemExit(1)\n")
+        decision = _hook(ws, repo_dir=shadow)
+        check("a broken gate lets the turn end", decision == {}, repr(decision))
+
+
+def test_room_ops_records_only_a_successful_say() -> None:
+    """The wiring, through `room_ops._main` — the real dispatch, not a re-call.
+
+    Run in a subprocess with the workspace pinned through the repo's documented
+    test hatch, and the resolved path ASSERTED inside it: an unpinned run would
+    write into the caller's live workspace, and this test is the one place that
+    exercises resolution rather than passing a path.
+    """
+    driver = '''
+import json, os, pathlib, sys
+from unittest import mock
+sys.path.insert(0, os.environ["ROOM_OPS"])
+sys.path.insert(0, os.environ["SRC"])
+import turn_ledger, room_ops
+ws = pathlib.Path(os.environ["WS"]).resolve()
+resolved = turn_ledger.ledger_path().resolve()
+assert resolved == ws / "state" / turn_ledger.LEDGER_NAME, f"unpinned: {resolved}"
+for ok, eid in ((True, "$evt"), (True, None), (False, None)):
+    res = {"ok": ok, "room_id": "!r:ag2.space", "event_id": eid}
+    with mock.patch.object(room_ops._say, "say", return_value=res):
+        room_ops._main(["say", "!r:ag2.space", "hello"])
+print(json.dumps(turn_ledger.read_entries()))
+'''
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = _workspace(tmp)
+        env = dict(os.environ, SUTANDO_TEST_MODE="1", SUTANDO_WORKSPACE=str(ws),
+                   ROOM_OPS=str(ROOM_OPS), SRC=str(REPO / "src"), WS=str(ws))
+        out = subprocess.run([sys.executable, "-c", driver], capture_output=True,
+                             text=True, env=env)
+        if out.returncode != 0:
+            check("room_ops driver ran", False, out.stderr[-600:])
+            return
+        entries = json.loads(out.stdout.strip().splitlines()[-1])
+        check("a confirmed say is recorded",
+              len(entries) >= 1 and entries[0] == {**entries[0], "kind": "room",
+                                                   "target": "!r:ag2.space"},
+              repr(entries))
+        check("an unconfirmed (ok, no event id) say is recorded too",
+              len(entries) == 2, f"expected 2 entries, got {len(entries)}: {entries}")
+        check("a failed say records nothing",
+              all(e.get("target") == "!r:ag2.space" for e in entries) and len(entries) == 2,
+              repr(entries))
+
+
+def main() -> int:
+    for fn in (
+        test_module_records_both_kinds,
+        test_the_file_is_bounded_and_keeps_the_newest,
+        test_concurrent_writers_do_not_lose_or_interleave_a_line,
+        test_an_archived_result_is_not_this_turns_message,
+        test_hook_is_inert_until_the_ledger_exists,
+        test_hook_blocks_a_silent_turn,
+        test_a_recorded_send_lets_the_turn_end,
+        test_a_recorded_no_send_lets_the_turn_end,
+        test_the_result_file_surface,
+        test_the_boundary_advances,
+        test_an_unanswered_task_still_blocks_with_the_task_reason,
+        test_a_gate_that_cannot_run_fails_open,
+        test_room_ops_records_only_a_successful_say,
+    ):
+        print(f"{fn.__name__}:")
+        fn()
+    if FAILURES:
+        print(f"turn-ledger-stop-gate: FAIL ({len(FAILURES)}): {', '.join(FAILURES)}")
+        return 1
+    print("turn-ledger-stop-gate: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/turn-ledger-stop-gate.test.py
+++ b/tests/turn-ledger-stop-gate.test.py
@@ -405,6 +405,7 @@ def main() -> int:
         test_one_reminder_per_turn_not_a_standing_refusal,
         test_ended_on_a_message_versus_sent_then_went_quiet,
         test_a_delivered_result_archived_flat_is_still_a_message,
+        test_the_reader_uses_the_writers_archive_calendar,
         test_turn_start_is_reachable_from_the_command_line,
         test_record_say_contract_in_process,
         test_a_result_older_than_the_boundary_is_not_this_turns,
@@ -699,6 +700,42 @@ def test_a_delivered_result_archived_flat_is_still_a_message() -> None:
         found = turn_ledger._result_after(since, ws)
         check("a flat-archived delivery is found",
               found is not None and "task-abc123" in found["target"], repr(found))
+
+
+def test_the_reader_uses_the_writers_archive_calendar() -> None:
+    """The writer partitions by LOCAL month; a UTC reader misses it at a boundary.
+
+    Frozen at 2026-09-01 01:00 UTC, a Los Angeles host archives into 2026-08
+    while UTC says 2026-09, so the delivered reply became invisible and the turn
+    was reminded for silence after it had answered.
+    """
+    import calendar, task_archive
+    boundary = calendar.timegm(datetime.datetime(2026, 9, 1, 1, 0, 0).timetuple())
+    previous = os.environ.get("TZ")
+    try:
+        os.environ["TZ"] = "America/Los_Angeles"
+        time.tzset()
+        writer_month = task_archive.archive_month(boundary)
+        utc_month = datetime.datetime.fromtimestamp(
+            boundary, datetime.timezone.utc).strftime("%Y-%m")
+        check("setup: the two calendars genuinely disagree here",
+              writer_month != utc_month, f"{writer_month} vs {utc_month}")
+        with tempfile.TemporaryDirectory() as tmp:
+            ws = _workspace(tmp)
+            partition = pathlib.Path(ws) / "results" / "archive" / writer_month
+            partition.mkdir(parents=True, exist_ok=True)
+            reply = partition / "task-reply.txt"
+            reply.write_text("a real reply\n", encoding="utf-8")
+            os.utime(reply, (boundary + 30, boundary + 30))
+            found = turn_ledger._result_after(boundary - 60, ws)
+            check("a reply in the writer's partition is found",
+                  found is not None and "task-reply" in found["target"], repr(found))
+    finally:
+        if previous is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = previous
+        time.tzset()
 
 
 def test_turn_start_is_reachable_from_the_command_line() -> None:

--- a/tests/turn-ledger-stop-gate.test.py
+++ b/tests/turn-ledger-stop-gate.test.py
@@ -665,8 +665,7 @@ def test_ended_on_a_message_versus_sent_then_went_quiet() -> None:
         original = turn_ledger.ENDED_ON_A_MESSAGE_S
         try:
             turn_ledger.ENDED_ON_A_MESSAGE_S = 0.0    # the send is now "long ago"
-            # The send is still AFTER the boundary, so this measures the elapsed
-            # rule rather than an empty window.
+            # Still after the boundary, so this measures the elapsed rule.
             assert turn_ledger.delivery_after(turn_ledger.last_stop_ts(ws), ws) is not None, (
                 "setup wrong: nothing after the boundary, so the rule is untested"
             )


### PR DESCRIPTION
## What changed, and why

The owner's rule: **"the end of a turn must be a msg or no-send."** There was no
surface that could enforce it.

`src/check-pending-tasks.sh` (the Stop hook, registered on every install by
`src/install-claude-hooks.sh`) can only see a turn that **answers a queued task**:
it walks `<workspace>/tasks/` and requires a ready `results/<same name>`. A
proactive turn, or one that replies by calling `skills/agent-room-ops/room_ops.py
say`, has no task file — and `say` posts over HTTP and **writes nothing to disk**
— so the hook read an empty queue, emitted `{}`, and the agent went idle having
said nothing to anybody. Nothing anywhere recorded whether a message had happened.

This adds the missing record and gates the Stop on it.

- **`src/turn_ledger.py`** (new) — append-only JSONL at `<workspace>/state/turn-ledger.jsonl`,
  one line per outbound message (`{ts, kind, target}`) or explicit no-send
  (`{ts, kind: "no-send", reason}`). `O_APPEND` + a single `write()` per line, so
  concurrent workers cannot interleave and nothing read-modify-writes the log.
- **`skills/agent-room-ops/room_ops.py`** — a successful `say` records `("room", room_id)`.
  Import and call are both defensive; the skill keeps working with `src/` unreachable.
- **`src/check-pending-tasks.sh`** — after the existing task checks pass, refuse the
  Stop when nothing was sent and no no-send was recorded since the previous Stop.

Only the **first** Stop on a fresh install is unjudgeable (no boundary to measure
from). An absent ledger file is *not* an excuse to pass: a turn that never sends
never creates one, so treating "no ledger" as "cannot judge" would make the gate
inert for exactly the case it exists to catch.

## What reviewers should look at first

1. `src/turn_ledger.py::stop_gate` — the unjudgeable-first-stop rule and the two evidence surfaces.
2. `src/check-pending-tasks.sh` — the fail-open condition (`rc 1 AND a reason`).
3. `skills/agent-room-ops/room_ops.py::_record_say` — **records on `ok`, not on an event id**
   (see "Deviations" below).

## Before / after evidence

`scratchpad/demo.sh` pins a temp workspace through the documented
`SUTANDO_TEST_MODE` hatch and asserts the resolved path before writing.

### BEFORE — parent commit 2e68e8c2

```
### BEFORE — parent commit (PR #4025 head)  (2e68e8c2)
workspace pinned to: /private/var/folders/.../tmp.q21KPv9VQc
-- is there any record-of-message mechanism at all?
   src/turn_ledger.py: ABSENT — nothing records that the agent spoke
-- turn 1: the agent replies (a room message, the surface that writes no file)
   (nothing to record with)
   hook says: {}
-- turn 2: the agent works, then stops WITHOUT a message and WITHOUT a no-send
   tasks/ is empty:   0 files
   results/ is empty: 0 files
   hook says: {}
-- turn 2 again, after the agent records an explicit no-send
   hook says: {}
```

The silent turn and the answered turn are indistinguishable — both `{}`.

### AFTER — this PR (bbceb0e8)

```
### AFTER — this PR  (bbceb0e8)
workspace pinned to: /private/var/folders/.../tmp.usKFfh000P
-- is there any record-of-message mechanism at all?
   src/turn_ledger.py: present
-- turn 1: the agent replies (a room message, the surface that writes no file)
   ledger: {"kind": "room", "target": "!room:ag2.space", "ts": 1788832955.879152}
   hook says: {}
-- turn 2: the agent works, then stops WITHOUT a message and WITHOUT a no-send
   tasks/ is empty:   0 files
   results/ is empty: 0 files
   hook says: {"decision":"block","reason":"Turn is ending without a message or an explicit no-send","additionalContext":"This turn is ending without a message and without an explicit no-send. End the turn by replying — post to the room (`room_ops.py say`) or write the result file the task expects — or, if silence is the right answer, record that decision: `python3 src/turn_ledger.py no-send \"<why>\"`."}
-- turn 2 again, after the agent records an explicit no-send
   hook says: {}
```

## Tests

New: `tests/turn-ledger-stop-gate.test.py` — 30 assertions, all mutation-checked against HEAD.

```
$ python3 tests/turn-ledger-stop-gate.test.py
...
turn-ledger-stop-gate: PASS
```

Both suites that pin the existing behaviour still pass (the workspace suite with the three-line adjustment described below):

```
$ python3 tests/stop-hook-emits-valid-json.test.py
stop-hook-emits-valid-json: PASS

$ bash tests/check-pending-tasks-workspace.test.sh
  ok   workspace task blocks
  ok   block payload names the task
  ok   result present suppresses the block
  ok   legacy <repo>/tasks/ does not block
  ok   empty queue emits {}
PASS
```

### Mutation checks

Every new assertion was proved live by breaking the implementation and confirming
the specific assertion fails. Each mutation is verified byte-identical to the
intended text on disk **before** the test runs (an exact-text comparison, not a
substring check — a replacement whose new string contains the old one defeats
that, which is how a no-op replace hides), and the file is restored byte-for-byte
after, with the suite re-run to confirm it returns to green.

```
DETECTED       M1 arming rule reinstated             -> a second silent turn is refused
DETECTED       M2 boundary never advances           -> the next turn cannot reuse that send
DETECTED       M3 gate never refuses                -> armed + nothing said: the turn is blocked (+4)
DETECTED       M4 readiness ignored for results     -> a whitespace-only result is not a message
DETECTED       M5 result scan points at the archive -> an archived result is not counted (+2)
DETECTED       M6 room_ops wiring removed           -> a confirmed say is recorded (+2)
DETECTED       M7 room_ops records failed sends     -> a failed say records nothing
DETECTED       M8 bound removed                     -> the ledger stays under the cap
DETECTED       M9 trim keeps the OLDEST             -> what survives is a contiguous suffix of the newest
DETECTED       M10 mid-line fragment kept           -> no half-line survived the trim
DETECTED       M11 hook fails CLOSED instead of open-> a broken gate lets the turn end
DETECTED       M12 last_action_after returns oldest -> last_action_after returns the newest entry
ALL MUTATIONS DETECTED
```

M13, run separately — replacing the O_APPEND write with a read-modify-write (the
anti-pattern CLAUDE.md's shared-record rule forbids). Landing was verified by
exact-text comparison of the file against the intended mutation, not a substring
check:

```
$ grep -c "prior + line" src/turn_ledger.py
1                                     # <- read-modify-write in place
$ python3 tests/turn-ledger-stop-gate.test.py
test_concurrent_writers_do_not_lose_or_interleave_a_line:
  FAIL no concurrent write was lost
     15 of 480 recorded; missing 465
  FAIL no line was interleaved
turn-ledger-stop-gate: FAIL (2)
# restored:
turn-ledger-stop-gate: PASS
```

M9 replaced a weaker assertion. The original ("the last entry is the newest") is
true of *any* trim direction, because the newest append always lands at the end;
only "what survives is a contiguous suffix" can see a head-keeping trim.

### Why there is no "arming" rule

An earlier revision of this branch made the gate inert until the ledger file
existed, so the sibling suite would stay green untouched. That was wrong, and
measurably so — the ledger is created only by a recorded send, so a turn that
never sends never creates the file that would catch it:

```
# the earlier revision (2a25863e), five consecutive silent stops:
['allowed', 'allowed', 'allowed', 'allowed', 'allowed']

# HEAD (d54a631c), same fixture, no ledger file present at all:
  stop 1 -> rc=0 (allowed — first stop has no boundary to measure from)
  stop 2 -> rc=1 (blocked)
  stop 3 -> rc=1 (blocked)
  ledger file exists? NO
```

`tests/check-pending-tasks-workspace.test.sh` gained three lines as a result: its
cases 4 and 5 assert the TASK gate, so they now satisfy the turn gate first
(`record_delivery`) rather than measuring the wrong refusal. Both directions of
that suite's original intent are unchanged and it passes.

### review-checks

```
$ bash scripts/review-checks.sh --diff <(git diff 2e68e8c2...HEAD)
prose-cap: PASS (comment blocks within cap 2, exts .py)
review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
```

Scanned 6 files / 758 insertions. Negative control, so the PASS is not the
silent zero-file case:

```
$ bash scripts/review-checks.sh --diff /dev/null
review-checks: ERROR — empty diff; nothing was scanned, so this is NOT a pass.
```

## Worst-case disruption (REVIEW.md lesson 5)

**This is always-on.** `src/install-claude-hooks.sh:99` registers
`Stop → src/check-pending-tasks.sh` on every install, so once the ledger arms on
a host, every turn there must end in a message or a recorded no-send. **That is
the reviewer's decision point**, and the reason this is a PR rather than a
deployment. Four things bound it:

1. **It is live from the second Stop on every install** — there is no arming
   grace period, deliberately (see above). This is the biggest single thing to
   weigh before merging.
2. **Fail-open.** Any gate error (missing module, crash, rc 2) lets the turn end.
   A Stop gate that failed closed would wedge the agent into a turn it has no
   action left to end — pinned by `test_a_gate_that_cannot_run_fails_open`.
3. **The result-file surface.** The ordinary case — answer a task, stop — passes
   without any new agent behaviour, because a ready `results/*.txt` counts.
4. **A one-command escape** that always clears the block:
   `python3 src/turn_ledger.py no-send "<why>"`.

No unrecoverable state exists: `no-send` always clears. If a reviewer wants this
opt-in for a release first, the natural seam is a config gate in `stop_gate`.

## Deviations from the brief, and why

1. **Branched off PR #4025, not `origin/main`.** The brief told me to use `"$PYBIN"`
   and to keep `tests/stop-hook-emits-valid-json.test.py` passing. Neither exists on
   `origin/main` — both arrive in #4024/#4025. Branching from `main` would have meant
   re-adding another PR's change. See merge order below.
2. **A ready result file counts as a message.** The brief specified ledger entries
   only. Implemented literally, every task-answering turn would block, because a
   result-file reply writes no ledger entry — the hook would deadlock the live agent
   on its most common path.
3. **`say` is recorded on `ok`, not on `ok` + an event id.** The brief said "with an
   event id" but told me to verify against the code. `receipt.classify` returns
   CONFIRMED *and* UNCONFIRMED (HTTP 200, no id) as `ok: true`, and `receipt.py`
   explicitly adopts fail-open for the missing id — "the caller re-sends a delivered
   message" is the failure it rejects. Requiring an id here would put the opposite
   policy two files away, and its cost lands on a *gate*: the agent refused a turn
   ending it had already earned. `ok: false` never records.

## Known limitation — please read

**This enforces "the turn produced a message", not "the turn's last act was a message."**
`stop_gate` measures from the previous Stop, so a turn that replies early, works for
ten more minutes, and then stops **passes**. The brief called that a violation, and it
is not detectable from a Stop hook: the hook is invoked only at the turn boundary and
observes no intra-turn events, so "was anything done after the send?" has no input.
Catching it needs intra-turn instrumentation, which is a separate change.

## Docs

`docs/src-map.md` regenerated (`python3 scripts/gen-src-map.py`) for the new module —
`tests/src-map.test.py` enforces it. No other canonical doc covers this behaviour;
`docs/catalog.json` has no entry for the Stop hook.

## Stacked PR

Parent: **#4025** (`fix/stop-hook-empty-result-is-not-a-reply`), itself on **#4024**.
Merge order: **#4024 → #4025 → this**. After the parents land I will rebase and rerun
the full checks before treating this as merge-ready.

## Not verified

- **No live round trip.** Deliberate: the running agent's checkout must not be moved
  onto this branch, since a bug here stops it ending a turn or replying to its owner.
  All evidence above is from pinned temp workspaces. A reviewer wanting a live check
  should use the detached-worktree recipe in CONTRIBUTING.md.
- The full `npm run test:py` sweep (857 files) was still running at both base and HEAD
  when this was opened; results are posted as a follow-up comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
