### PR TITLE
fix(x-twitter): the read-back guard refused every multi-paragraph post

### DIFF
--- a/skills/x-twitter/composer-text.mjs
+++ b/skills/x-twitter/composer-text.mjs
@@ -45,7 +45,13 @@ export function normalizeComposerText(t) {
 // this artifact generates, so it is left alone and still fails closed — per this
 // module's rule that an unmeasured difference must refuse, never be laundered.
 function undoEmptyLineDoubling(t) {
-  return t.replace(/\n{3,}/g, (run) =>
+  // INTERIOR runs only — a non-newline on both sides. That is the boundary the
+  // table above was measured at, and the edges do NOT follow the same law:
+  // measured 2026-09-08, requested "\n\nAAA" reads back as "\n\n\n\nAAA" (four, not
+  // the interior three), and a trailing run the composer drops outright. Widening
+  // past the measured interior would launder an unmeasured difference, which is
+  // the failure this module exists to prevent.
+  return t.replace(/(?<=[^\n])\n{3,}(?=[^\n])/g, (run) =>
     run.length % 2 === 1 ? '\n'.repeat((run.length + 1) / 2) : run);
 }
 

--- a/skills/x-twitter/composer-text.mjs
+++ b/skills/x-twitter/composer-text.mjs
@@ -30,6 +30,29 @@ export function normalizeComposerText(t) {
     .replace(/\r\n?/g, '\n');          // CRLF -> LF (contenteditable line endings)
 }
 
+// OBSERVED ARTIFACT (measured 2026-09-08 against the live composer, not inferred):
+// X renders each EMPTY line as its own paragraph, so `innerText` emits two newlines
+// where the request had one. Requested-vs-read-back, one run between two words:
+//
+//     requested \n x1 -> composer \n x1     (no artifact)
+//     requested \n x2 -> composer \n x3
+//     requested \n x3 -> composer \n x5
+//     requested \n x4 -> composer \n x7     i.e. composer = 2n-1 for n >= 2
+//
+// So EVERY multi-paragraph post failed the guard and could not be published at all.
+// The inverse is applied to the READ-BACK side only, and only to the odd run lengths
+// the artifact can produce: m -> (m+1)/2 for odd m >= 3. An even run is not a shape
+// this artifact generates, so it is left alone and still fails closed — per this
+// module's rule that an unmeasured difference must refuse, never be laundered.
+function undoEmptyLineDoubling(t) {
+  return t.replace(/\n{3,}/g, (run) =>
+    run.length % 2 === 1 ? '\n'.repeat((run.length + 1) / 2) : run);
+}
+
 export function composerMatches(requested, actual) {
-  return normalizeComposerText(requested) === normalizeComposerText(actual);
+  const r = normalizeComposerText(requested);
+  const a = normalizeComposerText(actual);
+  // Asymmetric on purpose: the artifact is the editor's, so it is undone on the
+  // editor's side. Never transform what the caller asked for.
+  return r === a || r === undoEmptyLineDoubling(a);
 }

--- a/tests/x-post-composer-readback.test.mjs
+++ b/tests/x-post-composer-readback.test.mjs
@@ -25,6 +25,24 @@ const check = (name, cond, detail = '') => {
   if (!cond) failures++;
 };
 
+// --- empty-line doubling (measured 2026-09-08 against the live composer) ---------
+// Every multi-paragraph post failed the guard: X renders an empty line as its own
+// paragraph, so innerText returns 2n-1 newlines where n were requested (n >= 2).
+check('a paragraph break read back doubled is tolerated',
+  composerMatches('AAA\n\nBBB', 'AAA\n\n\nBBB'));
+check('two paragraph breaks — the real failing case',
+  composerMatches('a\n\nb\n\nc', 'a\n\n\nb\n\n\nc'));
+check('three requested newlines read back as five',
+  composerMatches('AAA\n\n\nBBB', 'AAA\n\n\n\n\nBBB'));
+check('a single newline is untouched by the rule',
+  composerMatches('AAA\nBBB', 'AAA\nBBB'));
+check('an EVEN run is not this artifact and still fails closed',
+  !composerMatches('AAA\n\nBBB', 'AAA\n\n\n\nBBB'));
+check('doubling does not launder a changed word',
+  !composerMatches('AAA\n\nBBB', 'AAA\n\n\nCCC'));
+check('the rule is asymmetric — requested text is never transformed',
+  !composerMatches('AAA\n\n\nBBB', 'AAA\n\nBBB'));
+
 console.log('composer read-back guard');
 
 // --- must MATCH: benign editor-side transformations -----------------------------

--- a/tests/x-post-composer-readback.test.mjs
+++ b/tests/x-post-composer-readback.test.mjs
@@ -43,6 +43,17 @@ check('doubling does not launder a changed word',
 check('the rule is asymmetric — requested text is never transformed',
   !composerMatches('AAA\n\n\nBBB', 'AAA\n\nBBB'));
 
+// The edges are NOT the interior law (qingyun-wu, #4040). Measured 2026-09-08:
+// requested "\n\nAAA" reads back "\n\n\n\nAAA" — four, not the interior three —
+// and a trailing run is dropped by the composer outright. So an edge run is an
+// UNMEASURED difference and must still refuse.
+check('a leading-edge run is unmeasured and refuses',
+  !composerMatches('\n\na', '\n\n\na'));
+check('a trailing-edge run is unmeasured and refuses',
+  !composerMatches('a\n\n', 'a\n\n\n'));
+check('newlines-only is unmeasured and refuses',
+  !composerMatches('\n\n', '\n\n\n'));
+
 console.log('composer read-back guard');
 
 // --- must MATCH: benign editor-side transformations -----------------------------


### PR DESCRIPTION
## What breaks

`composerMatches()` refused **every multi-paragraph post**. Not a tolerated diff — a hard block on a whole class of post. Two agents hit it on the same text tonight before it was diagnosed; one reported "both paths are blocked, and one of them is lying to me."

## Why

X renders each empty line as its own paragraph, so the composer's `innerText` returns two newlines where one was requested. Measured against the live composer, one run between two words:

```
requested \n x1  ->  composer \n x1     (no artifact)
requested \n x2  ->  composer \n x3
requested \n x3  ->  composer \n x5
requested \n x4  ->  composer \n x7     i.e. 2n-1 for n >= 2
```

My first hypothesis was a flat "+1 per break". That is wrong, and only measuring three cases showed the real shape — which is why the rule is derived from the table rather than from the one failing example.

## The fix is narrow on purpose

`composer-text.mjs` already says how to handle an editor artifact: *"Fix that case with an observed, documented artifact rule; do not widen the normalizer back out to a blanket trim."* So:

- the inverse is applied to the **read-back side only**, never to the caller's text;
- only to the **odd** run lengths this artifact can produce (`m -> (m+1)/2` for odd `m >= 3`);
- an **even** run is not a shape it generates, so it is left alone and still fails closed.

Posting is irreversible, so anything unmeasured must refuse rather than be laundered into a match.

## Evidence

At this branch, with only the test file applied to the parent's `composer-text.mjs`:

```
new tests on the parent's composer-text.mjs   ->  FAILED (3)
    FAIL a paragraph break read back doubled is tolerated
    FAIL two paragraph breaks — the real failing case
    FAIL three requested newlines read back as five
    ok   an EVEN run is not this artifact and still fails closed

with the fix                                  ->  37 ok, rc=0
```

Three of the seven added tests must fail if the rule is wrong in either direction: an even run, a changed word hidden behind doubling, and the asymmetry (the requested text is never transformed). The pre-existing cases the module cares about — edge whitespace, dropped emoji, partially-typed CJK — still pass.

## Live path

Verified end to end on this host: the same text that the guard had refused published successfully after the change, `{"posted":true,"verified":true}`, byte-for-byte as written.

Stand: Echo Act IV Mini
