### PR TITLE
fix(sync): count distinct paths in conflict report headline

### DIFF
--- a/scripts/sync-conflicts-report.py
+++ b/scripts/sync-conflicts-report.py
@@ -247,7 +247,7 @@ def main() -> int:
         # means nothing unless the reader can see WHICH workspace was examined.
         print(f"sync-conflicts: no unmerged peer content ({ws})")
         return 0
-    print(f"sync-conflicts: {len(rows)} file(s) hold peer content not in the live copy")
+    print(f"sync-conflicts: {len({rel for _batch, rel, _n in rows})} file(s) hold peer content not in the live copy")
     for batch, rel, n in rows:
         if n is None:
             where = "live file MISSING"

--- a/tests/sync-conflicts-report-distinct-count.test.py
+++ b/tests/sync-conflicts-report-distinct-count.test.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Regression test for #3133: headline counts paths, not saved snapshots."""
+import contextlib
+import importlib.util
+import io
+import pathlib
+import sys
+import types
+import unittest
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "scripts" / "sync-conflicts-report.py"
+
+
+def _load_module() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location("sync_conflicts_report_distinct_count", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+MOD = _load_module()
+
+
+class TestDistinctConflictPathCount(unittest.TestCase):
+    def test_headline_deduplicates_paths_but_detail_rows_stay_per_snapshot(self):
+        same = pathlib.Path("memory/same.md")
+        rows = [
+            ("batch-a", same, (1, 1, 0)),
+            ("batch-b", same, (2, 2, 0)),
+            ("batch-c", pathlib.Path("memory/other.md"), (1, 1, 0)),
+        ]
+        original_unmerged = MOD.unmerged
+        original_argv = sys.argv
+        buf = io.StringIO()
+        MOD.unmerged = lambda _workspace: (rows, None)
+        sys.argv = [str(SCRIPT), "/unused"]
+        try:
+            with contextlib.redirect_stdout(buf):
+                rc = MOD.main()
+        finally:
+            MOD.unmerged = original_unmerged
+            sys.argv = original_argv
+
+        output = buf.getvalue().splitlines()
+        self.assertEqual(rc, 1)
+        self.assertEqual(
+            output[0],
+            "sync-conflicts: 2 file(s) hold peer content not in the live copy",
+        )
+        self.assertEqual(sum("memory/same.md" in line for line in output[1:]), 2)
+        self.assertEqual(sum("memory/other.md" in line for line in output[1:]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #3133.

## What changed, and why?

`scripts/sync-conflicts-report.py` reports one row per `(snapshot, path)` pair, but its headline labeled `len(rows)` as a file count. A path preserved in multiple conflict snapshots therefore inflated the headline.

This keeps the per-snapshot detail rows unchanged and derives the headline count from distinct `rel` paths instead.

## Review first

- `scripts/sync-conflicts-report.py` — the headline count only
- `tests/sync-conflicts-report-distinct-count.test.py` — regression coverage for repeated snapshots of one path

## What user behavior or bug does this prove?

The regression fixture supplies three rows: two snapshots for `memory/same.md` and one for `memory/other.md`. The intended headline is therefore `2 file(s)`, while both detail rows for `memory/same.md` must remain visible.

An independent production check in this PR discussion also reproduced the same defect at much larger scale on an unfixed live workspace: 227 detail rows represented only 18 distinct paths, a 12.6x headline overstatement. The reviewer also verified that this change leaves the per-snapshot detail rows intact.

## Feature/documentation consistency

N/A. This corrects the count in an existing diagnostic; it does not add, remove, or change a documented capability.

## Before/after evidence

Parent: `6aca4b372469da45d2cbb9ffc89484c3e3aaf26a`

The parent uses `len(rows)`, so the regression fixture's 3 `(snapshot, path)` rows are labeled as 3 files even though they contain 2 distinct paths.

HEAD uses `len({rel for _batch, rel, _n in rows})`, so the same fixture expects:

```text
sync-conflicts: 2 file(s) hold peer content not in the live copy
```

The two `memory/same.md` detail rows remain present.

## Tests / checks

Added `tests/sync-conflicts-report-distinct-count.test.py` to pin both sides of the contract:

- headline deduplicates repeated snapshot paths
- detail output remains one row per saved snapshot

The CLA check is green. Upstream GitHub Actions are currently `action_required` with no jobs started, which is the repository's approval gate for workflows from this fork rather than a test failure. No claim is made that upstream CI executed this branch yet.

## Scope / edge cases

Checked the mixed case of repeated snapshots for one path plus a second distinct path. `rows` itself is intentionally unchanged, so retirement and per-batch reporting semantics are untouched.

## Migrations / config / permissions / rollback / deployment risks

N/A. One diagnostic expression plus focused test coverage; no state mutation, migration, config, permission, or live-service path changes.

## Known gaps / follow-up work

The separate rename-related `live file MISSING` behavior discussed in #3133 is intentionally out of scope.