### PR TITLE
fix(runtime-health): anchor the not-logged-in marker, so quoting it is not being it

### DIFF
--- a/src/runtime-health.py
+++ b/src/runtime-health.py
@@ -27,6 +27,7 @@ observer; it starts nothing and kills nothing.
 import json
 import math
 import os
+import re
 import tempfile
 import socket
 import subprocess
@@ -166,7 +167,6 @@ def severity_gate(verdict, *, confirm_min=2, freshly_booted=False):
 # staring at an unresponsive agent, so a false "needs_login" (rare) is far less
 # costly than missing a real one.
 _LOGIN_MARKERS = (
-    "not logged in",
     "please run /login",
     "run `claude login`",
     "run 'claude login'",
@@ -174,6 +174,12 @@ _LOGIN_MARKERS = (
     "invalid api key",
     "authentication_error",
 )
+# Three common words: unanchored, this fires on any pane that merely QUOTES them.
+# Require the CLI's own line-start form, or adjacency to a /login token.
+_NOT_LOGGED_IN = re.compile(
+    r"^[\s⎿·|>]*(?:you(?:'re| are) )?not logged in\b"
+    r"|not logged in\b.{0,60}/login\b"
+    r"|/login\b.{0,60}not logged in\b", re.I)
 
 
 def _run(cmd):
@@ -479,7 +485,10 @@ def needs_login(pane_text):
     """Pure predicate: does the core pane show claude's auth prompt? Testable
     without a live tmux — this is the load-bearing 'stuck vs thinking' decision."""
     low = pane_text.lower()
-    return any(m in low for m in _LOGIN_MARKERS)
+    if any(m in low for m in _LOGIN_MARKERS):
+        return True
+    # Per LINE: the anchored form must bind to a line start, not to the pane's.
+    return any(_NOT_LOGGED_IN.search(line) for line in pane_text.splitlines())
 
 
 def _core_status(workspace):

--- a/tests/runtime-health.test.py
+++ b/tests/runtime-health.test.py
@@ -51,6 +51,23 @@ WORKING_PANE = """\
 check("needs_login: false on a working pane", rh.needs_login(WORKING_PANE) is False)
 check("needs_login: false on empty pane", rh.needs_login("") is False)
 
+# 2b) Incidental mentions must NOT fire: the phrase is three common words, so an
+#      unanchored match escalated a healthy core. Anchor = line start, or /login nearby.
+for _incidental in (
+    "  ⎿  gh: not logged in to github.com",
+    "  ⎿  wacli auth status: not logged in",
+    "  src/auth.py:42: raise RuntimeError('not logged in')",
+    "  shown to a visitor who is not logged in",
+):
+    check("needs_login: false on incidental %r" % _incidental.strip()[:28],
+          rh.needs_login(_incidental) is False)
+# ...while every real form still fires.
+for _real in ("Not logged in", "You are not logged in",
+              "  ⎿  Not logged in · Please run /login",
+              "not logged in — run /login to continue"):
+    check("needs_login: true on real %r" % _real.strip()[:28],
+          rh.needs_login(_real) is True)
+
 # 3) offline end-to-end: a socket with no session → health=offline, authed=null.
 env = dict(os.environ)
 env["SUTANDO_TMUX_SOCKET"] = "/tmp/rh-test-nonexistent-%d.sock" % os.getpid()


### PR DESCRIPTION
## The defect

`_LOGIN_MARKERS` carried the bare string `"not logged in"`, substring-matched against the **whole pane** by `needs_login()`. Three common words match any pane that merely *contains* them. `needs_login` then maps to `logged-out` in `core-input-watch.py:255`, and `logged-out` is in `_CHAT_ESCALATE_STATES` (`:411`), so a false hit reaches the owner as **"core needs you: logged-out"** on a core that is running.

## Measured live, on this host

```
health-check          ⚠ core-supervisor  warn  core needs you: logged-out
core-supervisor.json  {"state":"logged-out","detail":"core not authenticated (needs /login)",
                       "session":"sutando-core"}   mtime 04:00:30Z, 30s old

the actual pane       · Percolating… (58s · ↓ 2.1k tokens)     <- healthy, mid-turn
grep -in "not logged in" pane
  line 3:  "  You are not logged in                  -> blocked-human"
  line 4:  "  not logged in — run /login to continue -> blocked-human"
```

Those lines are a probe table printed into the terminal while reviewing the **identical** defect in the sibling detector (`_REFUSAL` in `core-input-watch.py`, narrowed in #4022). So reviewing the bug tripped its twin and escalated a healthy core.

## The fix

Same shape as #4022's: keep the unambiguous markers as substrings; require the ambiguous phrase at a **line start** (after optional wrapped-result glyphs) or **adjacent to a `/login` token**. Matched per line — `^` against the whole pane would only ever bind to its first line.

```
                                                     before -> after
gh: not logged in to github.com                       True  -> False
wacli auth status: not logged in                      True  -> False
src/auth.py:42: raise RuntimeError('not logged in')   True  -> False
shown to a visitor who is not logged in               True  -> False

Not logged in                                         True  (unchanged)
You are not logged in                                 True
⎿  Not logged in · Please run /login                  True   <- the repo's own STUCK_PANE fixture
not logged in — run /login to continue                True
```

## Stated limit — the live case is NOT fully solved

A **verbatim quotation** of the refusal is indistinguishable from the refusal. The two lines still matching on my own pane are exact refusal strings I wrote as fixtures. No regex separates those without out-of-band marking. This removes the *incidental* class (tool errors, code, prose) and not the *quoted* one, and I would rather say that than let the before/after table imply otherwise.

The code comment for `#2456`'s rationale — *"a false needs_login (rare)"* — is what this narrows. That issue is about **ordering** (`needs_login` short-circuiting before `core-status.json`) and is untouched here; this is about the marker's breadth.

## Controls

```
fix reverted  -> tests/runtime-health.test.py  FAIL — 4 failing   (the 4 new incidental assertions)
fix restored  -> PASS — runtime-health green
also green    -> tests/core-health-verdict.test.py, tests/core-input-watch.test.py
review-checks -> PASS (hardcoded-paths + root-artifacts + prose-cap)
```

A checker never observed failing is not a validated checker, so the revert run is included rather than described.

Single concern; no bundled refactor. Not stacked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
