### PR TITLE
fix(idle-held): --add requires --note, so a hold cannot be unauditable

### DIFF
--- a/docs/proactive-loop-rationale.md
+++ b/docs/proactive-loop-rationale.md
@@ -434,14 +434,14 @@ Skip step 6 (end the pass early after step 3) if and only if one of these applie
    # 1. COMPUTE — no --write and no --commit, so nothing is persisted and nothing is
    #    stamped. `idle-held.py` prints the resulting list before it consults --write.
    python3 skills/proactive-loop/scripts/idle-held.py --state "$WORKSPACE/state/idle-streak.json" \
-       --remove <id> --reason "<why>" --add <id>:<gate> \
+       --remove <id> --reason "<why>" --add <id>:<gate> --note <owner/repo#n> \
      | python3 skills/proactive-loop/scripts/idle-surface-hash.py \
          --state "$WORKSPACE/state/idle-streak.json"
    # -> post <hash>   (changed set: surface it)   |   quiet <hash>  (unchanged)
 
    # 2. Post the message. THEN persist the ops and stamp the set as surfaced:
    python3 skills/proactive-loop/scripts/idle-held.py --state "$WORKSPACE/state/idle-streak.json" \
-       --remove <id> --reason "<why>" --add <id>:<gate> --write \
+       --remove <id> --reason "<why>" --add <id>:<gate> --note <owner/repo#n> --write \
      | python3 skills/proactive-loop/scripts/idle-surface-hash.py \
          --state "$WORKSPACE/state/idle-streak.json" --commit
    ```

--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -77,7 +77,7 @@ caps this file and refuses date stamps in it).
 6.5. **Idle surface.** Record the pass:
    `python3 skills/proactive-loop/scripts/idle-surface-hash.py --state "$WORKSPACE/state/idle-streak.json" --pass-outcome substantive|noop`.
    The held set is edited only through
-   `python3 skills/proactive-loop/scripts/idle-held.py --state "$WORKSPACE/state/idle-streak.json" --remove <id> --reason "<why>" --add <id>:<gate>`
+   `python3 skills/proactive-loop/scripts/idle-held.py --state "$WORKSPACE/state/idle-streak.json" --remove <id> --reason "<why>" --add <id>:<gate> --note <owner/repo#n>`
    (no whole-list interface; a removal needs a reason); audit notes with `--audit-notes "$PWD"` and
    retire merged items. Compute: `idle-held.py … | idle-surface-hash.py --state …` → `post <hash>` or
    `quiet <hash>`. On `post`: send ONE FYI line to the owner's primary channel, THEN re-run with

--- a/skills/proactive-loop/scripts/idle-held.py
+++ b/skills/proactive-loop/scripts/idle-held.py
@@ -125,6 +125,17 @@ def apply_ops(items, adds, removes):
 BRANCH_SHA = re.compile(r"`?([\w./-]+/[\w./-]+)`?\s*@\s*`?([0-9a-f]{7,40})`?")
 
 
+def refuse_blank(values, flag: str, paired: str) -> "str | None":
+    """A present-but-blank explanation passes a count check and satisfies nothing:
+    the audit sees the key and does not even list it as missing."""
+    for i, v in enumerate(values):
+        if not str(v).strip():
+            return (f"REFUSED: {flag} #{i + 1} is blank. A count check cannot tell a "
+                    f"blank explanation from a real one, so {paired} would record an "
+                    f"unauditable entry with the key present.")
+    return None
+
+
 def audit_notes(doc, repo) -> int:
     """A sha written into a note is a COPY of a fact git owns, and copies drift.
 
@@ -334,6 +345,13 @@ def main(argv=None) -> int:
 
     if a.audit_notes:
         return audit_notes(doc, a.audit_notes)
+
+    for _vals, _flag, _paired in ((a.reason, "--reason", "--remove"),
+                                 (a.note, "--note", "--add")):
+        _err = refuse_blank(_vals, _flag, _paired)
+        if _err:
+            print(_err, file=sys.stderr)
+            return 1
 
     if a.remove and len(a.reason) != len(a.remove):
         print(f"REFUSED: {len(a.remove)} --remove but {len(a.reason)} --reason. "

--- a/skills/proactive-loop/scripts/idle-held.py
+++ b/skills/proactive-loop/scripts/idle-held.py
@@ -268,6 +268,9 @@ def main(argv=None) -> int:
     ap.add_argument("--remove", action="append", default=[], metavar="ID")
     ap.add_argument("--reason", action="append", default=[],
                     help="why an id is being removed; one per --remove")
+    ap.add_argument("--note", action="append", default=[],
+                    help="the held item's note; one per --add. An `owner/repo#n` "
+                         "here is what --audit-prs reads to check the hold")
     ap.add_argument("--write", action="store_true",
                     help="persist the new held_item_ids (atomic; other keys untouched)")
     ap.add_argument("--audit-prs", action="store_true",
@@ -336,6 +339,12 @@ def main(argv=None) -> int:
               "A silent shrink is the failure this tool exists to stop.", file=sys.stderr)
         return 1
 
+    if a.add and len(a.note) != len(a.add):
+        print(f"REFUSED: {len(a.add)} --add but {len(a.note)} --note. A hold with no "
+              "note is invisible to --audit-prs, which is the other half of the "
+              "silent-shrink failure.", file=sys.stderr)
+        return 1
+
     adds = []
     for spec in a.add:
         if ":" not in spec:
@@ -362,6 +371,8 @@ def main(argv=None) -> int:
           file=sys.stderr)
     for rid, why in zip(a.remove, a.reason):
         print(f"  removed {rid}: {why}", file=sys.stderr)
+    for (aid, _g), note in zip(adds, a.note):
+        print(f"  added {aid}: {note}", file=sys.stderr)
 
     if a.write:
         def apply_under_lock(fresh):
@@ -375,6 +386,11 @@ def main(argv=None) -> int:
             log = fresh.setdefault("held_item_removals", [])
             for rid, why in zip(a.remove, a.reason):
                 log.append({"id": rid, "reason": why})
+            # Same lock as the id write: an id that lands without its note is the
+            # unauditable hold this pairing exists to prevent.
+            notes = fresh.setdefault("held_item_notes", {})
+            for (aid, _g), note in zip(adds, a.note):
+                notes[aid] = note
             return None
 
         res = locked_update(state, apply_under_lock, indent=2)

--- a/skills/proactive-loop/scripts/idle-held.py
+++ b/skills/proactive-loop/scripts/idle-held.py
@@ -17,7 +17,7 @@ So this tool never accepts a list. It reads `held_item_ids` from the state file
 and applies explicit add/remove operations:
 
   idle-held.py --state <ws>/state/idle-streak.json --remove cinny-717 --reason merged
-  idle-held.py --state ... --add ds-pr-13:owner
+  idle-held.py --state ... --add ds-pr-13:owner --note owner/repo#13
   idle-held.py --state ... --remove X --reason "..." --write | idle-surface-hash.py --state ... --commit
 
 A removal REQUIRES a reason, because a silent shrink is the failure that

--- a/skills/proactive-loop/scripts/idle-held.py
+++ b/skills/proactive-loop/scripts/idle-held.py
@@ -269,8 +269,9 @@ def main(argv=None) -> int:
     ap.add_argument("--reason", action="append", default=[],
                     help="why an id is being removed; one per --remove")
     ap.add_argument("--note", action="append", default=[],
-                    help="the held item's note; one per --add. An `owner/repo#n` "
-                         "here is what --audit-prs reads to check the hold")
+                    help="the held item's note; one per --add. Any string is "
+                         "accepted; an `owner/repo#n` in it is what --audit-prs "
+                         "reads, and a hold with no PR needs a note all the same")
     ap.add_argument("--write", action="store_true",
                     help="persist the new held_item_ids (atomic; other keys untouched)")
     ap.add_argument("--audit-prs", action="store_true",

--- a/tests/proactive-loop-idle-held.test.py
+++ b/tests/proactive-loop-idle-held.test.py
@@ -515,5 +515,34 @@ check("...and an unrelated pre-existing note survives that write",
 _rc, _, _ = run(["--state", str(_wp), "--remove", "z", "--reason", "done"])
 check("a removal still needs no --note", _rc == 0)
 
+
+# A blank explanation passes a COUNT check and satisfies nothing: the audit sees the
+# key present and does not even list it among the missing (qingyun-wu, #4042).
+for _flag, _val, _label in (("--note", "", "an empty"), ("--note", "   ", "a whitespace-only")):
+    _bp = state(list(BASE))
+    _before = _bp.read_bytes()
+    _rc, _, _err = run(["--state", str(_bp), "--add", "blank:owner", _flag, _val, "--write"])
+    check(f"{_label} --note is REFUSED", _rc == 1, _err[:90])
+    check(f"...and {_label} --note leaves the file BYTE-IDENTICAL",
+          _bp.read_bytes() == _before)
+
+# The sibling flag has the same shape, and an unauditable REMOVAL is the silent
+# shrink this tool exists to stop.
+for _val, _label in (("", "an empty"), ("  ", "a whitespace-only")):
+    _bp = state(list(BASE))
+    _before = _bp.read_bytes()
+    _rc, _, _err = run(["--state", str(_bp), "--remove", "ds-pr-12", "--reason", _val, "--write"])
+    check(f"{_label} --reason is REFUSED", _rc == 1, _err[:90])
+    check(f"...and {_label} --reason leaves the file BYTE-IDENTICAL",
+          _bp.read_bytes() == _before)
+
+# The guard must not over-refuse: a non-PR explanation is explicitly allowed.
+_op = state(list(BASE))
+_rc, _, _ = run(["--state", str(_op), "--add", "prose:owner", "--note", "no PR; owner judgement", "--write"])
+check("a non-PR --note is still accepted", _rc == 0)
+_op2 = state(list(BASE))
+_rc2, _, _ = run(["--state", str(_op2), "--remove", "ds-pr-12", "--reason", "landed", "--write"])
+check("a plain --reason is still accepted", _rc2 == 0)
+
 print(f"\n{'FAILED: ' + ', '.join(fails) if fails else 'all passed'} ({ran - len(fails)}/{ran} assertions)")
 sys.exit(1 if fails else 0)

--- a/tests/proactive-loop-idle-held.test.py
+++ b/tests/proactive-loop-idle-held.test.py
@@ -52,13 +52,13 @@ check("an id built from RECALL is refused, not silently applied",
 check("...and it names the near-miss so the real id is one read away",
       "sutando-3198" in err, err[:90])
 
-rc, out, _ = run(["--state", str(p), "--add", "new-thing:ci"])
+rc, out, _ = run(["--state", str(p), "--add", "new-thing:ci", "--note", "sonichi/sutando#1"])
 check("add appends the pair", rc == 0 and ["new-thing","ci"] in json.loads(out))
 
-rc, _, err = run(["--state", str(p), "--add", "cinny-717:owner"])
+rc, _, err = run(["--state", str(p), "--add", "cinny-717:owner", "--note", "n"])
 check("adding an existing id is refused", rc == 1 and "already held" in err, err[:70])
 
-rc, _, err = run(["--state", str(p), "--add", "nogate"])
+rc, _, err = run(["--state", str(p), "--add", "nogate", "--note", "n"])
 check("--add without a gate is refused", rc == 1 and "ID:GATE" in err, err[:70])
 
 # there is NO interface that takes a whole list — the defect, made unreachable
@@ -306,7 +306,7 @@ fresh = pathlib.Path(tempfile.mkdtemp()) / "s.json"
 fresh.write_text(json.dumps({"streak": 0, "noop_total": 48,
                              "last_surfaced_ids": ["3753:peer-review"]}))
 
-rc, _, err = run(["--state", str(fresh), "--add", "3857:owner", "--write"])
+rc, _, err = run(["--state", str(fresh), "--add", "3857:owner", "--note", "sonichi/sutando#3857", "--write"])
 check("PRE-CONTROL: --add on a keyless state still refuses",
       rc == 2 and "refusing to invent" in err, err[:80])
 
@@ -325,7 +325,7 @@ rc, _, err = run(["--state", str(fresh), "--init-empty"])
 check("--init-empty REFUSES a second time — it bootstraps, never clears",
       rc == 2 and "REFUSED" in err, err[:80])
 
-rc, _, _ = run(["--state", str(fresh), "--add", "3857:owner", "--write"])
+rc, _, _ = run(["--state", str(fresh), "--add", "3857:owner", "--note", "sonichi/sutando#3857", "--write"])
 check("THE POINT: --add works after the bootstrap",
       rc == 0 and json.loads(fresh.read_text())["held_item_ids"] == [["3857", "owner"]],
       str(json.loads(fresh.read_text()).get("held_item_ids"))[:60])
@@ -407,7 +407,7 @@ def _refuses_held(argv, label):
           f"rc={rc} changed={f.read_text() != before} err={str(err).strip()[:60]!r}")
 
 _refuses_held(["--init-empty"], "--init-empty")
-_refuses_held(["--add", "x:owner", "--write"], "--add --write")
+_refuses_held(["--add", "x:owner", "--note", "n", "--write"], "--add --write")
 _refuses_held(["--archive-orphan-notes", "--write"], "--archive-orphan-notes --write")
 
 _valid_h = pathlib.Path(tempfile.mkdtemp()) / "idle-streak.json"
@@ -440,7 +440,7 @@ def _under_race(argv, err="raced corruption", seed=None):
 
 for _argv, _label, _seed in (
         (["--init-empty"], "--init-empty", {"streak": 1}),
-        (["--add", "x:owner", "--write"], "--add --write", {"held_item_ids": []}),
+        (["--add", "x:owner", "--note", "n", "--write"], "--add --write", {"held_item_ids": []}),
         (["--archive-orphan-notes", "--write"], "--archive-orphan-notes --write",
          {"held_item_ids": [], "held_item_notes": {"gone": "n"}}),
 ):
@@ -456,7 +456,7 @@ _f.write_text(json.dumps({KEY_HELD: []}))
 _before = _f.read_text()
 ih.idle_state.read_state_strict = lambda path: ({KEY_HELD: [["x", "owner"]]}, None)
 try:
-    _rc, _, _err = run(["--state", str(_f), "--add", "x:owner", "--write"])
+    _rc, _, _err = run(["--state", str(_f), "--add", "x:owner", "--note", "n", "--write"])
 finally:
     ih.idle_state.read_state_strict = _orig_rss
 check("a racer that added the same id under the lock aborts the write (exit 1)",
@@ -486,6 +486,34 @@ check("the no-key refusal NAMES the flag that resolves it",
       _doc_d is None and "--init-empty" in (_err2 or ""), repr(_err2))
 check("...and still says what it refuses to do, so the reason survives",
       "refusing to invent one" in (_err2 or ""), repr(_err2))
+
+# --add without --note: an id lands in held_item_ids that --audit-prs can never
+# check, which is the silent-shrink failure pointing the other way (#4033).
+_np = state(BASE)
+_rc, _, _err = run(["--state", str(_np), "--add", "z:owner"])
+check("an add with NO note is refused", _rc == 1 and "invisible to --audit-prs" in _err, _err[:90])
+
+_rc, _, _err = run(["--state", str(_np), "--add", "z:owner", "--add", "y:owner", "--note", "n"])
+check("a --note count that does not match --add is refused",
+      _rc == 1 and "2 --add but 1 --note" in _err, _err[:90])
+
+_rc, _out, _err = run(["--state", str(_np), "--add", "z:owner", "--note", "sonichi/sutando#77"])
+check("a paired add still succeeds and echoes the note",
+      _rc == 0 and ["z","owner"] in json.loads(_out) and "added z: sonichi/sutando#77" in _err,
+      _err[:100])
+
+_wp = state(BASE)
+_rc, _, _ = run(["--state", str(_wp), "--add", "z:owner", "--note", "sonichi/sutando#77", "--write"])
+_after = json.loads(_wp.read_text())
+check("--write persists the note under the SAME lock as the id",
+      _rc == 0 and ["z","owner"] in _after["held_item_ids"]
+      and _after["held_item_notes"].get("z") == "sonichi/sutando#77",
+      json.dumps(_after.get("held_item_notes"))[:100])
+check("...and an unrelated pre-existing note survives that write",
+      _after["held_item_notes"].get("keep") == "must survive a write")
+
+_rc, _, _ = run(["--state", str(_wp), "--remove", "z", "--reason", "done"])
+check("a removal still needs no --note", _rc == 0)
 
 print(f"\n{'FAILED: ' + ', '.join(fails) if fails else 'all passed'} ({ran - len(fails)}/{ran} assertions)")
 sys.exit(1 if fails else 0)

--- a/tests/proactive-loop-idle-surface-hash.test.py
+++ b/tests/proactive-loop-idle-surface-hash.test.py
@@ -158,7 +158,7 @@ def _read_then_race(path):
     if not _spawned:                 # once, while --commit holds the lock
         _spawned["p"] = subprocess.Popen(
             [_sys.executable, "-B", _HELD, "--state", str(path),
-             "--add", "raced:owner", "--write"],
+             "--add", "raced:owner", "--note", "race fixture", "--write"],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
         time.sleep(0.4)              # let it reach and block on the lock
     return got


### PR DESCRIPTION
## The defect

`--audit-prs` checks a held item by reading an `owner/repo#n` out of `held_item_notes`. `--add` has no way to write one. So every id added by the tool becomes a hold the audit cannot check — it prints them as `unmapped` and carries on, which reads as a clean audit:

```
9 held id(s): 4 PR-mapped, 5 unmapped, 0 unresolvable
  unmapped (no `owner/repo#n` in the note, NOT guessed): slack-draft-…, 3924, 3669, 3316, 3565
```

Four of those five are ordinary `sonichi/sutando` PRs. Checked by hand, all four are `OPEN APPROVED CLEAN` — so nothing was stale this time. That is luck, not the tool: the audit exists precisely because a hold can go terminal without anyone noticing, and it was structurally blind to 5 of 9.

This is the silent-shrink failure the `--remove`/`--reason` pairing already guards, pointing the other way. The existing refusal says it plainly:

> `REFUSED: 1 --remove but 0 --reason. A silent shrink is the failure this tool exists to stop.`

A removal with no reason shrinks the list invisibly; an add with no note grows it invisibly.

## Why a flag rather than remembering

I have attached these notes by hand three times — the same fix, from the same audit output, on three separate days. The second time I diagnosed it correctly and explicitly declined to add the flag, reasoning that `idle-held.py` is engine-tree and a change there dies at the next app update. That was wrong in one specific way: it is true of editing the shipped copy and false of the repo, which is where a change persists. Declining to fix the tool was a decision to keep paying the cost manually, and the very next `--add` reproduced it.

## The change

`--note` pairs one-per-`--add`, exactly as `--reason` pairs with `--remove`: refused on a count mismatch, echoed in the summary, and written to `held_item_notes` **inside the same `locked_update` that writes the id** — so an id cannot land without its note even under a racing writer.

`--remove` is untouched and still needs no note.

## Before / after

The new assertions run against the tool at the parent commit (`origin/main` 46076f9ba) and at HEAD. At base the suite does not fail an assertion — it **cannot complete**, because argparse rejects the unknown flag and `SystemExit(2)` unwinds the harness:

```
===== origin/main 46076f9ba
idle-held
  ok    no ops emits the RECORDED list verbatim
  ok    remove drops exactly one, order preserved
  ok    a removal with NO reason is refused
  ok    an id built from RECALL is refused, not silently applied
  ok    ...and it names the near-miss so the real id is one read away
rc=2        (5 ok lines, then the first --note call site; no summary line)

===== HEAD d5d753812
all passed (83/83 assertions)
```

**Mutation-checked** — each new assertion is tied to the line it guards:

```
drop the pairing guard        FAILED: an add with NO note is refused,
                                      a --note count that does not match --add is refused  (81/83)
drop the locked note write    FAILED: --write persists the note under the SAME lock as the id  (82/83)
restored                      all passed (83/83)
```

The suite was 75 assertions and is 83; the 8 existing `--add` call sites gained a `--note`, which is the contract change being made rather than a workaround.

## Not covered

- No live round trip: this is a workspace-state editor invoked from the proactive loop, not a bridge or delivery path. The `--write` assertions exercise the real `locked_update`, including the existing racer cases.
- Callers with a bare `--add` now get exit 1 and a message naming `--audit-prs`. That is the intended breaking change; the only caller in-tree is the loop's step 6.5, which is prose instructing the operator, not a script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
