### PR TITLE
fix(quarantine): restore must not clobber a live result — check and move are one step

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/undelivered_quarantine.py
+++ b/packages/ag2-sparrow/ag2_sparrow/undelivered_quarantine.py
@@ -11,6 +11,7 @@ supplies the results directory.
 """
 from __future__ import annotations
 
+import os
 import re
 import time
 from enum import Enum
@@ -81,7 +82,11 @@ def restore(results_dir: Path, task_id: str) -> "tuple[RestoreOutcome, Optional[
         return RestoreOutcome.NOTHING_QUARANTINED, None
     stem = f"task-{task_id}" if not str(task_id).startswith("task-") else str(task_id)
     target = Path(results_dir) / f"{stem}.txt"
-    if target.exists():
+    # os.link fails atomically if target exists; rename would replace it. A
+    # separate exists() check cannot: a producer can write between check and move.
+    try:
+        os.link(found[-1], target)
+    except FileExistsError:
         return RestoreOutcome.LIVE_RESULT_PRESENT, target
-    found[-1].rename(target)
+    os.unlink(found[-1])
     return RestoreOutcome.RESTORED, target

--- a/src/undelivered_quarantine.py
+++ b/src/undelivered_quarantine.py
@@ -11,6 +11,7 @@ supplies the results directory.
 """
 from __future__ import annotations
 
+import os
 import re
 import time
 from enum import Enum
@@ -81,7 +82,11 @@ def restore(results_dir: Path, task_id: str) -> "tuple[RestoreOutcome, Optional[
         return RestoreOutcome.NOTHING_QUARANTINED, None
     stem = f"task-{task_id}" if not str(task_id).startswith("task-") else str(task_id)
     target = Path(results_dir) / f"{stem}.txt"
-    if target.exists():
+    # os.link fails atomically if target exists; rename would replace it. A
+    # separate exists() check cannot: a producer can write between check and move.
+    try:
+        os.link(found[-1], target)
+    except FileExistsError:
         return RestoreOutcome.LIVE_RESULT_PRESENT, target
-    found[-1].rename(target)
+    os.unlink(found[-1])
     return RestoreOutcome.RESTORED, target

--- a/tests/quarantine-restore-no-clobber.test.py
+++ b/tests/quarantine-restore-no-clobber.test.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""restore() must not clobber a live result that lands inside its own window.
+
+`restore()` promises, in its docstring, to refuse to overwrite a live result.
+It checked `target.exists()` and then called `Path.rename`, which on POSIX
+silently replaces the destination — so a producer writing the canonical name
+between those two statements lost its newer reply to a resurrected older one.
+The check and the move have to be one atomic step for the promise to hold.
+
+The interleaving is injected at the production move itself, not simulated by a
+reimplementation, so the test exercises the shipped function.
+"""
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+_spec = importlib.util.spec_from_file_location(
+    "undelivered_quarantine", ROOT / "src" / "undelivered_quarantine.py")
+uq = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(uq)
+
+
+class ConcurrentProducerAtTheMoveBoundary(unittest.TestCase):
+    def setUp(self):
+        import tempfile
+        self.tmp = tempfile.TemporaryDirectory()
+        self.results = Path(self.tmp.name)
+        (self.results / uq.DIRNAME).mkdir(parents=True)
+        self.addCleanup(self.tmp.cleanup)
+
+    def _quarantine(self, task_id, body, when):
+        p = self.results / uq.DIRNAME / uq.quarantine_name(f"task-{task_id}", when)
+        p.write_text(body, encoding="utf-8")
+        return p
+
+    def test_a_reply_written_inside_the_window_survives(self):
+        """The exact production-writer interleaving, driven through restore()."""
+        task = "abc123"
+        self._quarantine(task, "OLD quarantined body", 1)
+        target = self.results / f"task-{task}.txt"
+
+        # The concurrent producer: land a newer reply at the canonical name
+        # after restore() has looked, in the instant before it moves.
+        _os = getattr(uq, "os", None)
+        real_link = getattr(_os, "link", None) if _os is not None else None
+        real_rename = Path.rename
+        fired = {"n": 0}
+
+        def _write_then_delegate(path_self, dst, *a, **kw):
+            fired["n"] += 1
+            Path(dst).write_text("NEW live reply", encoding="utf-8")
+            return real_rename(path_self, dst, *a, **kw)
+
+        def _write_then_link(src, dst, *a, **kw):
+            fired["n"] += 1
+            Path(dst).write_text("NEW live reply", encoding="utf-8")
+            return real_link(src, dst, *a, **kw)
+
+        Path.rename = _write_then_delegate
+        if real_link is not None:
+            _os.link = _write_then_link
+        try:
+            outcome, _ = uq.restore(self.results, task)
+        finally:
+            Path.rename = real_rename
+            if real_link is not None:
+                _os.link = real_link
+
+        self.assertGreater(fired["n"], 0,
+                           "the injection never ran — the test proves nothing")
+        self.assertEqual(
+            target.read_text(encoding="utf-8"), "NEW live reply",
+            "restore() overwrote a live result that landed inside its window; "
+            f"outcome={outcome}")
+        self.assertIs(outcome, uq.RestoreOutcome.LIVE_RESULT_PRESENT)
+
+    def test_the_ordinary_restore_still_works(self):
+        """Negative control: with no concurrent writer the body is restored."""
+        task = "plain1"
+        self._quarantine(task, "the only body", 1)
+        outcome, path = uq.restore(self.results, task)
+        self.assertIs(outcome, uq.RestoreOutcome.RESTORED)
+        self.assertEqual(path.read_text(encoding="utf-8"), "the only body")
+
+    def test_nothing_quarantined_is_still_distinct(self):
+        outcome, path = uq.restore(self.results, "absent")
+        self.assertIs(outcome, uq.RestoreOutcome.NOTHING_QUARANTINED)
+        self.assertIsNone(path)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

`src/undelivered_quarantine.py::restore()` documents that it

> Refuses to overwrite a live result: a newer reply already waiting to go is the one the user should get, not a resurrected older one.

The implementation could not hold that promise under concurrency:

```python
    if target.exists():                       # CHECK
        return RestoreOutcome.LIVE_RESULT_PRESENT, target
    found[-1].rename(target)                  # USE — os.rename replaces silently
```

A producer writing the canonical name between those two statements loses its newer reply, and `restore()` returns `RESTORED` — telling the operator it succeeded while destroying the reply it promised to keep.

Replaced with `os.link` + `unlink`. `os.link` fails atomically with `FileExistsError` when the destination exists, so the refusal and the move are one indivisible step and the window does not exist.

## Why now

This is the blocker filed on **#3853** at head `3c05fb23` (2026-09-07T19:37:43Z). #3853 merged at that exact head (`fe6f7d3e5c2a`, 2026-09-08T01:41:36Z) with nothing landing after the block, so the race is on `main`. This is the follow-up the review named: *atomic no-clobber publication, a test for the production-writer interleaving, and keep the vendored helper synchronized.* All three are here.

## Evidence — before and after, actual output

`tests/quarantine-restore-no-clobber.test.py` drives the **production** `restore()` and injects the concurrent write at the move boundary itself, rather than reimplementing the logic.

Against the unfixed source:

```
AssertionError: 'OLD quarantined body' != 'NEW live reply'
 : restore() overwrote a live result that landed inside its window; outcome=RestoreOutcome.RESTORED
Ran 3 tests — FAILED (failures=1)
```

With the fix:

```
Ran 3 tests in 0.004s
OK
```

**The failure was re-confirmed at the final state of the code** by stashing only the source change (`unfixed: FAILED (failures=1)` → `refixed: OK`), so the test is demonstrably able to fail rather than passing by construction.

Two negative controls pass in **both** states, so the suite is not simply asserting that everything fails:
- ordinary restore with no concurrent writer still returns `RESTORED` with the right body
- `NOTHING_QUARANTINED` remains distinct

## Vendored copy

`packages/ag2-sparrow/ag2_sparrow/undelivered_quarantine.py` carried a byte-identical `restore()` with the same defect. Both are fixed and their `restore()` bodies diff clean again.

## Checks

- Related suites green: `list-undelivered-replies`, `approved-poll-path-and-quarantine`, `health-check-proactive-quarantine`, `health-check-quarantine-skip-markers`
- `scripts/review-checks.sh --diff` on the cumulative diff: **PASS** (hardcoded-paths + root-artifacts + prose-cap), rc=0

## Scope

Single concern. No behaviour change on the non-concurrent path; the only difference is that a live result now wins the race it was always documented to win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)