### PR TITLE
fix(sync): measure excluded media in migration dry-run

### DIFF
--- a/scripts/sync-workspace.sh
+++ b/scripts/sync-workspace.sh
@@ -1744,9 +1744,24 @@ _migrate_from_legacy_impl() {
     fi
     if [ -d "$legacy_dir/notes" ]; then
         if [ "$DRY_RUN" = "1" ]; then
-            local n_notes
+            local n_notes excluded_size
             n_notes=$(find "$legacy_dir/notes" -type f -not -path "$legacy_dir/notes/generated/*" -not -path "$legacy_dir/notes/media/*" 2>/dev/null | wc -l | tr -d ' ')
-            echo "DRY-RUN: would: rsync notes/ (EXCL generated/ + media/) → workspace/notes/  (${n_notes} text files; ~2.65 GB media left archived in legacy)" >&2
+            excluded_size=$(
+                {
+                    if [ -d "$legacy_dir/notes/generated" ]; then
+                        du -skL "$legacy_dir/notes/generated" 2>/dev/null || true
+                    fi
+                    if [ -d "$legacy_dir/notes/media" ]; then
+                        du -skL "$legacy_dir/notes/media" 2>/dev/null || true
+                    fi
+                } | awk '{kb += $1} END {
+                    if (kb >= 1048576) printf "%.2f GB", kb / 1048576
+                    else if (kb >= 1024) printf "%.1f MB", kb / 1024
+                    else if (kb > 0) printf "%d KB", kb
+                    else printf "0B"
+                }'
+            )
+            echo "DRY-RUN: would: rsync notes/ (EXCL generated/ + media/) → workspace/notes/  (${n_notes} text files; ${excluded_size} generated/media left archived in legacy)" >&2
         else
             rsync -a --exclude='generated/' --exclude='media/' "$legacy_dir/notes"/ "$WORKSPACE_DIR/notes"/ 2>/dev/null || true
             log "_migrate_from_legacy_impl: rsynced notes/ (excl generated,media) → workspace/notes/"

--- a/tests/sync-workspace-dry-run-media-size.test.sh
+++ b/tests/sync-workspace-dry-run-media-size.test.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO/scripts/sync-workspace.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+WS="$TMP/workspace"
+LEGACY="$TMP/legacy"
+VAULT="$TMP/vault.git"
+mkdir -p "$WS" "$LEGACY/notes"
+git init -q "$LEGACY"
+git init -q --bare "$VAULT"
+printf 'text\n' > "$LEGACY/notes/note.md"
+
+run_dry() {
+    env \
+        SUTANDO_REPO_DIR="$REPO" \
+        SUTANDO_WORKSPACE="$WS" \
+        SUTANDO_TEST_MODE=1 \
+        SUTANDO_HOST_OVERRIDE=testhost \
+        SUTANDO_WS_ID_OVERRIDE=a2285a \
+        SUTANDO_MEMORY_SYNC_DIR="$LEGACY" \
+        SUTANDO_SYNC_LOCK_DIR="$TMP/lock.d" \
+        bash "$SCRIPT" --vault-url "$VAULT" --migrate-from-legacy --dry-run 2>&1
+}
+
+fail=0
+out="$(run_dry)"
+if grep -Fq '~2.65 GB' <<<"$out"; then
+    echo "FAIL: dry-run still prints the hardcoded ~2.65 GB estimate"
+    fail=$((fail + 1))
+else
+    echo "OK: hardcoded ~2.65 GB estimate is gone"
+fi
+if grep -Fq '1 text files; 0B generated/media left archived in legacy' <<<"$out"; then
+    echo "OK: absent generated/media directories report 0B"
+else
+    echo "FAIL: absent generated/media directories did not report 0B"
+    printf '%s\n' "$out" | grep 'rsync notes/' || true
+    fail=$((fail + 1))
+fi
+
+mkdir -p "$LEGACY/notes/media" "$LEGACY/notes/generated"
+dd if=/dev/zero of="$LEGACY/notes/media/blob.bin" bs=1024 count=1024 >/dev/null 2>&1
+dd if=/dev/zero of="$LEGACY/notes/generated/blob.bin" bs=1024 count=1024 >/dev/null 2>&1
+out="$(run_dry)"
+if grep -Eq '[1-9][0-9]*(\.[0-9]+)? (KB|MB|GB) generated/media left archived in legacy' <<<"$out"; then
+    echo "OK: present generated/media directories report a nonzero measured size"
+else
+    echo "FAIL: present generated/media directories did not report a nonzero measured size"
+    printf '%s\n' "$out" | grep 'rsync notes/' || true
+    fail=$((fail + 1))
+fi
+
+# Relocated media trees are commonly symlinked. The measurement must follow the
+# symlink itself rather than report only the link inode as ~0 KB.
+rm -rf "${LEGACY:?}/notes/media" "${LEGACY:?}/notes/generated"
+MEDIA_TARGET="$TMP/media-target"
+GENERATED_TARGET="$TMP/generated-target"
+mkdir -p "$MEDIA_TARGET" "$GENERATED_TARGET"
+dd if=/dev/zero of="$MEDIA_TARGET/blob.bin" bs=1024 count=1024 >/dev/null 2>&1
+dd if=/dev/zero of="$GENERATED_TARGET/blob.bin" bs=1024 count=1024 >/dev/null 2>&1
+ln -s "$MEDIA_TARGET" "$LEGACY/notes/media"
+ln -s "$GENERATED_TARGET" "$LEGACY/notes/generated"
+out="$(run_dry)"
+if grep -Eq '[1-9][0-9]*(\.[0-9]+)? (KB|MB|GB) generated/media left archived in legacy' <<<"$out"; then
+    echo "OK: symlinked generated/media directories measure their targets"
+else
+    echo "FAIL: symlinked generated/media directories reported zero instead of target size"
+    printf '%s\n' "$out" | grep 'rsync notes/' || true
+    fail=$((fail + 1))
+fi
+
+if [ "$fail" -ne 0 ]; then
+    echo "sync-workspace-dry-run-media-size: $fail failure(s)"
+    exit 1
+fi
+echo "sync-workspace-dry-run-media-size: all passed"


### PR DESCRIPTION
Closes #2285.

## What changed, and why?

`sync-workspace.sh --migrate-from-legacy --dry-run` hardcoded `~2.65 GB` for the excluded `notes/generated/` + `notes/media/` directories, so every host saw one machine's old size instead of its own data.

The dry-run now measures only those two excluded directories with `du -skL`, sums them, and formats the result as `0B`, KB, MB, or GB. `-L` is intentional: if `generated/` or `media/` is itself a symlink to relocated storage, the measurement follows the target instead of reporting the link inode as approximately zero. Missing or unreadable excluded paths remain non-fatal so a dry-run cannot fail merely because one of those optional directories is absent.

## Review first

- `scripts/sync-workspace.sh` — the notes migration dry-run branch only
- `tests/sync-workspace-dry-run-media-size.test.sh` — hermetic missing, real-directory, and symlinked-directory controls

## What user behavior or bug does this prove?

The regression drives the real migration dry-run against a temporary legacy clone and workspace.

It verifies three cases:

1. neither `generated/` nor `media/` exists → the output reports `0B`, not a guessed size
2. both exist as real directories with fixture data → the output reports a nonzero measured size
3. both are symlinks to fixture data → the output follows those targets and still reports a nonzero measured size

## Feature/documentation consistency

N/A. This corrects an existing diagnostic value; it does not add, remove, or change a documented capability or navigation surface.

## Before/after evidence

Parent: `6aca4b372469da45d2cbb9ffc89484c3e3aaf26a`

Before the original fix, the regression against the unpatched parent showed the hardcoded value in every case:

```text
FAIL: dry-run still prints the hardcoded ~2.65 GB estimate
FAIL: absent generated/media directories did not report 0B
DRY-RUN: would: rsync notes/ (EXCL generated/ + media/) → workspace/notes/  (1 text files; ~2.65 GB media left archived in legacy)
FAIL: present generated/media directories did not report a nonzero measured size
DRY-RUN: would: rsync notes/ (EXCL generated/ + media/) → workspace/notes/  (1 text files; ~2.65 GB media left archived in legacy)
sync-workspace-dry-run-media-size: 3 failure(s)
```

Reviewer follow-up reproduced a second edge case against the first revision of this PR:

```text
OK: hardcoded ~2.65 GB estimate is gone
OK: absent generated/media directories report 0B
OK: present generated/media directories report a nonzero measured size
FAIL: symlinked generated/media directories reported zero instead of target size
DRY-RUN: would: rsync notes/ (EXCL generated/ + media/) → workspace/notes/  (1 text files; 0B generated/media left archived in legacy)
```

After switching the two measurements to `du -skL`:

```text
OK: hardcoded ~2.65 GB estimate is gone
OK: absent generated/media directories report 0B
OK: present generated/media directories report a nonzero measured size
OK: symlinked generated/media directories measure their targets
sync-workspace-dry-run-media-size: all passed
```

## Tests

```text
bash -n scripts/sync-workspace.sh                                      PASS
bash tests/sync-workspace-dry-run-media-size.test.sh                   PASS
shellcheck tests/sync-workspace-dry-run-media-size.test.sh             PASS
```

I also ran ShellCheck over the changed production block during the original pass. Three unrelated warnings already present elsewhere in the 1,900-line script (`SC2317`, `SC2155`, `SC2012`) were left out of scope rather than bundled into this PR.

Repository scanner output after the symlink follow-up:

```text
prose-cap: no in-scope files (exts .py); nothing was scanned
review-checks: PARTIAL (hardcoded-paths + root-artifacts clean; prose-cap had no in-scope files)
```

`PARTIAL` is reported intentionally rather than as `PASS`: this diff contains no `.py` file for prose-cap to scan.

## Scope / edge cases

- both excluded directories absent → `0B`
- both present as real directories → combined nonzero measured size
- either excluded directory may be a symlink; its target is measured
- a `du` failure is tolerated and does not make `--dry-run` fail
- the real copy path and its `rsync --exclude='generated/' --exclude='media/'` behavior are unchanged

## Migrations / config / permissions / rollback / deployment risks

N/A. No state mutation, migration policy, permissions, configuration, or live-service path changes. Reverting the single commit restores the previous diagnostic output.

## Known gaps / follow-up work

N/A for this issue. The measurement uses `du -skL` disk usage for the two excluded trees so operator-facing output reflects relocated/symlinked media storage as well as ordinary directories.