### PR TITLE
fix(refresh-skill): propagate restore failures

### DIFF
--- a/skills/refresh-skill.sh
+++ b/skills/refresh-skill.sh
@@ -61,28 +61,59 @@ refresh_one() {
   sync; sleep "$SETTLE_S"
   rm -rf "$link"
   ln -s "$target" "$link"
-  if [ -L "$link" ]; then echo "  refreshed $name"; else echo "  ERROR restoring $name symlink!"; fi
+  if [ -L "$link" ]; then
+    echo "  refreshed $name"
+    return 0
+  fi
+  echo "  ERROR restoring $name symlink!"
+  return 1
+}
+
+# Wait every background refresh in a chunk and retain failure if ANY child
+# failed. A bare `wait` reports only the job it waits for, which made --all
+# discard an earlier restore failure when another child completed cleanly.
+wait_refresh_batch() {
+  local pid rc=0
+  for pid in "$@"; do
+    wait "$pid" || rc=1
+  done
+  return "$rc"
 }
 
 main() {
   mkdir -p "$SKILLS_DST"
   [ "$#" -ge 1 ] || { echo "usage: refresh-skill.sh <name> [<name> ...] | --all" >&2; exit 2; }
+  local failed=0
   if [ "$1" = "--all" ]; then
     # Each skill's settle is WAITING, not work, so --all runs them concurrently.
     # Chunked, not unbounded: a crash strands at most $REFRESH_SKILL_JOBS as copies,
     # which refresh_one then refuses to touch ("not a symlink").
     local any=0 running=0
+    local -a pids=()
     for link in "$SKILLS_DST"/*; do
       [ -L "$link" ] || continue
       refresh_one "$(basename "$link")" &
+      pids+=("$!")
       any=1; running=$((running + 1))
-      if [ "$running" -ge "$JOBS" ]; then wait; running=0; fi
+      if [ "$running" -ge "$JOBS" ]; then
+        wait_refresh_batch "${pids[@]}" || failed=1
+        pids=(); running=0
+      fi
     done
-    wait
+    if [ "${#pids[@]}" -gt 0 ]; then
+      wait_refresh_batch "${pids[@]}" || failed=1
+    fi
     [ "$any" = 1 ] || echo "  (no symlinked skills under $SKILLS_DST)"
   else
-    for name in "$@"; do refresh_one "$name"; done
+    for name in "$@"; do
+      refresh_one "$name" || failed=1
+    done
   fi
-  echo "done — updated skills are live in the running session (no restart)."
+  if [ "$failed" = 0 ]; then
+    echo "done — updated skills are live in the running session (no restart)."
+  else
+    echo "done — one or more skills failed to refresh; see errors above." >&2
+  fi
+  return "$failed"
 }
 main "$@"

--- a/tests/refresh-skill-exit-status.test.sh
+++ b/tests/refresh-skill-exit-status.test.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+SCRIPT="$REPO/skills/refresh-skill.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+REAL_LN="$(command -v ln)"
+BIN="$TMP/bin"
+SKILLS="$TMP/skills"
+TARGETS="$TMP/targets"
+mkdir -p "$BIN" "$SKILLS" "$TARGETS"
+
+cat > "$BIN/ln" <<'EOF'
+#!/usr/bin/env bash
+dest="${@: -1}"
+if [ -n "${REFRESH_TEST_FAIL_LINK:-}" ] && [ "${dest##*/}" = "$REFRESH_TEST_FAIL_LINK" ]; then
+    exit 1
+fi
+exec "$REFRESH_TEST_REAL_LN" "$@"
+EOF
+chmod +x "$BIN/ln"
+
+make_skill() {
+    local name="$1"
+    rm -rf "${SKILLS:?}/$name" "${TARGETS:?}/$name"
+    mkdir -p "$TARGETS/$name"
+    printf '# %s\n' "$name" > "$TARGETS/$name/SKILL.md"
+    "$REAL_LN" -s "$TARGETS/$name" "$SKILLS/$name"
+}
+
+run_refresh() {
+    env \
+        PATH="$BIN:$PATH" \
+        SKILLS_DST="$SKILLS" \
+        REFRESH_SKILL_SETTLE_S=0 \
+        REFRESH_SKILL_JOBS=2 \
+        REFRESH_TEST_REAL_LN="$REAL_LN" \
+        REFRESH_TEST_FAIL_LINK="${REFRESH_TEST_FAIL_LINK:-}" \
+        bash "$SCRIPT" "$@"
+}
+
+fails=0
+ok() { echo "  ok  $1"; }
+fail() { echo "FAIL: $1"; fails=$((fails + 1)); }
+
+# A direct refresh must surface a restore failure through its exit status.
+make_skill a-bad
+REFRESH_TEST_FAIL_LINK=a-bad
+run_refresh a-bad >/dev/null 2>&1
+rc=$?
+if [ "$rc" -ne 0 ]; then
+    ok "single-skill restore failure returns nonzero"
+else
+    fail "single-skill restore failure returned 0"
+fi
+
+# --all must retain a failed child status across a later successful chunk.
+make_skill a-bad
+make_skill b-good
+make_skill c-good
+REFRESH_TEST_FAIL_LINK=a-bad
+run_refresh --all >/dev/null 2>&1
+rc=$?
+if [ "$rc" -ne 0 ]; then
+    ok "--all returns nonzero when one background refresh fails"
+else
+    fail "--all returned 0 after a background restore failure"
+fi
+if [ -L "$SKILLS/b-good" ] && [ -L "$SKILLS/c-good" ]; then
+    ok "successful siblings still restore their symlinks"
+else
+    fail "a sibling refresh was stranded while collecting failures"
+fi
+
+# Clean control: every successful child still yields exit 0.
+make_skill a-good
+make_skill b-good
+REFRESH_TEST_FAIL_LINK=""
+run_refresh --all >/dev/null 2>&1
+rc=$?
+if [ "$rc" -eq 0 ]; then
+    ok "all-success batch returns 0"
+else
+    fail "all-success batch returned $rc"
+fi
+
+if [ "$fails" -ne 0 ]; then
+    echo "refresh-skill-exit-status: $fails failure(s)"
+    exit 1
+fi
+
+echo "refresh-skill-exit-status: all passed"


### PR DESCRIPTION
Closes #2776.

## What changed, and why?

`refresh_one()` printed `ERROR restoring <skill> symlink!` when `ln -s` failed, but that branch ended in `echo`, so the function still returned 0. After #2773 made `--all` concurrent, its bare `wait` also discarded individual child statuses. The result was that both a direct refresh and `--all` could visibly fail while the script exited success.

This change fixes both ends of that contract:

- `refresh_one()` now returns 1 when symlink restoration fails.
- `--all` records each background PID and waits every child in a bounded chunk, retaining failure if any child fails.
- explicit-name refreshes aggregate failures too, so a later successful refresh cannot erase an earlier failure.
- the existing bounded concurrency, per-skill settle, copy/swap behavior, and skip-as-success semantics are unchanged.

## Review first

- `skills/refresh-skill.sh` — restore return code + background status aggregation
- `tests/refresh-skill-exit-status.test.sh` — hermetic `ln` failure injection against the real script

## What user behavior or bug does this prove?

The regression replaces only `ln` in `PATH` and makes it fail for one designated skill during restoration. The actual `refresh-skill.sh` still performs the copy/swap, settle, parallel chunking, and sibling refreshes.

It proves:

1. a direct refresh returns nonzero when restoration fails
2. `--all` returns nonzero when one background child fails
3. a failure in the first chunk survives later successful refreshes
4. successful sibling skills are still restored normally
5. an all-success batch still returns 0

## Before/after evidence

Parent: `6aca4b372469da45d2cbb9ffc89484c3e3aaf26a`

Before, against the unpatched implementation:

```text
FAIL: single-skill restore failure returned 0
FAIL: --all returned 0 after a background restore failure
  ok  successful siblings still restore their symlinks
  ok  all-success batch returns 0
refresh-skill-exit-status: 2 failure(s)
```

After:

```text
  ok  single-skill restore failure returns nonzero
  ok  --all returns nonzero when one background refresh fails
  ok  successful siblings still restore their symlinks
  ok  all-success batch returns 0
refresh-skill-exit-status: all passed
```

## Tests

```text
bash -n skills/refresh-skill.sh                                      PASS
bash tests/refresh-skill-exit-status.test.sh                         PASS
shellcheck skills/refresh-skill.sh tests/refresh-skill-exit-status.test.sh  PASS
```

Repository scanner:

```text
prose-cap: no in-scope files (exts .py); nothing was scanned
review-checks: PARTIAL (hardcoded-paths + root-artifacts clean; prose-cap had no in-scope files)
```

`PARTIAL` is reported intentionally rather than as `PASS`: this diff has no `.py` file for prose-cap to scan.

## #2773 compatibility / safety

This is deliberately written on top of #2773's merged bounded-concurrency design rather than replacing it. `REFRESH_SKILL_JOBS` still caps the number of simultaneously swapped skills, and every `refresh_one` still performs its own `sync; sleep "$SETTLE_S"` before restoring the symlink. The new collector only retains child exit statuses; it does not move or remove the settle boundary.

## Scope / edge cases

- missing skill, non-symlink install, or missing target remain skip-success cases
- one failed restoration does not stop other requested skills from being attempted
- multiple failures collapse to a nonzero aggregate status rather than short-circuiting cleanup
- a later successful chunk cannot overwrite an earlier failed chunk's status
- no cron, config, workspace, deployment, or skill-content semantics change

## Rollback / deployment risk

Low. This changes only process exit-status reporting and the final summary on a failed run. Reverting the single commit restores the previous behavior. No migration or state format change is involved.