### PR TITLE
feat(health-check): per-host user-defined checks, no repo edit required

### DIFF
--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -391,7 +391,7 @@
    ],
    "status": "canonical",
    "canonical_for": "hosts/<hostname> workspace convention",
-   "last_verified": null
+   "last_verified": "2026-09-08"
   },
   "docs/workspace-per-host-paths.md": {
    "title": "Per-host carried paths",

--- a/docs/workspace-hosts-convention.md
+++ b/docs/workspace-hosts-convention.md
@@ -98,6 +98,7 @@ Per-host **config that should survive a rebuild** (the backup hole):
 | crons | `crons/<hostname>.json` (#1716) | `hosts/<hostname>/crons.json` — **wired** in `schedule-crons/SKILL.md` (self-heals from the interim/legacy path) |
 | build_log.md | machine-<host>/ (per-host) | `hosts/<hostname>/build_log.md` — F1 per-host decision; migrator (#1721) emits it; *loop write-side still emits workspace-root, relocation deferred* |
 | pending-questions.md | machine-local (per-host) | `hosts/<hostname>/pending-questions.md` — reader wired via `personal_path` (#1718) + migrator (#1721) |
+| health-checks-extra.json | (did not exist — a host-specific probe meant editing `run_all_checks` in shared repo code) | `hosts/<hostname>/health-checks-extra.json` — **wired** in `src/health-check.py` (`check_user_defined`); opt-in, absent on a host that declares none |
 
 ### Wiring status (implemented vs deferred)
 
@@ -105,7 +106,8 @@ The `hosts/<hostname>/` paths above are the **target** layout. The table is the
 intent; not every component writes there yet. As of #1716–#1721:
 
 - **Wired going-forward:** `crons.json` (read+write, `schedule-crons/SKILL.md`),
-  `pending-questions.md` (read via `personal_path`, #1718).
+  `pending-questions.md` (read via `personal_path`, #1718),
+  `health-checks-extra.json` (read by `src/health-check.py`).
 - **Migrator one-time copy only:** `PERSONAL_CLAUDE.md`, `stand-identity.json`,
   `tab-aliases.json`, channel `access.json`, `settings.json`, and `build_log.md`'s
   loop-writer. `--migrate-from-legacy` (#1721) copies these into

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -11429,6 +11429,9 @@ USER_CHECKS_FILE = "health-checks-extra.json"
 USER_CHECK_PREFIX = "extra:"
 USER_CHECK_TIMEOUT_S = 30.0
 USER_CHECK_DETAIL_CAP = 300
+#: Only DETAIL_CAP characters survive normalization; reading the whole sink lets an
+#: opt-in command size this process's memory. 200x headroom over what is rendered.
+USER_CHECK_OUTPUT_READ_CAP = 65536
 
 
 def user_checks_path(workspace_dir: Optional[Path] = None,
@@ -11470,6 +11473,15 @@ def load_user_checks(path: Path) -> list:
     return out
 
 
+def _reap_user_command_group(pgid: int) -> None:
+    """A shell can exit 0 while its background children keep running; the group
+    `start_new_session` created must be cleared on that path too, not only on timeout."""
+    try:
+        os.killpg(pgid, signal.SIGKILL)
+    except OSError:
+        pass
+
+
 def _kill_user_command_tree(proc) -> None:
     """SIGKILL the group `start_new_session` gave this command, not just the shell
     — killing the shell alone leaves its children running past the timeout."""
@@ -11495,13 +11507,18 @@ def run_user_command(command: str, timeout_s: float, cwd: Path) -> "tuple[int, s
                                     stdout=sink, stderr=subprocess.STDOUT, start_new_session=True)
         except OSError as exc:
             return 127, f"{type(exc).__name__}: {exc}"
+        # start_new_session makes the child its own group leader, so the group id is
+        # its pid — captured before the wait reaps it and the attribute is stale.
+        pgid = proc.pid
         try:
             code = proc.wait(timeout=timeout_s)
         except subprocess.TimeoutExpired:
             _kill_user_command_tree(proc)
             code = 124
+        else:
+            _reap_user_command_group(pgid)
         sink.seek(0)
-        return code, sink.read()
+        return code, sink.read(USER_CHECK_OUTPUT_READ_CAP)
 
 
 def run_user_check(decl: dict, cwd: Optional[Path] = None) -> dict:
@@ -11511,19 +11528,22 @@ def run_user_check(decl: dict, cwd: Optional[Path] = None) -> dict:
     notifier surfaces, so a host's own probe can never mask or manufacture an alert.
     """
     name = f"{USER_CHECK_PREFIX}{decl['name']}"
+    # Suppression is a property of the CHECK, not of its status: --emit-task,
+    # --notify-on-fail and --notify-slack each read a bare warn as a failure.
+    quiet = {"name": name, "alerting": False}
     try:
         code, output = run_user_command(decl["command"], decl["timeout"],
                                         cwd if cwd is not None else REPO_DIR)
     except Exception as exc:
-        return {"name": name, "status": "warn",
+        return {**quiet, "status": "warn",
                 "detail": f"could not run: {type(exc).__name__}: {exc}"[:USER_CHECK_DETAIL_CAP]}
     detail = " ".join(output.split())[:USER_CHECK_DETAIL_CAP] or "(no output)"
     if code == 124:
-        return {"name": name, "status": "warn",
+        return {**quiet, "status": "warn",
                 "detail": f"TIMEOUT after {decl['timeout']:.0f}s (killed): {detail}"}
     if code == 0:
-        return {"name": name, "status": "ok", "detail": detail}
-    return {"name": name, "status": "warn", "detail": f"exit {code}: {detail}"}
+        return {**quiet, "status": "ok", "detail": detail}
+    return {**quiet, "status": "warn", "detail": f"exit {code}: {detail}"}
 
 
 def check_user_defined(workspace_dir: Optional[Path] = None,

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -18,6 +18,10 @@ Checks:
   - Critical files (CLAUDE.md, build_log.md, ACTIVITY.md)
   - Memory system (MEMORY.md index, key memory files)
   - Notes directory
+  - Extra per-host probes declared in
+    <workspace>/hosts/<host-label>/health-checks-extra.json (opt-in; see
+    check_user_defined). Each entry is {"name", "command"[, "timeout"]};
+    exit 0 reads ok, anything else warn, with the command's output as the detail.
 """
 
 import ast
@@ -28,6 +32,7 @@ import json
 import os
 import re
 import shlex
+import signal
 import stat
 import statistics
 import shutil
@@ -11417,6 +11422,120 @@ def menubar_app_state(dev_bin, app_bin, plist, is_macos: bool) -> str:
     return "expected-missing" if plist.exists() else "not-applicable"
 
 
+#: Per-host declaration of EXTRA, user-defined probes — same `hosts/<host>/` JSON
+#: convention as skills/proactive-loop/scripts/tool-suites-check.py's extras.
+USER_CHECKS_FILE = "health-checks-extra.json"
+#: Name prefix so an extra row is never mistaken for a built-in probe.
+USER_CHECK_PREFIX = "extra:"
+USER_CHECK_TIMEOUT_S = 30.0
+USER_CHECK_DETAIL_CAP = 300
+
+
+def user_checks_path(workspace_dir: Optional[Path] = None,
+                     host: "str | None" = None) -> Path:
+    """Where this host declares its extra checks.
+
+    `hosts/<host>/` and not `state/`: the vault already carries the former, and
+    a `state/` path is re-ignored by the carve-out emitted after the includes.
+    """
+    ws = WORKSPACE_DIR if workspace_dir is None else Path(workspace_dir)
+    return ws / "hosts" / (host or _host_label()) / USER_CHECKS_FILE
+
+
+def load_user_checks(path: Path) -> list:
+    """Declared checks, or `[]` for absent / unreadable / malformed.
+
+    A hand-edited file must never take the health check down with it, so every
+    failure here degrades to "this host declares no extras".
+    """
+    try:
+        decl = json.loads(Path(path).read_text())
+    except Exception:
+        return []
+    entries = decl.get("checks") if isinstance(decl, dict) else None
+    out = []
+    for entry in _as_list(entries):
+        if not isinstance(entry, dict):
+            continue
+        name, command = entry.get("name"), entry.get("command")
+        if not (isinstance(name, str) and name.strip()):
+            continue
+        if not (isinstance(command, str) and command.strip()):
+            continue
+        out.append({
+            "name": name.strip(),
+            "command": command,
+            "timeout": _positive_seconds(entry.get("timeout")) or USER_CHECK_TIMEOUT_S,
+        })
+    return out
+
+
+def _kill_user_command_tree(proc) -> None:
+    """SIGKILL the group `start_new_session` gave this command, not just the shell
+    — killing the shell alone leaves its children running past the timeout."""
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except OSError:
+        proc.kill()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        pass
+
+
+def run_user_command(command: str, timeout_s: float, cwd: Path) -> "tuple[int, str]":
+    """Run one declared command bounded in time; return (exit code, output).
+
+    Output lands in a FILE, never a pipe: a command that leaves a background
+    grandchild holding the pipe open would block the drain past the timeout.
+    """
+    with tempfile.TemporaryFile(mode="w+", encoding="utf-8", errors="replace") as sink:
+        try:
+            proc = subprocess.Popen(command, shell=True, cwd=str(cwd), stdin=subprocess.DEVNULL,
+                                    stdout=sink, stderr=subprocess.STDOUT, start_new_session=True)
+        except OSError as exc:
+            return 127, f"{type(exc).__name__}: {exc}"
+        try:
+            code = proc.wait(timeout=timeout_s)
+        except subprocess.TimeoutExpired:
+            _kill_user_command_tree(proc)
+            code = 124
+        sink.seek(0)
+        return code, sink.read()
+
+
+def run_user_check(decl: dict, cwd: Optional[Path] = None) -> dict:
+    """One extra probe: exit 0 is `ok`, anything else `warn`, output as the detail.
+
+    `warn` on purpose — an extra check must not change the exit code or wake the
+    notifier surfaces, so a host's own probe can never mask or manufacture an alert.
+    """
+    name = f"{USER_CHECK_PREFIX}{decl['name']}"
+    try:
+        code, output = run_user_command(decl["command"], decl["timeout"],
+                                        cwd if cwd is not None else REPO_DIR)
+    except Exception as exc:
+        return {"name": name, "status": "warn",
+                "detail": f"could not run: {type(exc).__name__}: {exc}"[:USER_CHECK_DETAIL_CAP]}
+    detail = " ".join(output.split())[:USER_CHECK_DETAIL_CAP] or "(no output)"
+    if code == 124:
+        return {"name": name, "status": "warn",
+                "detail": f"TIMEOUT after {decl['timeout']:.0f}s (killed): {detail}"}
+    if code == 0:
+        return {"name": name, "status": "ok", "detail": detail}
+    return {"name": name, "status": "warn", "detail": f"exit {code}: {detail}"}
+
+
+def check_user_defined(workspace_dir: Optional[Path] = None,
+                       host: "str | None" = None) -> list:
+    """Every extra probe this host declares — `[]` when it declares none."""
+    try:
+        decls = load_user_checks(user_checks_path(workspace_dir, host))
+    except Exception:
+        return []
+    return [run_user_check(d) for d in decls]
+
+
 def run_all_checks() -> list[dict]:
     checks = []
 
@@ -11968,6 +12087,10 @@ def run_all_checks() -> list[dict]:
     checks.append(check_runtime_identity())
     checks.append(check_live_tree_drift())
     checks.append(check_disk_space())
+
+    # Last, and only when this host declares any: a user probe must never
+    # delay or displace a built-in one.
+    checks.extend(check_user_defined())
 
     return checks
 

--- a/tests/health-check-user-defined-checks.test.py
+++ b/tests/health-check-user-defined-checks.test.py
@@ -20,6 +20,9 @@ Covers:
   i) an extra row never becomes an issue-> is_issue() stays False on a failing one
   j) the path is per-host + workspace    -> hosts/<label>/health-checks-extra.json
   k) run_all_checks appends them        -> the wiring exists, not just the helper
+  l) a shell that exits 0 leaving a bg child -> the child is killed, not orphaned
+  m) output far larger than the detail cap   -> retained bytes stay bounded
+  n) every outcome carries alerting: False   -> an opt-in probe cannot page anyone
 
 Run: python3 tests/health-check-user-defined-checks.test.py
 Exit code: 0 on pass, 1 on fail.
@@ -303,6 +306,62 @@ class TestUserDefinedChecks(unittest.TestCase):
                     and a.func.id == "check_user_defined" for a in n.args)
         ]
         self.assertEqual(len(extended), 1, "expected exactly one checks.extend(check_user_defined(...))")
+
+
+
+class TestUserCheckContainment(unittest.TestCase):
+    """The three runtime bounds: descendant lifetime, retained output, alerting."""
+
+    def test_a_background_child_does_not_outlive_a_normal_exit(self):
+        with tempfile.TemporaryDirectory() as d:
+            marker = Path(d) / "survived"
+            # The shell exits 0 immediately; the child would write AFTER that exit.
+            cmd = f"(sleep 0.6; touch {marker}) & exit 0"
+            code, _ = hc.run_user_command(cmd, 10.0, Path(d))
+            self.assertEqual(code, 0, "the shell itself must still report its own exit")
+            time.sleep(1.2)
+            self.assertFalse(marker.exists(),
+                             "a background grandchild outlived the command that spawned it")
+
+    def test_the_background_child_really_would_have_written_without_the_bound(self):
+        # Positive control: the same shape, run so nothing reaps the group, DOES write.
+        # Without this, the assertion above passes if `touch` simply never worked.
+        with tempfile.TemporaryDirectory() as d:
+            marker = Path(d) / "survived"
+            os.system(f"(sleep 0.2; touch {marker}) & exit 0")
+            time.sleep(0.9)
+            self.assertTrue(marker.exists(), "control failed: the child never wrote at all")
+
+    def test_output_far_over_the_cap_is_not_retained_whole(self):
+        with tempfile.TemporaryDirectory() as d:
+            mib = 2 * 1024 * 1024
+            code, output = hc.run_user_command(
+                f"python3 -c \"print('x' * {mib})\"", 30.0, Path(d))
+            self.assertEqual(code, 0)
+            self.assertLessEqual(len(output), hc.USER_CHECK_OUTPUT_READ_CAP,
+                                 "the whole sink was read into memory")
+            self.assertGreater(len(output), hc.USER_CHECK_DETAIL_CAP,
+                               "the read must still cover what gets rendered")
+
+    def test_every_outcome_suppresses_alerting(self):
+        outcomes = {
+            "ok": "exit 0",
+            "nonzero": "exit 3",
+            "timeout": "sleep 30",
+        }
+        for label, command in outcomes.items():
+            with self.subTest(outcome=label):
+                decl = {"name": label, "command": command, "timeout": 0.4}
+                row = hc.run_user_check(decl, cwd=Path("."))
+                self.assertIs(row.get("alerting"), False,
+                              f"{label} outcome can wake a notifier surface")
+                self.assertFalse(hc.is_issue(row))
+
+    def test_a_command_that_cannot_run_also_suppresses_alerting(self):
+        with mock.patch.object(hc, "run_user_command", side_effect=RuntimeError("boom")):
+            row = hc.run_user_check({"name": "x", "command": "true", "timeout": 1.0})
+        self.assertIs(row.get("alerting"), False)
+        self.assertEqual(row["status"], "warn")
 
 
 if __name__ == "__main__":

--- a/tests/health-check-user-defined-checks.test.py
+++ b/tests/health-check-user-defined-checks.test.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""
+Tests for the per-host user-defined health checks in src/health-check.py.
+
+A host-specific probe used to require editing `run_all_checks` — shared repo code
+— so every host either carried every other host's probes or went without its own.
+`<workspace>/hosts/<host>/health-checks-extra.json` is the opt-in extension point,
+mirroring the tool-suites extras convention
+(skills/proactive-loop/scripts/tool-suites-check.py).
+
+Covers:
+  a) no file at all                     -> zero rows (the CI / fresh-install case)
+  b) an exit-0 command                  -> ok, with its output as the detail
+  c) a non-zero command                 -> warn, exit code + output in the detail
+  d) a command that hangs               -> warn, killed at the declared timeout
+  e) a command that cannot be spawned   -> warn, never an exception
+  f) malformed JSON / wrong shape       -> no-op, never an exception
+  g) entries missing name or command    -> dropped, siblings still run
+  h) an extra row is distinguishable    -> the `extra:` name prefix
+  i) an extra row never becomes an issue-> is_issue() stays False on a failing one
+  j) the path is per-host + workspace    -> hosts/<label>/health-checks-extra.json
+  k) run_all_checks appends them        -> the wiring exists, not just the helper
+
+Run: python3 tests/health-check-user-defined-checks.test.py
+Exit code: 0 on pass, 1 on fail.
+"""
+
+from __future__ import annotations
+import ast
+import importlib.util
+import json
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+spec = importlib.util.spec_from_file_location("hc", REPO / "src" / "health-check.py")
+hc = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hc)
+
+
+class TestUserDefinedChecks(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.ws = Path(self._tmp.name)
+        self.host = "test-host"
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _declare(self, payload) -> Path:
+        path = self.ws / "hosts" / self.host / hc.USER_CHECKS_FILE
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(payload if isinstance(payload, str) else json.dumps(payload))
+        return path
+
+    def _run(self) -> list:
+        return hc.check_user_defined(workspace_dir=self.ws, host=self.host)
+
+    # --- a) absent ----------------------------------------------------------
+
+    def test_no_declaration_file_yields_no_rows(self):
+        """The fresh-install / CI case: nothing declared, nothing added."""
+        self.assertEqual(self._run(), [])
+
+    # --- j) where the file lives -------------------------------------------
+
+    def test_path_is_per_host_under_the_given_workspace(self):
+        path = hc.user_checks_path(workspace_dir=self.ws, host=self.host)
+        self.assertEqual(path, self.ws / "hosts" / self.host / "health-checks-extra.json")
+
+    def test_path_defaults_to_the_repo_host_label_resolver(self):
+        """The label must come from `_host_label()`, not a raw hostname slug."""
+        with mock.patch.object(hc, "_host_label", return_value="resolved-label") as m:
+            path = hc.user_checks_path(workspace_dir=self.ws)
+        m.assert_called_once_with()
+        self.assertEqual(path.parent.name, "resolved-label")
+
+    # --- b/c/h/i) the pass and fail verdicts --------------------------------
+
+    def test_exit_zero_is_ok_and_carries_the_command_output(self):
+        self._declare({"checks": [{"name": "backup", "command": "echo backup fresh"}]})
+        rows = self._run()
+        self.assertEqual(len(rows), 1, rows)
+        self.assertEqual(rows[0]["status"], "ok", rows[0])
+        self.assertIn("backup fresh", rows[0]["detail"])
+
+    def test_nonzero_exit_is_warn_with_the_code_and_the_output(self):
+        self._declare({"checks": [
+            {"name": "backup", "command": "echo snapshot 9 days old >&2; exit 3"}]})
+        row = self._run()[0]
+        self.assertEqual(row["status"], "warn", row)
+        self.assertIn("exit 3", row["detail"])
+        self.assertIn("snapshot 9 days old", row["detail"])
+
+    def test_an_extra_row_is_name_prefixed_so_it_reads_as_non_builtin(self):
+        self._declare({"checks": [{"name": "backup", "command": "true"}]})
+        self.assertEqual(self._run()[0]["name"], "extra:backup")
+
+    def test_a_failing_extra_check_is_never_an_issue(self):
+        """`warn` on purpose: a host's own probe must not move the exit code or
+        wake --emit-task / --notify-*, which key off `is_issue`."""
+        self._declare({"checks": [{"name": "backup", "command": "exit 1"}]})
+        row = self._run()[0]
+        self.assertEqual(row["status"], "warn")
+        self.assertFalse(hc.is_issue(row))
+
+    def test_a_silent_command_still_gets_a_readable_detail(self):
+        self._declare({"checks": [{"name": "quiet", "command": "true"}]})
+        self.assertEqual(self._run()[0]["detail"], "(no output)")
+
+    def test_detail_is_capped_so_a_chatty_command_cannot_flood_the_report(self):
+        self._declare({"checks": [
+            {"name": "chatty", "command": "python3 -c \"print('x' * 5000)\""}]})
+        self.assertLessEqual(len(self._run()[0]["detail"]), hc.USER_CHECK_DETAIL_CAP)
+
+    # --- d) a hang must not hang the health check ---------------------------
+
+    def test_a_hanging_command_is_killed_at_its_timeout_and_warns(self):
+        self._declare({"checks": [
+            {"name": "hangs", "command": "sleep 30", "timeout": 1}]})
+        started = time.monotonic()
+        row = self._run()[0]
+        elapsed = time.monotonic() - started
+        self.assertEqual(row["status"], "warn", row)
+        self.assertIn("TIMEOUT", row["detail"])
+        self.assertLess(elapsed, 15, f"took {elapsed:.1f}s — the timeout did not bound it")
+
+    def test_a_backgrounded_grandchild_cannot_hold_the_run_open(self):
+        """The reason output goes to a file and the whole process GROUP is killed:
+        a pipe held by a surviving grandchild outlives the timeout."""
+        self._declare({"checks": [
+            {"name": "daemonizes", "command": "sleep 30 & sleep 30", "timeout": 1}]})
+        started = time.monotonic()
+        row = self._run()[0]
+        elapsed = time.monotonic() - started
+        self.assertEqual(row["status"], "warn", row)
+        self.assertLess(elapsed, 15, f"took {elapsed:.1f}s — a grandchild blocked the drain")
+
+    def test_a_bad_timeout_value_falls_back_to_the_default(self):
+        for bad in (0, -5, True, "30", None):
+            with self.subTest(timeout=bad):
+                self._declare({"checks": [
+                    {"name": "n", "command": "true", "timeout": bad}]})
+                decls = hc.load_user_checks(
+                    hc.user_checks_path(workspace_dir=self.ws, host=self.host))
+                self.assertEqual(decls[0]["timeout"], hc.USER_CHECK_TIMEOUT_S)
+
+    # --- e) a command that cannot even be spawned ---------------------------
+
+    def test_a_spawn_failure_is_a_warn_not_an_exception(self):
+        self._declare({"checks": [{"name": "boom", "command": "true"}]})
+        with mock.patch.object(hc.subprocess, "Popen", side_effect=OSError("no fork")):
+            row = self._run()[0]
+        self.assertEqual(row["status"], "warn", row)
+        self.assertIn("no fork", row["detail"])
+
+    def test_an_unexpected_runner_error_is_a_warn_not_an_exception(self):
+        self._declare({"checks": [{"name": "boom", "command": "true"}]})
+        with mock.patch.object(hc, "run_user_command", side_effect=RuntimeError("kaboom")):
+            row = self._run()[0]
+        self.assertEqual(row["status"], "warn", row)
+        self.assertIn("kaboom", row["detail"])
+
+    def test_a_missing_command_binary_warns_rather_than_raising(self):
+        self._declare({"checks": [
+            {"name": "absent", "command": "sutando-no-such-binary-xyz"}]})
+        row = self._run()[0]
+        self.assertEqual(row["status"], "warn", row)
+
+    # --- f/g) malformed declarations ----------------------------------------
+
+    def _load(self) -> list:
+        """The LOADER, not the caller. `check_user_defined` wraps it in its own
+        try/except, so asserting only through that path leaves this guard untested
+        — a mutation removing it passed the whole suite until these were added."""
+        return hc.load_user_checks(hc.user_checks_path(workspace_dir=self.ws, host=self.host))
+
+    def test_the_loader_itself_swallows_malformed_json(self):
+        self._declare("{ this is not json")
+        self.assertEqual(self._load(), [])
+
+    def test_the_loader_itself_swallows_a_non_object_document(self):
+        self._declare(["echo hi"])
+        self.assertEqual(self._load(), [])
+
+    def test_the_loader_itself_swallows_a_non_list_checks_key(self):
+        self._declare({"checks": "echo hi"})
+        self.assertEqual(self._load(), [])
+
+    def test_the_loader_itself_swallows_a_missing_file(self):
+        self.assertEqual(self._load(), [])
+
+    def test_the_loader_itself_swallows_an_unreadable_file(self):
+        self._declare({"checks": [{"name": "n", "command": "true"}]})
+        with mock.patch.object(Path, "read_text", side_effect=OSError("EACCES")):
+            self.assertEqual(self._load(), [])
+
+    def test_malformed_json_is_a_silent_no_op(self):
+        self._declare("{ this is not json")
+        self.assertEqual(self._run(), [])
+
+    def test_a_non_object_document_is_a_silent_no_op(self):
+        self._declare(["echo hi"])
+        self.assertEqual(self._run(), [])
+
+    def test_a_non_list_checks_key_is_a_silent_no_op(self):
+        self._declare({"checks": "echo hi"})
+        self.assertEqual(self._run(), [])
+
+    def test_an_unreadable_declaration_is_a_silent_no_op(self):
+        self._declare({"checks": [{"name": "n", "command": "true"}]})
+        with mock.patch.object(Path, "read_text", side_effect=OSError("EACCES")):
+            self.assertEqual(self._run(), [])
+
+    def test_a_directory_where_the_file_belongs_is_a_silent_no_op(self):
+        (self.ws / "hosts" / self.host / hc.USER_CHECKS_FILE).mkdir(parents=True)
+        self.assertEqual(self._run(), [])
+
+    def test_incomplete_entries_are_dropped_and_valid_siblings_still_run(self):
+        """A typo in one entry must not silently cancel the rest of the file.
+        Above, in order: no name, no command, blank name, blank command, and an
+        entry that is not an object at all."""
+        self._declare({"checks": [
+            {"command": "true"},
+            {"name": "no-command"},
+            {"name": "  ", "command": "true"},
+            {"name": "blank-cmd", "command": "   "},
+            "echo not-an-object",
+            {"name": "good", "command": "echo ran"},
+        ]})
+        rows = self._run()
+        self.assertEqual([r["name"] for r in rows], ["extra:good"], rows)
+        self.assertEqual(rows[0]["status"], "ok")
+
+    def test_declared_order_is_preserved(self):
+        self._declare({"checks": [
+            {"name": "one", "command": "true"},
+            {"name": "two", "command": "true"},
+            {"name": "three", "command": "true"},
+        ]})
+        self.assertEqual([r["name"] for r in self._run()],
+                         ["extra:one", "extra:two", "extra:three"])
+
+    # --- k) the wiring, not just the helper ---------------------------------
+
+    def test_run_all_checks_calls_check_user_defined(self):
+        """A helper nothing calls is a feature nobody gets.
+
+        Asserted over `run_all_checks`'s own AST rather than by executing it: the
+        real function shells out to tmux, lsof, pgrep and the network, and a stub
+        set wide enough to neutralise 60 probes breaks on the next probe added.
+        """
+        tree = ast.parse((REPO / "src" / "health-check.py").read_text())
+        fn = next((n for n in ast.walk(tree)
+                   if isinstance(n, ast.FunctionDef) and n.name == "run_all_checks"), None)
+        self.assertIsNotNone(fn, "run_all_checks not found")
+        called = {n.func.id for n in ast.walk(fn)
+                  if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)}
+        self.assertIn("check_user_defined", called,
+                      "run_all_checks never calls check_user_defined — the extras "
+                      "are unreachable however well the helper behaves")
+
+    def test_the_call_site_extends_the_checks_list(self):
+        """`checks.extend(...)`, not a bare call: a list of rows appended one at a
+        time or dropped on the floor reaches no reader."""
+        tree = ast.parse((REPO / "src" / "health-check.py").read_text())
+        fn = next(n for n in ast.walk(tree)
+                  if isinstance(n, ast.FunctionDef) and n.name == "run_all_checks")
+        extended = [
+            n for n in ast.walk(fn)
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+            and n.func.attr == "extend"
+            and any(isinstance(a, ast.Call) and isinstance(a.func, ast.Name)
+                    and a.func.id == "check_user_defined" for a in n.args)
+        ]
+        self.assertEqual(len(extended), 1, "expected exactly one checks.extend(check_user_defined(...))")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/health-check-user-defined-checks.test.py
+++ b/tests/health-check-user-defined-checks.test.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import ast
 import importlib.util
 import json
+import os
 import sys
 import tempfile
 import time
@@ -149,6 +150,29 @@ class TestUserDefinedChecks(unittest.TestCase):
                 decls = hc.load_user_checks(
                     hc.user_checks_path(workspace_dir=self.ws, host=self.host))
                 self.assertEqual(decls[0]["timeout"], hc.USER_CHECK_TIMEOUT_S)
+
+    def test_the_group_kill_falls_back_to_the_process_when_there_is_no_group(self):
+        """A process that already exited has no group left to signal; the fallback
+        must still reap the direct child rather than let the OSError escape."""
+        proc = mock.Mock(pid=os.getpid())
+        with mock.patch.object(hc.os, "getpgid", side_effect=OSError("ESRCH")):
+            hc._kill_user_command_tree(proc)
+        proc.kill.assert_called_once_with()
+        proc.wait.assert_called_once()
+
+    def test_a_process_that_ignores_the_kill_does_not_block_the_run(self):
+        proc = mock.Mock(pid=os.getpid())
+        proc.wait.side_effect = hc.subprocess.TimeoutExpired(cmd="x", timeout=5)
+        with mock.patch.object(hc.os, "getpgid", return_value=1), \
+                mock.patch.object(hc.os, "killpg"):
+            hc._kill_user_command_tree(proc)
+
+    def test_an_unresolvable_path_yields_no_rows_instead_of_raising(self):
+        """The declaration path is resolved OUTSIDE load_user_checks, so its own
+        failure needs its own guard — otherwise it takes the health check down."""
+        self._declare({"checks": [{"name": "n", "command": "true"}]})
+        with mock.patch.object(hc, "_host_label", side_effect=RuntimeError("no scutil")):
+            self.assertEqual(hc.check_user_defined(workspace_dir=self.ws), [])
 
     # --- e) a command that cannot even be spawned ---------------------------
 


### PR DESCRIPTION
## What changed, and why?

All ~60 probes in `src/health-check.py` are hardcoded into `run_all_checks()`. A check
that only matters on **one** host — "is my Time Machine backup fresh", "is the vault
volume mounted", "is that one launchd job loaded" — could only be added by editing
shared repo code that every other host then carries. The practical result is that
host-specific checks don't get written at all.

This adds an **opt-in** extension point: a per-host declaration at

```
<workspace>/hosts/<host-label>/health-checks-extra.json
```

```json
{
  "checks": [
    {"name": "time-machine", "command": "tmutil latestbackup"},
    {"name": "vault-mounted", "command": "test -d /Volumes/vault", "timeout": 5}
  ]
}
```

Exit 0 reads `ok`, anything else `warn`, with the command's output as the detail.

**This follows the existing precedent, it does not invent a convention.**
`skills/proactive-loop/scripts/tool-suites-check.py` already declares extra *test suites*
this way (`EXTRAS = "tool-suites-extra.json"`, resolved under `hosts/<host>/`, and
deliberately **not** under `state/` — the vault emits its `state/` carve-out after the
includes, and `include` replaces the carrier set wholesale). Same file location, same
"a JSON declaration with one top-level list key" schema shape. Workspace comes from
`resolve_workspace()` and the host label from `_host_label()` — the same resolvers
`check_per_host_config_backup` and the crons probes already use; no path is hardcoded.

### Deliberate properties

- **Absent / unreadable / malformed → no-op.** A hand-edited config must never take the
  health check down. Guarded in `load_user_checks` itself, *and* at the `check_user_defined`
  call site (both layers are pinned by tests — see the mutation note below).
- **Extra rows are `warn`-level only.** `warn` is not an issue (`is_issue`), so a host's own
  probe can never move the exit code or wake `--emit-task` / `--notify-slack` /
  `--notify-gateway`. A user check cannot manufacture or mask an alert.
- **A hang cannot hang the health check.** Output is captured to a *file*, never a pipe, and
  the whole process **group** is killed at the timeout (`start_new_session` + `killpg`) — the
  same trap `src/cron-runner.py:_run_shell_command` documents for its `shell_command` jobs.
  A plain `subprocess.run(timeout=)` with pipes is defeated by a backgrounded grandchild
  holding the pipe open; there is a test for exactly that.
- **No existing probe changes.** A host that declares nothing produces byte-identical output.
  57 probes before, 57 after (see evidence).
- **Visually distinguishable.** Rows are name-prefixed `extra:`, so they read as non-built-in in
  the human listing, in `--json`, and in `summary_line`.

### Worst-case disruption (CONTRIBUTING / REVIEW.md lesson 5)

This executes shell commands from a workspace file. That is **not a new capability class** for
this repo: `hosts/<host>/crons.json` already holds `shell_command` entries that
`src/cron-runner.py` runs unattended on a timer, from the same per-host directory. This is
strictly narrower — read-only intent, bounded at 30s by default, `warn`-only, and it runs
**nothing at all** unless the owner creates the file. For every current install the file does
not exist, so the change is inert: same probe count, same text, same exit code.

## What files should reviewers look at first?

1. `src/health-check.py` — the new block immediately above `run_all_checks()`
   (`USER_CHECKS_FILE` … `check_user_defined`), plus the one-line call site at the end of
   `run_all_checks()`.
2. `tests/health-check-user-defined-checks.test.py` — 32 assertions.
3. `docs/workspace-hosts-convention.md` — the new row in the `hosts/<hostname>/` table.

## What user behavior does this prove?

An owner can add a machine-specific health probe without touching the repo, and a broken
declaration degrades to "this host declares no extras" instead of breaking `health-check.py`
for the host.

## Feature/documentation consistency

Updated `docs/workspace-hosts-convention.md` (canonical for the `hosts/<hostname>` convention
per `docs/catalog.json`): new table row + "Wired going-forward" entry, and bumped its
`last_verified` to `2026-09-08`. `docs_audit.py` passes.

## Before/after evidence

Both runs use the **same** declaration file, in isolated worktrees whose workspace resolves
to their own `workspace/` (never the live one):

```json
{"checks": [
  {"name": "time-machine",           "command": "echo 'last backup 2h ago'"},
  {"name": "obsidian-vault-mounted", "command": "echo 'vault path missing' >&2; exit 1"},
  {"name": "slow-probe",             "command": "sleep 20", "timeout": 2}
]}
```

**BEFORE — parent commit `ebd4c978`, extras file present:**

```
$ python3 src/health-check.py --json | ...
total probes: 57 | issues: 3
extra rows: []
```

**AFTER — HEAD, same file:**

```
$ python3 src/health-check.py --json | ...
total probes: 60 | issues: 3
  extra:time-machine           | ok   | last backup 2h ago
  extra:obsidian-vault-mounted | warn | exit 1: vault path missing
  extra:slow-probe             | warn | TIMEOUT after 2s (killed): (no output)
```

Note `issues: 3` in **both** — the two failing extras are warnings, so the exit code is
unchanged. The `sleep 20` probe returned after ~2s: the whole run took 2.77s wall.

**Human-readable listing at HEAD** (the `extra:` prefix + the summary line):

```
  ⚠ extra:obsidian-vault-mounted   warn         exit 1: vault path missing
  ⚠ extra:slow-probe               warn         TIMEOUT after 2s (killed): (no output)

3 ISSUE(S): build_log.md, .env, notes-dir — plus 7 warning(s): quota-telemetry, claude-hooks,
live-checkout-branch, task-watcher, skill-symlinks, extra:obsidian-vault-mounted, extra:slow-probe
```

(The 3 issues and 5 non-extra warnings are the scratch worktree's own empty workspace — identical
before and after.)

**Malformed file at HEAD** — `{ "checks": [ this is not json`:

```
total probes: 57 | issues: 3
extra rows: []
stderr bytes: 0
```

Back to the built-in 57, nothing printed, health check unaffected.

**The new test against the parent commit vs HEAD:**

```
# at ebd4c978
$ python3 -u tests/health-check-user-defined-checks.test.py
AssertionError: 0 != 1 : expected exactly one checks.extend(check_user_defined(...))
Ran 29 tests in 0.319s
FAILED (failures=2, errors=31)

# at HEAD
$ python3 -u tests/health-check-user-defined-checks.test.py
Ran 29 tests in 2.296s
OK
```

## What tests did you run?

- `python3 tests/health-check-user-defined-checks.test.py` → **32 passed**. It is discovered by
  the `test:py` runner's `find tests -name '*.test.py'` glob (verified: it appears at position
  419 of the 859-file discovery list), i.e. it is registered, not orphaned.
- Every health-related suite in the repo: `122 suites, ALL PASSED`
  (`find tests -name 'health-check-*.test.py' -o -name 'runtime-health*' -o -name 'core-health*'`).
- `bash scripts/review-checks.sh --diff` → PASS (hardcoded-paths + root-artifacts + prose-cap).
  It initially **failed** on two over-cap comment blocks; both were trimmed before commit.
- `scripts/lint-vault-sync-paths.sh`, `scripts/lint-class-rules.py`, `scripts/lint-host-label.sh --diff`,
  `BASE_REF=origin/main scripts/lint-workspace-resolution.sh --diff`,
  `scripts/check-utc-z-strftime.py`, `skills/release/scripts/docs_audit.py`,
  `scripts/gen-src-map.py` (no drift), `ruff check` → all clean.

### Mutation testing (a green suite proves nothing on its own)

Each mutation was applied to `src/health-check.py`, the suite re-run, then reverted:

| Mutation | Result |
| --- | --- |
| Delete `checks.extend(check_user_defined())` from `run_all_checks` | **FAILED (2)** — `'check_user_defined' not found in {...}`; `0 != 1 : expected exactly one checks.extend(...)` |
| `proc.wait(timeout=timeout_s)` → ignore the declared timeout | **FAILED (2)** — `'ok' != 'warn'` on the hang and the grandchild cases; suite time went 2.3s → 60.4s |
| `USER_CHECK_PREFIX = "extra:"` → `""` | **FAILED (3)** — `'backup' != 'extra:backup'` and two list comparisons |
| Non-zero exit returns `ok` instead of `warn` | **FAILED (4)** — `'ok' != 'warn'` on non-zero exit, spawn failure, and missing binary |
| Remove the `try/except` around `json.loads` in `load_user_checks` | **PASSED at first — a real hole.** The outer guard in `check_user_defined` masked it, so the loader's own robustness was untested. Fixed by adding five `test_the_loader_itself_*` cases that call `load_user_checks` directly; the same mutation then **FAILED (3 errors)** with `json.decoder.JSONDecodeError` and `OSError: EACCES`. |

### Diff-coverage gate

The first push failed `diff coverage >= 95% (python)` at 90.9% — 6 uncovered lines:
`src/health-check.py 11478-11479,11482-11483,11534-11535` (the group-kill fallback when the
process has no group left, the wait-after-kill timeout, and the guard around path resolution).
Commit `74e4f98a` adds three tests for exactly those branches; locally
`coverage json` now reports all six as covered, and the gate is green on the current head.

## Live path?

N/A — `health-check.py` is invoked per-run (cron, launchd fallback, dashboard, `--json`
consumers); it is not a long-lived bridge or delivery loop. The runs above are real invocations
of the real entry point, not a harness.

## One thing worth a maintainer's call

The brief I worked from specified **silent** no-op for a malformed file, and that is what this
implements. The sibling precedent deliberately does the opposite — `tool-suites-check.py` *raises*
on a declared-but-missing suite, on the grounds that a typo silently reporting a clean bill is the
exact failure the extras mechanism exists to prevent. I kept silence because a health check that
refuses to run is worse than one that skips extras, but a one-row `extra-checks: warn (declaration
unreadable: …)` would satisfy both and I'm happy to add it if reviewers prefer that.

Stand: Echo Act IV Blue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
