### PR TITLE
fix(proactive-loop): warn-already-triaged printed 3 of N candidates and named no gap

### DIFF
--- a/skills/proactive-loop/scripts/warn-already-triaged.py
+++ b/skills/proactive-loop/scripts/warn-already-triaged.py
@@ -68,6 +68,10 @@ def lines_of(path):
 # Component count is unbounded; the 3..40 length check below is the only size
 # bound. A cap truncates a hyphenated name and drops a snake_case one entirely.
 ENT = re.compile(r'`([^`]{3,40})`|([\w./-]+\.(?:py|sh|json|md|ts|yml))|\b([a-z][a-z0-9]+(?:-[a-z0-9]+)+)\b|\b(_?[A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)+)\b|(?<!\w)(#\d{3,5})\b')
+# A truncated candidate list reads as a complete one. Must exceed the worst
+# real miss: 7 hits, answer 7th.
+SHOW_CANDIDATES = 12
+
 STOP = {"health-check", "not-running", "restart-needed", "session-read", "read-limit"}
 
 def tokens(name, text):
@@ -107,11 +111,14 @@ def report(name, text, files):
                         hits.append((tok, display(f), i, line.strip()[:92]))
                     break
     if hits:
-        # ALL candidates, not just the first. A probe warns for SEVERAL distinct
-        # conditions and a parking for one does NOT cover another.
+        # Hit order is token-then-file, NOT relevance, so a silent truncation
+        # hides an arbitrary subset. Anything withheld is counted out loud.
         print(f"  CANDIDATES {label:25} ({len(hits)}) — verify the CONDITION matches, not just the probe")
-        for tok, fn, i, line in hits[:3]:
+        for tok, fn, i, line in hits[:SHOW_CANDIDATES]:
             print(f"             via '{tok}' -> {fn}:{i}  {line}")
+        if len(hits) > SHOW_CANDIDATES:
+            print(f"             +{len(hits) - SHOW_CANDIDATES} further candidate(s) NOT shown — "
+                  f"narrow the claim to see them")
         return "parked"
     body = []
     for tok in toks:

--- a/tests/warn-already-triaged-truncation.test.py
+++ b/tests/warn-already-triaged-truncation.test.py
@@ -1,0 +1,68 @@
+"""A truncated candidate list must count what it withholds.
+
+`report()` prints the TRUE number of candidates in its header and used to print
+three of them. Hits are ordered by token then file — not by relevance — so the
+three shown are an arbitrary subset, and a reader who verified every line on
+screen could conclude "not parked" while the matching entry sat below the cut.
+That is the failure this pins: the header and the body disagreed silently.
+"""
+import contextlib
+import importlib.util
+import io
+import pathlib
+import tempfile
+import unittest
+
+_SRC = (pathlib.Path(__file__).resolve().parents[1]
+        / "skills" / "proactive-loop" / "scripts" / "warn-already-triaged.py")
+_spec = importlib.util.spec_from_file_location("wat", _SRC)
+wat = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(wat)
+
+
+def _parking(dirpath, n):
+    """n parking files, each with ONE heading carrying the token."""
+    out = []
+    for i in range(n):
+        p = pathlib.Path(dirpath) / f"note-{i:02d}.md"
+        p.write_text(f"## snowflake-decode case {i}\n\nbody\n")
+        out.append(p)
+    return out
+
+
+def _run(files, claim="the `snowflake-decode` path"):
+    wat._LINES.clear()
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        verdict = wat.report(None, claim, files)
+    return verdict, buf.getvalue()
+
+
+class Truncation(unittest.TestCase):
+    def test_the_header_count_and_the_shown_lines_agree_or_the_gap_is_named(self):
+        with tempfile.TemporaryDirectory() as d:
+            files = _parking(d, 20)   # literal, so this arm does not
+                                     # depend on the constant existing
+            verdict, out = _run(files)
+        self.assertEqual(verdict, "parked")
+        shown = out.count("via '")
+        header = int(out.split("(", 1)[1].split(")", 1)[0])
+        self.assertGreater(header, shown, "fixture must exceed the display cap")
+        # The gap is the whole point: it must be stated, with the real number.
+        self.assertIn(f"+{header - shown} further candidate", out)
+
+    def test_nothing_is_withheld_silently_below_the_cap(self):
+        with tempfile.TemporaryDirectory() as d:
+            files = _parking(d, 3)
+            _, out = _run(files)
+        self.assertEqual(out.count("via '"), 3)
+        self.assertNotIn("further candidate", out)
+
+    def test_the_cap_is_large_enough_to_have_shown_the_real_miss(self):
+        """The incident had 7 heading hits and the answer was the 7th. A cap of
+        3 hid it; any cap below 7 would hide it again."""
+        self.assertGreaterEqual(getattr(wat, "SHOW_CANDIDATES", 3), 7)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The defect

`report()` prints the true candidate count in its header, then printed `hits[:3]`. Hits are ordered by token then file — **not by relevance** — so the three shown are an arbitrary subset, and nothing on screen indicates more exist.

The comment directly above the loop already said the opposite of what the code did:

```python
# ALL candidates, not just the first. A probe warns for SEVERAL distinct
# conditions and a parking for one does NOT cover another.
print(f"  CANDIDATES {label:25} ({len(hits)}) — verify the CONDITION matches, not just the probe")
for tok, fn, i, line in hits[:3]:
```

## Before — on this host's real parking corpus

Claim: ``a `regex` over a structured file classifies the formatting not the content``

```
tokens: ['regex']          TOTAL heading hits: 7      (the tool PRINTS only hits[:3])

  1 regex -> pending-questions.md:8018
  2 regex -> build_log.md:4183
  3 regex -> memory/feedback_consumer_without_producer_trail.md:464
  ---------------------------- cut, silently ----------------------------
  4 regex -> memory/feedback_exposure_is_not_defect_ask_which_way_it_fails.md:239
  5 regex -> memory/feedback_inline_js_escaping.md:32
  6 regex -> memory/feedback_no_anchor_on_documented_marker.md:136
  7 regex -> memory/feedback_parse_dont_regex_structured.md:263   <- the answer
```

The memory that parks that exact lesson is the **7th** hit. A reader follows the header's own instruction, verifies the three wrong-subject candidates shown, and concludes the claim is untriaged.

Not hypothetical: two agents hit this independently tonight and each diagnosed a *different* non-defect from the truncated output — one "the gate's verdict varies by host", one "frontmatter eats the token budget". Both dissolved once the unprinted hits were visible.

## After

Cap raised to 12, and anything still withheld is counted out loud:

```
+17 further candidate(s) NOT shown — narrow the claim to see them
```

## Test

`tests/warn-already-triaged-truncation.test.py`, 3 arms. The primary arm uses a literal 20-file fixture so it does not depend on the new constant existing.

Control at the parent commit — fails on **behaviour**, not on a missing symbol:

```
AssertionError: '+17 further candidate' not found in
  "  CANDIDATES this claim (20) — verify the CONDITION matches, not just the probe
             via 'snowflake-decode' -> note-00.md:1  ## snowflake-decode case 0
             via 'snowflake-decode' -> note-01.md:1  ## snowflake-decode case 1
             via 'snowflake-decode' -> note-02.md:1  ## snowflake-decode case 2"
AssertionError: 3 not greater than or equal to 7
Ran 3 tests — FAILED (failures=2)
```

At HEAD: `Ran 3 tests — OK`.

Existing suite `tests/proactive-loop-warn-already-triaged.test.py`: **39 tests, OK** at HEAD.

## Scope

Display only. Token extraction, search order, exit codes and the three verdicts are untouched.
