### PR TITLE
fix(collab-intel): a null-filled roster row shadowed a usable peer row

### DIFF
--- a/skills/collaboration-intelligence/scripts/notify_reviewers.py
+++ b/skills/collaboration-intelligence/scripts/notify_reviewers.py
@@ -51,7 +51,7 @@ sys.path.insert(0, str(_REPO / "src"))
 
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from roster_union import (declared, declared_routes, host_rosters,
+from roster_union import (TEXT_FIELDS, declared, declared_routes, host_rosters,
                           roster_login, roster_union)
 
 _ROSTER_LEAF = Path("data") / "collaboration-intelligence" / "reviewer-stands.json"
@@ -131,7 +131,7 @@ def stated_reason(entry: dict) -> str:
     A blank `stand` can be missing data OR a deliberate DO-NOT-ROUTE. Only the
     entry knows which, and a refusal that omits it invites the repair that
     overrides it (#3468)."""
-    for key in ("refusal_basis", "note"):
+    for key in TEXT_FIELDS:
         reason = declared(entry.get(key))
         if reason:
             return " ".join(reason.split())

--- a/skills/collaboration-intelligence/scripts/notify_reviewers.py
+++ b/skills/collaboration-intelligence/scripts/notify_reviewers.py
@@ -51,7 +51,7 @@ sys.path.insert(0, str(_REPO / "src"))
 
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from roster_union import host_rosters, roster_login, roster_union
+from roster_union import declared, host_rosters, roster_login, roster_union
 
 _ROSTER_LEAF = Path("data") / "collaboration-intelligence" / "reviewer-stands.json"
 
@@ -123,9 +123,9 @@ def stated_reason(entry: dict) -> str:
     entry knows which, and a refusal that omits it invites the repair that
     overrides it (#3468)."""
     for key in ("refusal_basis", "note"):
-        v = entry.get(key)
-        if isinstance(v, str) and v.strip():
-            return " ".join(v.split())
+        reason = declared(entry.get(key))
+        if reason:
+            return " ".join(reason.split())
     return ""
 
 

--- a/skills/collaboration-intelligence/scripts/notify_reviewers.py
+++ b/skills/collaboration-intelligence/scripts/notify_reviewers.py
@@ -51,9 +51,14 @@ sys.path.insert(0, str(_REPO / "src"))
 
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from roster_union import declared, host_rosters, roster_login, roster_union
+from roster_union import (declared, declared_routes, host_rosters,
+                          roster_login, roster_union)
 
 _ROSTER_LEAF = Path("data") / "collaboration-intelligence" / "reviewer-stands.json"
+
+# The transports this tool can DRIVE. Stated once: the union tie-break and
+# resolve() must not answer "is this row deliverable?" differently.
+SUPPORTED_ROUTES = ("matrix",)
 
 
 def _host_label() -> str:
@@ -107,13 +112,17 @@ def roster_paths() -> "list[tuple[str, Path]]":
 
 
 def load_roster() -> dict:
-    """Union across hosts; the merge policy is roster_union's, not restated here."""
+    """Union across hosts; the merge policy is roster_union's, not restated here.
+
+    It is told which transports this tool can drive, so a row it could never
+    send on cannot displace one it can and then be refused by resolve().
+    """
     paths = roster_paths()
     if not paths:
         where = os.environ.get("SUTANDO_SCI_ROSTER") or "any host"
         raise SystemExit(f"no roster at {where} — seed it from the map before "
                          "notifying (never guess Stand identities)")
-    return roster_union(paths)
+    return roster_union(paths, SUPPORTED_ROUTES)
 
 
 def stated_reason(entry: dict) -> str:
@@ -142,7 +151,10 @@ def resolve(names: "list[str]", roster: dict) -> "tuple[list[dict], int]":
                   "add them from the map, do not guess", file=sys.stderr)
             worst = max(worst, 2)
             continue
-        stand, room = entry.get("stand"), entry.get("room")
+        # Both the ROUTE and its VALUES come from the classifier, so what is sent
+        # is what was validated -- a blank or a list can reach neither.
+        routes = declared_routes(entry, SUPPORTED_ROUTES)
+        stand, room = declared(entry.get("stand")), declared(entry.get("room"))
         why = stated_reason(entry)
         # A caveat nobody prints is a note, not a step. Derived from the entry:
         # a named field list misses the next caveat silently.
@@ -150,10 +162,13 @@ def resolve(names: "list[str]", roster: dict) -> "tuple[list[dict], int]":
             if entry.get(field):
                 label = field[: -len("_caveat")].upper().replace("_", " ")
                 print(f"{label} CAVEAT '{name}': {entry[field]}", file=sys.stderr)
-        if not stand or not room:
+        if not routes:
             # a human id alone cannot be a target: person-mentions trigger no Stand
+            other = ", ".join(declared_routes(entry))
             print(f"UNUSABLE entry '{name}': needs both 'stand' and 'room' "
-                  f"(human-only = not Stand addressing)", file=sys.stderr)
+                  f"(human-only = not Stand addressing)"
+                  + (f" — declares {other}, which this tool cannot send on"
+                     if other else ""), file=sys.stderr)
             # Without this the refusal reads as a data gap, and the obvious
             # repair — populate the fields — silently overrides the refusal.
             if why:

--- a/skills/collaboration-intelligence/scripts/notify_reviewers.py
+++ b/skills/collaboration-intelligence/scripts/notify_reviewers.py
@@ -255,7 +255,7 @@ def _github_login(name: str, roster: dict) -> "tuple[str, str]":
     # so a timeout would discard owner-stated identity for the colliding key.
     if gh:
         return gh, f"roster {field} -> {gh}"
-    sib = entry.get("same_actor_as")
+    sib = declared(entry.get("same_actor_as"))
     if sib:
         return sib, f"via same_actor_as -> {sib}"
     if _is_github_user(name):
@@ -396,7 +396,9 @@ def _actor_map(roster) -> dict:
         if not isinstance(v, dict) or k.startswith("_"):
             continue
         find(k)
-        other = v.get("same_actor_as")
+        # A non-string here is a dict KEY below: a list or dict raises
+        # TypeError and takes the whole notifier down, not just this row.
+        other = declared(v.get("same_actor_as"))
         if other:
             union(k, other)
     return {k: find(k) for k in parent}

--- a/skills/collaboration-intelligence/scripts/notify_reviewers.py
+++ b/skills/collaboration-intelligence/scripts/notify_reviewers.py
@@ -51,7 +51,7 @@ sys.path.insert(0, str(_REPO / "src"))
 
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from roster_union import (REFUSAL_FIELDS, TEXT_FIELDS, declared, declared_routes, host_rosters,
+from roster_union import (CAVEAT_SUFFIX, is_caveat, REFUSAL_FIELDS, TEXT_FIELDS, declared, declared_routes, host_rosters,
                           roster_login, roster_union)
 
 _ROSTER_LEAF = Path("data") / "collaboration-intelligence" / "reviewer-stands.json"
@@ -158,9 +158,9 @@ def resolve(names: "list[str]", roster: dict) -> "tuple[list[dict], int]":
         why = stated_reason(entry)
         # A caveat nobody prints is a note, not a step. Derived from the entry:
         # a named field list misses the next caveat silently.
-        for field in sorted(k for k in entry if k.endswith("_caveat")):
+        for field in sorted(k for k in entry if is_caveat(k)):
             if entry.get(field):
-                label = field[: -len("_caveat")].upper().replace("_", " ")
+                label = field[: -len(CAVEAT_SUFFIX)].upper().replace("_", " ")
                 print(f"{label} CAVEAT '{name}': {entry[field]}", file=sys.stderr)
         if not routes:
             # a human id alone cannot be a target: person-mentions trigger no Stand

--- a/skills/collaboration-intelligence/scripts/notify_reviewers.py
+++ b/skills/collaboration-intelligence/scripts/notify_reviewers.py
@@ -51,7 +51,7 @@ sys.path.insert(0, str(_REPO / "src"))
 
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from roster_union import (TEXT_FIELDS, declared, declared_routes, host_rosters,
+from roster_union import (REFUSAL_FIELDS, TEXT_FIELDS, declared, declared_routes, host_rosters,
                           roster_login, roster_union)
 
 _ROSTER_LEAF = Path("data") / "collaboration-intelligence" / "reviewer-stands.json"
@@ -131,7 +131,7 @@ def stated_reason(entry: dict) -> str:
     A blank `stand` can be missing data OR a deliberate DO-NOT-ROUTE. Only the
     entry knows which, and a refusal that omits it invites the repair that
     overrides it (#3468)."""
-    for key in TEXT_FIELDS:
+    for key in REFUSAL_FIELDS:
         reason = declared(entry.get(key))
         if reason:
             return " ".join(reason.split())

--- a/skills/collaboration-intelligence/scripts/roster_union.py
+++ b/skills/collaboration-intelligence/scripts/roster_union.py
@@ -42,6 +42,23 @@ REFUSAL_FIELDS = ("refusal_basis", "note")
 TEXT_FIELDS = REFUSAL_FIELDS + ("authority_caveat", "same_actor_as") + IDENTITY_FIELDS
 
 
+CAVEAT_SUFFIX = "_caveat"
+
+
+def is_caveat(field) -> bool:
+    """The resolver prints EVERY `*_caveat`, so the family is the unit here."""
+    return str(field).endswith(CAVEAT_SUFFIX)
+
+
+def is_text_field(field) -> bool:
+    """Text-typed: the named list plus the whole caveat family.
+
+    A named spelling misses the next caveat silently, and the consumer already
+    reads the family, so the policy guarding it must read the family too.
+    """
+    return field in TEXT_FIELDS or is_caveat(field)
+
+
 def states_field(field, value) -> bool:
     """Whether a NAMED field states something, by that field's OWN type.
 
@@ -50,7 +67,7 @@ def states_field(field, value) -> bool:
     list or a `False` in one prints as no reason at all, so letting it overlay
     would erase a peer's stated refusal with a value no reader can read.
     """
-    return bool(declared(value)) if field in TEXT_FIELDS else is_declared(value)
+    return bool(declared(value)) if is_text_field(field) else is_declared(value)
 
 
 def roster_login(row) -> "tuple[str, str]":

--- a/skills/collaboration-intelligence/scripts/roster_union.py
+++ b/skills/collaboration-intelligence/scripts/roster_union.py
@@ -17,6 +17,25 @@ ROSTER_LEAF = Path("data") / "collaboration-intelligence" / "reviewer-stands.jso
 IDENTITY_FIELDS = ("gh", "github")
 
 
+def declared(value) -> str:
+    """The text a roster field STATES: stripped, or "" when it states nothing.
+
+    The single spelling of blank-is-absent. Every reader of a row and the union's
+    own overlay must answer it identically, or a blank local field reads as data
+    to one and as silence to the next — and erases a peer's explicit refusal.
+    """
+    return value.strip() if isinstance(value, str) else ""
+
+
+def is_declared(value) -> bool:
+    """`declared` widened past text, for callers that overlay whole values.
+
+    Same rule for strings; a non-string states itself, so `allowlisted: false`
+    survives while `None` and a blank string remain the absence readers assume.
+    """
+    return bool(declared(value)) if isinstance(value, str) else value is not None
+
+
 def roster_login(row) -> "tuple[str, str]":
     """(GitHub login this row declares, the field it came from); ("", "") if none.
 
@@ -27,9 +46,9 @@ def roster_login(row) -> "tuple[str, str]":
     if not isinstance(row, dict):
         return "", ""
     for field in IDENTITY_FIELDS:
-        value = row.get(field)
-        if isinstance(value, str) and value.strip():
-            return value.strip(), field
+        login = declared(row.get(field))
+        if login:
+            return login, field
     return "", ""
 
 
@@ -55,7 +74,7 @@ def _usable(row) -> bool:
     `refusal_basis`/`note` is DO-NOT-ROUTE and must not lose to a peer row."""
     if not isinstance(row, dict):
         return False
-    if any(str(row.get(k) or "").strip() for k in ("refusal_basis", "note")):
+    if any(declared(row.get(k)) for k in ("refusal_basis", "note")):
         return True
     # Only a route both consumers can actually deliver on counts. A discord id
     # is not one here: resolve() builds Matrix targets from stand+room alone.
@@ -75,7 +94,7 @@ def _is_routing_placeholder(row) -> bool:
     """
     if not isinstance(row, dict):
         return True
-    return not any(str(row.get(k) or "").strip() for k in _ROUTING)
+    return not any(declared(row.get(k)) for k in _ROUTING)
 
 
 def _promote(winner: dict, local: dict) -> dict:
@@ -86,11 +105,13 @@ def _promote(winner: dict, local: dict) -> dict:
     loc = local if isinstance(local, dict) else {}
     # Identity is preserved semantically: roster_login ranks `gh` over `github`,
     # so a surviving peer alias outranks the local spelling.
-    if roster_login(loc)[0] or str(loc.get("same_actor_as") or "").strip():
+    if roster_login(loc)[0] or declared(loc.get("same_actor_as")):
         for alias in IDENTITY_FIELDS + ("same_actor_as",):
             out.pop(alias, None)
+    # `is_declared`, never `is not None`: a blank local field is ABSENT to every
+    # reader, so overlaying it erases the refusal or identity the peer stated.
     for field, value in loc.items():
-        if field not in _ROUTING and value is not None:
+        if field not in _ROUTING and is_declared(value):
             out[field] = value
     return out
 

--- a/skills/collaboration-intelligence/scripts/roster_union.py
+++ b/skills/collaboration-intelligence/scripts/roster_union.py
@@ -62,6 +62,33 @@ def _usable(row) -> bool:
     return bool(row.get("stand") and row.get("room"))
 
 
+_ROUTING = ("stand", "room")
+
+
+def _is_routing_placeholder(row) -> bool:
+    """No routing value of its own -- nothing of that kind is lost by promoting.
+
+    Applied WITH `not _usable(row)`, never instead of it: `_usable` is also true
+    for a refusal row, which carries no routing value and must still never be
+    overwritten. This adds the partial-identity case -- a row naming a stand but
+    no room states an identity, and promoting over it routes under the wrong one.
+    """
+    if not isinstance(row, dict):
+        return True
+    return not any(str(row.get(k) or "").strip() for k in _ROUTING)
+
+
+def _promote(winner: dict, local: dict) -> dict:
+    """Peer routing, local everything-else. `allowlisted: false` is a refusal and
+    survives; consumers check it AFTER the bare-key lookup, so an @local copy
+    does not protect delivery."""
+    out = dict(winner)
+    for field, value in (local if isinstance(local, dict) else {}).items():
+        if field not in _ROUTING and value is not None:
+            out[field] = value
+    return out
+
+
 def roster_union(paths) -> dict:
     """(host, path) pairs, NEAREST FIRST -> merged rows.
 
@@ -82,9 +109,10 @@ def roster_union(paths) -> dict:
             elif merged[key] != row:
                 # Precedence is by origin EXCEPT when exactly one row is usable:
                 # `stand: null` is a row, so it won a collision like a filled one.
-                if _usable(row) and not _usable(merged[key]):
+                if (_usable(row) and not _usable(merged[key])
+                        and _is_routing_placeholder(merged[key])):
                     merged[f"{key}@local"] = merged[key]
-                    merged[key] = row
+                    merged[key] = _promote(row, merged[key])
                 else:
                     merged[f"{key}@{host or 'legacy'}"] = row
     return merged

--- a/skills/collaboration-intelligence/scripts/roster_union.py
+++ b/skills/collaboration-intelligence/scripts/roster_union.py
@@ -77,10 +77,23 @@ ROUTE_FIELDS = (
 )
 
 
-def _names_route(value) -> bool:
-    """Whether a routing field NAMES a route. Built on `declared`, not a second
-    spelling of it: `false` and `0` are how a row says "no route", not a route."""
-    return is_declared(value) and bool(value)
+# Discord addresses are numeric on the wire; every other route field is text.
+NUMERIC_ROUTE_FIELDS = frozenset(f for g in dict(ROUTE_FIELDS)["discord"]
+                                 for f in g)
+
+
+def _names_route(field, value) -> bool:
+    """Whether a routing FIELD names a route, by `declared`'s rule — not a
+    second spelling of it.
+
+    Text that states nothing states no route, so a blank, a list and a dict all
+    fail here rather than reaching a consumer that assumes a string. `false` and
+    `0` are still how a row says "no route"; only an id field may be numeric.
+    """
+    if declared(value):
+        return True
+    return (field in NUMERIC_ROUTE_FIELDS and isinstance(value, int)
+            and not isinstance(value, bool) and bool(value))
 
 
 def routing_fields(kinds=None) -> "tuple[str, ...]":
@@ -95,19 +108,25 @@ def routing_fields(kinds=None) -> "tuple[str, ...]":
                                for group in groups for field in group))
 
 
-def declared_routes(row) -> "tuple[str, ...]":
+def declared_routes(row, kinds=None) -> "tuple[str, ...]":
     """The route kinds this row can be delivered on, PREFERRED FIRST.
 
     The union asks whether a row has ANY; the notifier asks WHICH. Reading one
     table is what stops either deciding alone that a declared route does not
     exist -- the union calling a usable Discord row a placeholder let a synced
     peer's Matrix row take over a destination the local row already named.
+
+    `kinds=None` means every route, and a caller that narrows it states which
+    transports it can DRIVE -- the same declaration `states_routing` takes. A
+    consumer answering that question differently is how the two disagreed.
     """
     if not isinstance(row, dict):
         return ()
     return tuple(kind for kind, groups in ROUTE_FIELDS
-                 if all(any(_names_route(row.get(field)) for field in group)
-                        for group in groups))
+                 if (kinds is None or kind in kinds)
+                 and all(any(_names_route(field, row.get(field))
+                             for field in group)
+                         for group in groups))
 
 
 def states_routing(row, kinds=None) -> bool:
@@ -119,17 +138,18 @@ def states_routing(row, kinds=None) -> bool:
     """
     if not isinstance(row, dict):
         return False
-    return any(_names_route(row.get(field)) for field in routing_fields(kinds))
+    return any(_names_route(field, row.get(field))
+               for field in routing_fields(kinds))
 
 
-def _usable(row) -> bool:
-    """Addressable, OR a deliberate refusal. A blank `stand` carrying
+def _usable(row, kinds=None) -> bool:
+    """Addressable ON `kinds`, OR a deliberate refusal. A blank `stand` carrying
     `refusal_basis`/`note` is DO-NOT-ROUTE and must not lose to a peer row."""
     if not isinstance(row, dict):
         return False
     if any(declared(row.get(k)) for k in ("refusal_basis", "note")):
         return True
-    return bool(declared_routes(row))
+    return bool(declared_routes(row, kinds))
 
 
 def _is_routing_placeholder(row) -> bool:
@@ -167,7 +187,7 @@ def _promote(winner: dict, local: dict) -> dict:
     return out
 
 
-def roster_union(paths) -> dict:
+def roster_union(paths, kinds=None) -> dict:
     """(host, path) pairs, NEAREST FIRST -> merged rows.
 
     LOCAL WINS a key collision; the differing peer row is KEPT under
@@ -175,6 +195,11 @@ def roster_union(paths) -> dict:
     wrote are indistinguishable afterwards. An identical peer row is not
     suffixed — agreement is not a conflict. `_`-prefixed schema notes are
     overwritten rather than suffixed, so they are not duplicated per host.
+
+    `kinds` is the CALLER's declaration of what it can deliver on (default:
+    every route). A caller that cannot drive a transport must say so, or the
+    tie-break hands it a winner it will then refuse, and the reachable row for
+    that person survives only under a suffix its own resolver never reads.
     """
     merged: dict = {}
     for host, p in paths:
@@ -187,7 +212,7 @@ def roster_union(paths) -> dict:
             elif merged[key] != row:
                 # Precedence is by origin EXCEPT when exactly one row is usable:
                 # `stand: null` is a row, so it won a collision like a filled one.
-                if (_usable(row) and not _usable(merged[key])
+                if (_usable(row, kinds) and not _usable(merged[key], kinds)
                         and _is_routing_placeholder(merged[key])):
                     merged[f"{key}@local"] = merged[key]
                     merged[key] = _promote(row, merged[key])

--- a/skills/collaboration-intelligence/scripts/roster_union.py
+++ b/skills/collaboration-intelligence/scripts/roster_union.py
@@ -83,7 +83,13 @@ def _promote(winner: dict, local: dict) -> dict:
     survives; consumers check it AFTER the bare-key lookup, so an @local copy
     does not protect delivery."""
     out = dict(winner)
-    for field, value in (local if isinstance(local, dict) else {}).items():
+    loc = local if isinstance(local, dict) else {}
+    # Identity is preserved semantically: roster_login ranks `gh` over `github`,
+    # so a surviving peer alias outranks the local spelling.
+    if roster_login(loc)[0] or str(loc.get("same_actor_as") or "").strip():
+        for alias in IDENTITY_FIELDS + ("same_actor_as",):
+            out.pop(alias, None)
+    for field, value in loc.items():
         if field not in _ROUTING and value is not None:
             out[field] = value
     return out

--- a/skills/collaboration-intelligence/scripts/roster_union.py
+++ b/skills/collaboration-intelligence/scripts/roster_union.py
@@ -36,9 +36,10 @@ def is_declared(value) -> bool:
     return bool(declared(value)) if isinstance(value, str) else value is not None
 
 
-# The roster fields schema.md types as STRING, in the precedence the notifier
-# prints them. The ONE statement of which fields carry text rather than a value.
-TEXT_FIELDS = ("refusal_basis", "note")
+# The ONE statement of which roster fields carry TEXT rather than a value.
+# Identity included: a `False` or a list in one reads as blank to every reader.
+TEXT_FIELDS = ("refusal_basis", "note", "authority_caveat",
+               "same_actor_as") + IDENTITY_FIELDS
 
 
 def states_field(field, value) -> bool:

--- a/skills/collaboration-intelligence/scripts/roster_union.py
+++ b/skills/collaboration-intelligence/scripts/roster_union.py
@@ -36,10 +36,10 @@ def is_declared(value) -> bool:
     return bool(declared(value)) if isinstance(value, str) else value is not None
 
 
-# The ONE statement of which roster fields carry TEXT rather than a value.
-# Identity included: a `False` or a list in one reads as blank to every reader.
-TEXT_FIELDS = ("refusal_basis", "note", "authority_caveat",
-               "same_actor_as") + IDENTITY_FIELDS
+# TYPE is not INTENT: only these two withhold a route.
+REFUSAL_FIELDS = ("refusal_basis", "note")
+# The ONE list of fields carrying TEXT, not a value: a False or list reads blank.
+TEXT_FIELDS = REFUSAL_FIELDS + ("authority_caveat", "same_actor_as") + IDENTITY_FIELDS
 
 
 def states_field(field, value) -> bool:
@@ -164,7 +164,7 @@ def _usable(row, kinds=None) -> bool:
     `refusal_basis`/`note` is DO-NOT-ROUTE and must not lose to a peer row."""
     if not isinstance(row, dict):
         return False
-    if any(declared(row.get(k)) for k in TEXT_FIELDS):
+    if any(declared(row.get(k)) for k in REFUSAL_FIELDS):
         return True
     return bool(declared_routes(row, kinds))
 

--- a/skills/collaboration-intelligence/scripts/roster_union.py
+++ b/skills/collaboration-intelligence/scripts/roster_union.py
@@ -69,6 +69,59 @@ def host_rosters(workspace) -> "list[tuple[str, Path]]":
     return out
 
 
+# Every route kind a row can declare, and the field groups it must fill -- any
+# one spelling per group satisfies its group. The ONE statement of route shape.
+ROUTE_FIELDS = (
+    ("matrix", (("stand",), ("room",))),
+    ("discord", (("discord_id", "stand_discord_id"), ("home_channel",))),
+)
+
+
+def _names_route(value) -> bool:
+    """Whether a routing field NAMES a route. Built on `declared`, not a second
+    spelling of it: `false` and `0` are how a row says "no route", not a route."""
+    return is_declared(value) and bool(value)
+
+
+def routing_fields(kinds=None) -> "tuple[str, ...]":
+    """Every field the named routes read, deduped, in ROUTE_FIELDS order.
+
+    `kinds=None` means every route. A caller that narrows it is stating which
+    transports its question is about, which is the part that used to be an
+    unwritten assumption inside each consumer.
+    """
+    return tuple(dict.fromkeys(field for kind, groups in ROUTE_FIELDS
+                               if kinds is None or kind in kinds
+                               for group in groups for field in group))
+
+
+def declared_routes(row) -> "tuple[str, ...]":
+    """The route kinds this row can be delivered on, PREFERRED FIRST.
+
+    The union asks whether a row has ANY; the notifier asks WHICH. Reading one
+    table is what stops either deciding alone that a declared route does not
+    exist -- the union calling a usable Discord row a placeholder let a synced
+    peer's Matrix row take over a destination the local row already named.
+    """
+    if not isinstance(row, dict):
+        return ()
+    return tuple(kind for kind, groups in ROUTE_FIELDS
+                 if all(any(_names_route(row.get(field)) for field in group)
+                        for group in groups))
+
+
+def states_routing(row, kinds=None) -> bool:
+    """Any routing value at all for the named routes, complete or not.
+
+    A partial route still names an identity, so promoting over it routes under
+    a different one. Which transports that protection covers is the CALLER's
+    declaration, not this module's guess -- see the union's placeholder test.
+    """
+    if not isinstance(row, dict):
+        return False
+    return any(_names_route(row.get(field)) for field in routing_fields(kinds))
+
+
 def _usable(row) -> bool:
     """Addressable, OR a deliberate refusal. A blank `stand` carrying
     `refusal_basis`/`note` is DO-NOT-ROUTE and must not lose to a peer row."""
@@ -76,12 +129,7 @@ def _usable(row) -> bool:
         return False
     if any(declared(row.get(k)) for k in ("refusal_basis", "note")):
         return True
-    # Only a route both consumers can actually deliver on counts. A discord id
-    # is not one here: resolve() builds Matrix targets from stand+room alone.
-    return bool(row.get("stand") and row.get("room"))
-
-
-_ROUTING = ("stand", "room")
+    return bool(declared_routes(row))
 
 
 def _is_routing_placeholder(row) -> bool:
@@ -91,10 +139,12 @@ def _is_routing_placeholder(row) -> bool:
     for a refusal row, which carries no routing value and must still never be
     overwritten. This adds the partial-identity case -- a row naming a stand but
     no room states an identity, and promoting over it routes under the wrong one.
+
+    Scoped to `matrix`: a COMPLETE Discord route is already protected by
+    `_usable`, while a lone Discord id is deliberately still promotable, so a
+    peer with a working Stand can reach someone this host cannot address.
     """
-    if not isinstance(row, dict):
-        return True
-    return not any(declared(row.get(k)) for k in _ROUTING)
+    return not states_routing(row, ("matrix",))
 
 
 def _promote(winner: dict, local: dict) -> dict:
@@ -110,8 +160,9 @@ def _promote(winner: dict, local: dict) -> dict:
             out.pop(alias, None)
     # `is_declared`, never `is not None`: a blank local field is ABSENT to every
     # reader, so overlaying it erases the refusal or identity the peer stated.
+    routing = routing_fields()
     for field, value in loc.items():
-        if field not in _ROUTING and is_declared(value):
+        if field not in routing and is_declared(value):
             out[field] = value
     return out
 

--- a/skills/collaboration-intelligence/scripts/roster_union.py
+++ b/skills/collaboration-intelligence/scripts/roster_union.py
@@ -36,6 +36,22 @@ def is_declared(value) -> bool:
     return bool(declared(value)) if isinstance(value, str) else value is not None
 
 
+# The roster fields schema.md types as STRING, in the precedence the notifier
+# prints them. The ONE statement of which fields carry text rather than a value.
+TEXT_FIELDS = ("refusal_basis", "note")
+
+
+def states_field(field, value) -> bool:
+    """Whether a NAMED field states something, by that field's OWN type.
+
+    `is_declared` stays the default because its permissiveness is what keeps
+    `allowlisted: false` meaningful. A text field asks `declared` instead: a
+    list or a `False` in one prints as no reason at all, so letting it overlay
+    would erase a peer's stated refusal with a value no reader can read.
+    """
+    return bool(declared(value)) if field in TEXT_FIELDS else is_declared(value)
+
+
 def roster_login(row) -> "tuple[str, str]":
     """(GitHub login this row declares, the field it came from); ("", "") if none.
 
@@ -147,7 +163,7 @@ def _usable(row, kinds=None) -> bool:
     `refusal_basis`/`note` is DO-NOT-ROUTE and must not lose to a peer row."""
     if not isinstance(row, dict):
         return False
-    if any(declared(row.get(k)) for k in ("refusal_basis", "note")):
+    if any(declared(row.get(k)) for k in TEXT_FIELDS):
         return True
     return bool(declared_routes(row, kinds))
 
@@ -178,11 +194,11 @@ def _promote(winner: dict, local: dict) -> dict:
     if roster_login(loc)[0] or declared(loc.get("same_actor_as")):
         for alias in IDENTITY_FIELDS + ("same_actor_as",):
             out.pop(alias, None)
-    # `is_declared`, never `is not None`: a blank local field is ABSENT to every
-    # reader, so overlaying it erases the refusal or identity the peer stated.
+    # Per FIELD, never `is not None`: absence is the field's own type's answer,
+    # so overlaying erases neither the refusal nor the identity the peer stated.
     routing = routing_fields()
     for field, value in loc.items():
-        if field not in routing and is_declared(value):
+        if field not in routing and states_field(field, value):
             out[field] = value
     return out
 

--- a/skills/collaboration-intelligence/scripts/roster_union.py
+++ b/skills/collaboration-intelligence/scripts/roster_union.py
@@ -57,8 +57,9 @@ def _usable(row) -> bool:
         return False
     if any(str(row.get(k) or "").strip() for k in ("refusal_basis", "note")):
         return True
-    return bool((row.get("stand") and row.get("room"))
-                or row.get("discord_id") or row.get("discord"))
+    # Only a route both consumers can actually deliver on counts. A discord id
+    # is not one here: resolve() builds Matrix targets from stand+room alone.
+    return bool(row.get("stand") and row.get("room"))
 
 
 def roster_union(paths) -> dict:

--- a/skills/collaboration-intelligence/scripts/roster_union.py
+++ b/skills/collaboration-intelligence/scripts/roster_union.py
@@ -51,10 +51,14 @@ def host_rosters(workspace) -> "list[tuple[str, Path]]":
 
 
 def _usable(row) -> bool:
-    """A row that can actually address someone. Absence and a null field are the
-    same answer here; only the merge treated them differently."""
-    return isinstance(row, dict) and bool(
-        (row.get("stand") and row.get("room")) or row.get("discord_id") or row.get("discord"))
+    """Addressable, OR a deliberate refusal. A blank `stand` carrying
+    `refusal_basis`/`note` is DO-NOT-ROUTE and must not lose to a peer row."""
+    if not isinstance(row, dict):
+        return False
+    if any(str(row.get(k) or "").strip() for k in ("refusal_basis", "note")):
+        return True
+    return bool((row.get("stand") and row.get("room"))
+                or row.get("discord_id") or row.get("discord"))
 
 
 def roster_union(paths) -> dict:

--- a/skills/collaboration-intelligence/scripts/roster_union.py
+++ b/skills/collaboration-intelligence/scripts/roster_union.py
@@ -50,6 +50,13 @@ def host_rosters(workspace) -> "list[tuple[str, Path]]":
     return out
 
 
+def _usable(row) -> bool:
+    """A row that can actually address someone. Absence and a null field are the
+    same answer here; only the merge treated them differently."""
+    return isinstance(row, dict) and bool(
+        (row.get("stand") and row.get("room")) or row.get("discord_id") or row.get("discord"))
+
+
 def roster_union(paths) -> dict:
     """(host, path) pairs, NEAREST FIRST -> merged rows.
 
@@ -68,5 +75,11 @@ def roster_union(paths) -> dict:
             if key.startswith("_") or key not in merged:
                 merged[key] = row
             elif merged[key] != row:
-                merged[f"{key}@{host or 'legacy'}"] = row
+                # Precedence is by origin EXCEPT when exactly one row is usable:
+                # `stand: null` is a row, so it won a collision like a filled one.
+                if _usable(row) and not _usable(merged[key]):
+                    merged[f"{key}@local"] = merged[key]
+                    merged[key] = row
+                else:
+                    merged[f"{key}@{host or 'legacy'}"] = row
     return merged

--- a/tests/notify-reviewers-transport-alignment.test.py
+++ b/tests/notify-reviewers-transport-alignment.test.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""The notifier's supported transports must agree with the shared classifier.
+
+Two ways they disagreed, both reproduced against the production path rather than
+against the union's helpers — a helper-level assertion passes while the consumer
+that reads the helper still refuses the row it selected:
+
+  1. The union counted a complete Discord row as usable and promoted a Discord
+     PEER over a null local placeholder, shutting out a Matrix peer for the same
+     person. `resolve()` cannot send on Discord, so the union's own winner was
+     undeliverable and the reviewer was silently omitted.
+  2. A route field holding a list or a dict passed the "names a route" test, so
+     an unhashable value reached `resolve()`'s duplicate key and aborted the
+     WHOLE batch; and a whitespace `stand` promoted by a refusal was returned as
+     a live target while the classifier said the row had no route at all.
+
+Six cases FAIL at a96e8312e58c7bcc9c7942a07eb408183d985387. Every one is paired
+with a must-still-work leg in `StillWorks`, so a resolver that refused everything
+— or a classifier tightened until nothing is a route — fails too.
+
+The arms are written transport-agnostically wherever the invariant is, so they
+keep their meaning once the tool learns a second transport; the one arm that
+pins WHICH peer wins states that precondition and skips when it no longer holds.
+
+Run: /usr/bin/python3 tests/notify-reviewers-transport-alignment.test.py
+"""
+import contextlib
+import importlib.util
+import io
+import json
+import pathlib
+import tempfile
+import unittest
+
+SCRIPTS = (pathlib.Path(__file__).resolve().parents[1] / "skills"
+           / "collaboration-intelligence" / "scripts")
+
+
+def _load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Read once, defensively: a tree without the declaration must still COLLECT, or
+# the arms that are meant to fail there never run at all.
+DECLARED = tuple(getattr(_load("nr_decl", SCRIPTS / "notify_reviewers.py"),
+                         "SUPPORTED_ROUTES", ()))
+
+LOCAL_NULL = {"stand": None, "room": None, "human": "@r:ag2.space"}
+PEER_DISCORD = {"discord_id": "123456789", "home_channel": "987654321"}
+PEER_MATRIX = {"stand": "@peer:x", "room": "!peer:x"}
+VALID = {"stand": "@valid:x", "room": "!valid:x"}
+
+
+class _Base(unittest.TestCase):
+    def setUp(self):
+        self.d = tempfile.mkdtemp()
+        self.ru = _load("ru_align", SCRIPTS / "roster_union.py")
+        self.nr = _load("nr_align", SCRIPTS / "notify_reviewers.py")
+
+    def _resolve(self, rosters, names):
+        """Production `load_roster()` -> `resolve()`.
+
+        Only on-disk DISCOVERY is supplied: the union call, the transport
+        declaration it carries and the resolver all stay production, which is
+        the seam a union-helper assertion cannot reach.
+        """
+        paths = []
+        for label, rows in rosters:
+            p = pathlib.Path(self.d, label + ".json")
+            p.write_text(json.dumps(rows))
+            paths.append((label, p))
+        self.nr.roster_paths = lambda: paths
+        roster = self.nr.load_roster()
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            targets, rc = self.nr.resolve(list(names), roster)
+        return targets, rc, err.getvalue(), roster
+
+
+class UnionWinnerMustBeDeliverable(_Base):
+    """Rosters ordered null local placeholder -> Discord peer -> Matrix peer."""
+
+    ROSTERS = [("local", {"reviewer": LOCAL_NULL, "other": VALID}),
+               ("host1", {"reviewer": PEER_DISCORD}),
+               ("host2", {"reviewer": PEER_MATRIX})]
+
+    def test_the_union_winner_is_one_resolve_can_actually_deliver(self):
+        """Transport-agnostic, so it keeps its meaning once the tool learns a
+        second transport: whatever row wins the bare key must be deliverable."""
+        targets, rc, err, roster = self._resolve(self.ROSTERS, ("reviewer", "other"))
+        self.assertIn(
+            "reviewer", [t["name"] for t in targets],
+            "the union handed resolve() a row it cannot send on; the reachable "
+            f"row survives only under a suffix. rc={rc} keys={sorted(roster)} "
+            f"err={err!r}")
+        self.assertEqual(rc, 0, err)
+        self.assertTrue(
+            set(self.ru.declared_routes(roster["reviewer"]))
+            & set(self.nr.SUPPORTED_ROUTES),
+            f"the winner declares {self.ru.declared_routes(roster['reviewer'])}, "
+            f"none of {self.nr.SUPPORTED_ROUTES}")
+
+    @unittest.skipUnless(DECLARED == ("matrix",),
+                         "pins the selection while Matrix is the only transport")
+    def test_the_MATRIX_peer_is_the_one_selected(self):
+        targets, rc, err, _ = self._resolve(self.ROSTERS, ("reviewer",))
+        self.assertEqual([(t["name"], t["stand"]) for t in targets],
+                         [("reviewer", "@peer:x")], err)
+
+    def test_a_LOCAL_row_this_tool_cannot_drive_is_not_the_end_of_it_either(self):
+        """The same invariant with the undrivable route held LOCALLY: precedence
+        by origin must not hand the resolver a row it will refuse."""
+        targets, rc, err, roster = self._resolve(
+            [("local", {"reviewer": {"discord_id": "D2", "home_channel": "C2"}}),
+             ("zpeer", {"reviewer": PEER_MATRIX})], ("reviewer",))
+        self.assertIn("reviewer", [t["name"] for t in targets],
+                      f"rc={rc} keys={sorted(roster)} err={err!r}")
+        self.assertEqual(rc, 0, err)
+
+    def test_neither_peer_row_is_dropped(self):
+        """The loser is kept under a suffix — a lost row and a row nobody wrote
+        are indistinguishable afterwards."""
+        _, _, _, roster = self._resolve(self.ROSTERS, ("reviewer",))
+        rows = [v for k, v in roster.items() if k.split("@")[0] == "reviewer"]
+        self.assertTrue(any(r.get("discord_id") for r in rows),
+                        f"the Discord row was dropped: {sorted(roster)}")
+        self.assertTrue(any(r.get("stand") == "@peer:x" for r in rows),
+                        f"the Matrix row was dropped: {sorted(roster)}")
+
+    def test_the_second_reviewer_resolves_either_way(self):
+        """Must-still-work: the valid row never depended on the tie-break."""
+        targets, _, err, _ = self._resolve(self.ROSTERS, ("reviewer", "other"))
+        self.assertIn("other", [t["name"] for t in targets], err)
+
+
+class MalformedRouteValues(_Base):
+    """A bad row must be SKIPPED, never abort the batch around it."""
+
+    def _batch(self, peer):
+        return self._resolve([("local", {"bad": LOCAL_NULL, "good": VALID}),
+                              ("host1", {"bad": peer})], ("bad", "good"))
+
+    def test_a_LIST_route_does_not_crash_the_batch(self):
+        targets, rc, err, _ = self._batch({"stand": ["@peer:x"], "room": "!peer:x"})
+        self.assertEqual([t["name"] for t in targets], ["good"], err)
+        self.assertEqual(rc, 3, err)
+
+    def test_a_DICT_route_does_not_crash_the_batch(self):
+        targets, rc, err, _ = self._batch(
+            {"stand": {"mxid": "@peer:x"}, "room": "!peer:x"})
+        self.assertEqual([t["name"] for t in targets], ["good"], err)
+        self.assertEqual(rc, 3, err)
+
+    def test_a_refusal_does_not_make_a_WHITESPACE_stand_a_target(self):
+        """The refusal legitimately protects the row from promotion; it must not
+        also make the blank it carries into a live mention target."""
+        targets, rc, err, _ = self._batch(
+            {"stand": "   ", "room": "!peer:x", "refusal_basis": "DO NOT ROUTE"})
+        self.assertEqual([t["name"] for t in targets], ["good"],
+                         f"a whitespace stand was returned as a target: {targets}")
+        self.assertEqual(rc, 3, err)
+        self.assertIn("DO NOT ROUTE", err,
+                      "the refusal was dropped, so the obvious repair overrides it")
+
+    def test_the_classifier_agrees_the_malformed_row_has_no_route(self):
+        for value in (["@peer:x"], {"mxid": "@peer:x"}, "   ", "", None):
+            self.assertEqual(
+                self.ru.declared_routes({"stand": value, "room": "!peer:x"}), (),
+                f"{value!r} was read as naming a Matrix route")
+
+
+class StillWorks(_Base):
+    """Controls: a blanket refusal, or a classifier tightened until nothing is a
+    route, must fail this class."""
+
+    def test_a_complete_matrix_entry_still_resolves(self):
+        targets, rc, err, _ = self._resolve([("local", {"v": VALID})], ("v",))
+        self.assertEqual(rc, 0, err)
+        self.assertEqual([(t["name"], t["stand"], t["room"]) for t in targets],
+                         [("v", "@valid:x", "!valid:x")])
+
+    def test_an_off_allowlist_entry_still_refuses_with_its_OWN_code(self):
+        """rc 4 must not collapse into the unusable rc 3."""
+        _, rc, err, _ = self._resolve(
+            [("local", {"v": dict(VALID, allowlisted=False)})], ("v",))
+        self.assertEqual(rc, 4, err)
+
+    def test_a_blank_stand_refusal_still_states_its_reason(self):
+        _, rc, err, _ = self._resolve(
+            [("local", {"v": {"stand": "", "room": "", "note": "DO NOT ROUTE"}})],
+            ("v",))
+        self.assertEqual(rc, 3, err)
+        self.assertIn("DO NOT ROUTE", err)
+
+    def test_an_unknown_reviewer_still_refuses_with_its_OWN_code(self):
+        _, rc, err, _ = self._resolve([("local", {"v": VALID})], ("nobody",))
+        self.assertEqual(rc, 2, err)
+
+    def test_a_NUMERIC_discord_id_still_names_a_route(self):
+        """Live rosters spell the id as a number; rejecting non-text wholesale
+        would make this row unroutable to every consumer."""
+        self.assertEqual(
+            self.ru.declared_routes({"discord_id": 42, "home_channel": "C"}),
+            ("discord",))
+        self.assertEqual(
+            self.ru.declared_routes({"stand_discord_id": 42, "home_channel": 7}),
+            ("discord",))
+        self.assertEqual(
+            self.ru.declared_routes({"discord_id": True, "home_channel": "C"}), (),
+            "a boolean is how a row says yes/no, never a snowflake")
+
+    def test_a_route_value_is_delivered_STRIPPED(self):
+        """The emitted target is the text the classifier validated: an unstripped
+        copy addresses a different string and reads as a second person."""
+        targets, rc, err, _ = self._resolve(
+            [("local", {"v": {"stand": " @valid:x ", "room": " !valid:x "}})], ("v",))
+        self.assertEqual(rc, 0, err)
+        self.assertEqual([(t["stand"], t["room"]) for t in targets],
+                         [("@valid:x", "!valid:x")])
+
+    def test_the_DECLARATION_matches_what_resolve_actually_accepts(self):
+        """The alignment itself, in both directions — so widening the resolver
+        without widening the declaration keeps the union narrowing a row the
+        resolver would now deliver, and fails here instead of silently."""
+        for kind, row in (("matrix", VALID), ("discord", PEER_DISCORD)):
+            targets, _, err, _ = self._resolve([("local", {"v": row})], ("v",))
+            self.assertEqual(
+                bool(targets), kind in self.nr.SUPPORTED_ROUTES,
+                f"resolve() and SUPPORTED_ROUTES disagree about {kind}: "
+                f"targets={targets} declared={self.nr.SUPPORTED_ROUTES} err={err!r}")
+
+    def test_a_local_discord_route_still_wins_for_a_caller_that_can_send_on_it(self):
+        """The default union is unchanged: narrowing is the CALLER's declaration,
+        so the repair this PR made for a Discord-capable consumer still holds."""
+        lp = pathlib.Path(self.d, "l.json")
+        pp = pathlib.Path(self.d, "p.json")
+        lp.write_text(json.dumps({"s": {"discord_id": "D2", "home_channel": "C2"}}))
+        pp.write_text(json.dumps({"s": PEER_MATRIX}))
+        u = self.ru.roster_union([("local", lp), ("zpeer", pp)])
+        self.assertEqual(u["s"].get("discord_id"), "D2", sorted(u))
+        self.assertIsNone(u["s"].get("stand"), u["s"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/roster-union-blank-overlay.test.py
+++ b/tests/roster-union-blank-overlay.test.py
@@ -43,7 +43,9 @@ BLANKS = ("", "   ", "\t\n")
 # A text field states nothing when it holds one of these: `stated_reason` prints
 # no reason for any of them, so neither may overlay a peer's stated refusal.
 NON_STRINGS = (False, 0, ["x"], {"a": 1})
-TEXT_FIELDS = ("refusal_basis", "note")
+IDENTITY_FIELDS = ("gh", "github")
+TEXT_FIELDS = ("refusal_basis", "note", "authority_caveat",
+               "same_actor_as") + IDENTITY_FIELDS
 
 
 def _load(name, filename):
@@ -305,9 +307,14 @@ class SharedPresencePredicate(unittest.TestCase):
         self.assertEqual(self.ru.TEXT_FIELDS, TEXT_FIELDS)
         union_src = (SCRIPTS / "roster_union.py").read_text()
         notify_src = (SCRIPTS / "notify_reviewers.py").read_text()
-        literal = re.compile(r'\(\s*"refusal_basis"\s*,\s*"note"\s*,?\s*\)')
+        literal = re.compile(r'"refusal_basis"\s*,\s*"note"')
         self.assertEqual(len(literal.findall(union_src + notify_src)), 1,
                          "the text-field list is spelled more than once")
+        # Identity is text too, and derived from IDENTITY_FIELDS rather than
+        # re-spelled, so widening one cannot leave the other behind.
+        self.assertIn("IDENTITY_FIELDS", union_src.split("TEXT_FIELDS =")[1][:200])
+        for f in ("gh", "github", "same_actor_as", "authority_caveat"):
+            self.assertIn(f, self.ru.TEXT_FIELDS)
         self.assertRegex(notify_src,
                          r"from roster_union import [^\n]*\bTEXT_FIELDS\b")
 

--- a/tests/roster-union-blank-overlay.test.py
+++ b/tests/roster-union-blank-overlay.test.py
@@ -265,6 +265,92 @@ class BlankOverlay(unittest.TestCase):
 
 
 
+class CaveatFamily(unittest.TestCase):
+    """`resolve()` prints EVERY `*_caveat`; a named spelling in the text policy
+    leaves the rest value-typed, so a malformed local one overlays and the peer's
+    warning vanishes with no route refused and nothing printed."""
+
+    # jurisdiction_/future_ are NOT named anywhere in the source: the unit is the
+    # family, so a caveat nobody has written yet must already be covered.
+    CAVEATS = ("identity_caveat", "room_caveat", "jurisdiction_caveat", "future_caveat")
+    WARN = "SHARED LOGIN: two stands use one account"
+    MALFORMED = NON_STRINGS + ([], {})
+
+    def setUp(self):
+        sys.path.insert(0, str(SCRIPTS))
+        self.addCleanup(sys.path.remove, str(SCRIPTS))
+        self.ru = _load("roster_union", "roster_union.py")
+        self.nr = _load("notify_reviewers", "notify_reviewers.py")
+        self.dir = Path(tempfile.mkdtemp())
+
+    def resolve_pair(self, local_row, peer_row):
+        paths = []
+        for host, row in (("local", local_row), ("peer", peer_row)):
+            p = self.dir / (host + str(abs(hash((str(local_row), host)))) + ".json")
+            p.write_text(json.dumps({"reviewer": row}))
+            paths.append((host, p))
+        merged = self.ru.roster_union(paths)
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            targets, rc = self.nr.resolve(["reviewer"], merged)
+        return targets, rc, err.getvalue(), merged
+
+    def peer(self, field):
+        return {"stand": "@peer:x", "room": "!peer:x", field: self.WARN}
+
+    def test_a_malformed_local_caveat_does_not_erase_the_peer_warning(self):
+        for field in self.CAVEATS:
+            for value in self.MALFORMED:
+                with self.subTest(field=field, local=value):
+                    t, rc, err, _ = self.resolve_pair(
+                        {"stand": None, "room": None, field: value}, self.peer(field))
+                    self.assertEqual((len(t), rc), (1, 0),
+                                     f"a local {value!r} in {field} withheld the route")
+                    self.assertIn(self.WARN, err,
+                                  f"a local {value!r} in {field} erased the peer warning "
+                                  "— it routes and says nothing")
+
+    def test_an_absent_local_caveat_leaves_the_peer_warning(self):
+        for field in self.CAVEATS:
+            with self.subTest(field=field):
+                t, rc, err, _ = self.resolve_pair(
+                    {"stand": None, "room": None}, self.peer(field))
+                self.assertEqual((len(t), rc), (1, 0))
+                self.assertIn(self.WARN, err)
+
+    def test_CONTROL_a_VALID_local_caveat_still_overrides_the_peer_text(self):
+        """Deliberate: real local text wins. Without this the fix could pass by
+        never letting a local caveat overlay at all."""
+        for field in self.CAVEATS:
+            with self.subTest(field=field):
+                t, rc, err, _ = self.resolve_pair(
+                    {"stand": None, "room": None, field: "LOCAL SAYS SO"}, self.peer(field))
+                self.assertEqual((len(t), rc), (1, 0))
+                self.assertIn("LOCAL SAYS SO", err)
+                self.assertNotIn(self.WARN, err)
+
+    def test_CONTROL_allowlisted_false_still_refuses(self):
+        """The permissive default is what keeps a `False` meaningful; widening
+        the text policy must not reach a non-text field."""
+        t, rc, _, _ = self.resolve_pair(
+            {"stand": None, "room": None, "allowlisted": False},
+            {"stand": "@peer:x", "room": "!peer:x"})
+        self.assertEqual((len(t), rc), (0, 4))
+
+    def test_the_caveat_family_is_spelled_once_and_both_readers_use_it(self):
+        union_src = (SCRIPTS / "roster_union.py").read_text()
+        notify_src = (SCRIPTS / "notify_reviewers.py").read_text()
+        self.assertEqual(
+            len(re.findall(r'endswith\(\s*["\']_caveat["\']\s*\)', union_src + notify_src)), 0,
+            "a second literal `_caveat` suffix test is how the two readers drift")
+        self.assertEqual((union_src + notify_src).count('"_caveat"'), 1,
+                         "the caveat suffix is spelled more than once")
+        self.assertRegex(notify_src, r"from roster_union import [^)]*\bis_caveat\b")
+        for f in self.CAVEATS:
+            self.assertTrue(self.ru.is_text_field(f), f"{f} is not text-typed")
+        self.assertFalse(self.ru.is_text_field("allowlisted"))
+
+
 class SharedPresencePredicate(unittest.TestCase):
     """The one predicate the three sites now share, pinned directly.
 

--- a/tests/roster-union-blank-overlay.test.py
+++ b/tests/roster-union-blank-overlay.test.py
@@ -265,6 +265,72 @@ class BlankOverlay(unittest.TestCase):
 
 
 
+class GateLoginAfterPromotion(unittest.TestCase):
+    """Which login the CAPABILITY GATE ends up probing, end to end.
+
+    resolve() can hand back the right target while `_github_login()` probes the
+    wrong account: a malformed local `gh` that overlays the promoted row leaves
+    the roster KEY as the login, so the ask is gated against a colliding account
+    rather than the peer-declared one. Only asserting the gate login sees it.
+    """
+
+    IDENTITY = ("gh", "github", "same_actor_as")
+    MALFORMED = NON_STRINGS + ([], {})
+
+    def setUp(self):
+        sys.path.insert(0, str(SCRIPTS))
+        self.addCleanup(sys.path.remove, str(SCRIPTS))
+        self.ru = _load("roster_union", "roster_union.py")
+        self.nr = _load("notify_reviewers", "notify_reviewers.py")
+        self.dir = Path(tempfile.mkdtemp())
+
+    def gate_login(self, field, local, omit=False):
+        row = {"stand": None, "room": None}
+        if not omit:
+            row[field] = local
+        peer = {"stand": "@peer:x", "room": "!peer:x", field: "peer-owner"}
+        paths = []
+        for host, data in (("local", row), ("peer", peer)):
+            p = self.dir / f"{host}{abs(hash((field, str(local), omit)))}.json"
+            p.write_text(json.dumps({"reviewer": data}))
+            paths.append((host, p))
+        merged = self.ru.roster_union(paths)
+        # Controlled: the real probe is a network call, and collapsing
+        # "no such user" with "probe failed" is a separate documented hazard.
+        original = self.nr._is_github_user
+        self.nr._is_github_user = lambda login: True
+        try:
+            login, _ = self.nr._github_login("reviewer", merged)
+        finally:
+            self.nr._is_github_user = original
+        return login, merged
+
+    def test_a_MALFORMED_local_identity_does_not_redirect_the_gate(self):
+        for field in self.IDENTITY:
+            for value in self.MALFORMED:
+                with self.subTest(field=field, local=value):
+                    login, merged = self.gate_login(field, value)
+                    self.assertEqual(
+                        login, "peer-owner",
+                        f"a local {value!r} in {field} sent the capability gate to "
+                        f"{login!r} — the peer-declared account was erased")
+                    self.assertTrue(
+                        any(r.get(field) == "peer-owner"
+                            for r in merged.values() if isinstance(r, dict)),
+                        "the peer identity vanished from the union entirely")
+
+    def test_CONTROL_an_absent_local_identity_gates_on_the_peer(self):
+        for field in self.IDENTITY:
+            with self.subTest(field=field):
+                self.assertEqual(self.gate_login(field, None, omit=True)[0], "peer-owner")
+
+    def test_CONTROL_a_VALID_local_identity_still_wins(self):
+        """Without this the fix could pass by ignoring local identity entirely."""
+        for field in self.IDENTITY:
+            with self.subTest(field=field):
+                self.assertEqual(self.gate_login(field, "mine")[0], "mine")
+
+
 class CaveatFamily(unittest.TestCase):
     """`resolve()` prints EVERY `*_caveat`; a named spelling in the text policy
     leaves the rest value-typed, so a malformed local one overlays and the peer's

--- a/tests/roster-union-blank-overlay.test.py
+++ b/tests/roster-union-blank-overlay.test.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""A blank local field must not erase what a peer row STATED.
+
+`roster_union._usable` and `notify_reviewers.stated_reason` both read a blank or
+whitespace `refusal_basis`/`note` as ABSENT, and roster-union's identity reader
+reads a blank `gh`/`github` the same way. The promotion overlay disagreed: it
+copied every non-`None` local value onto the promoted peer row, so a local
+placeholder carrying `refusal_basis: ""` blanked a peer's `"DO NOT ROUTE"` and
+the reviewer was then routed.
+
+Measured at three points, because "fixed" and "not a regression" are different
+claims and only the first group is a regression:
+
+  REGRESSED    the two refusal arms FAIL at the promoting head and PASS at
+               origin/main, which withholds correctly. A blank erasing a stated
+               refusal is behaviour that got WORSE, not merely unfinished.
+  INCOMPLETE   the reason-reaches-the-operator and identity arms fail at BOTH,
+               each for its own reason: origin/main never promotes, so the peer
+               row it preserves is only reachable under a suffix.
+  MUST-WORK    a real local value MUST still overlay and `False` is a value, so
+               "never overlay" and "overlay only what is truthy" both fail here.
+               These exercise promotion itself and so do not apply to
+               origin/main, which has none.
+
+Run: python3 tests/roster-union-blank-overlay.test.py   (stdlib only)
+"""
+import contextlib
+import importlib.util
+import io
+import json
+import re
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS = (Path(__file__).resolve().parents[1] / "skills"
+           / "collaboration-intelligence" / "scripts")
+
+PEER_REFUSAL = "DO NOT ROUTE"
+PEER_ROUTE = {"stand": "@peer:x", "room": "!peer:x"}
+BLANKS = ("", "   ", "\t\n")
+
+
+def _load(name, filename):
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS / filename)
+    mod = importlib.util.module_from_spec(spec)
+    # Registered before exec: notify_reviewers imports roster_union by name, and
+    # an unregistered module would be re-executed as a second, unpatched object.
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class BlankOverlay(unittest.TestCase):
+    def setUp(self):
+        sys.path.insert(0, str(SCRIPTS))
+        self.addCleanup(sys.path.remove, str(SCRIPTS))
+        self.ru = _load("roster_union", "roster_union.py")
+        self.nr = _load("notify_reviewers", "notify_reviewers.py")
+        self.dir = Path(tempfile.mkdtemp())
+
+    def union(self, *rosters):
+        """(host, {key: row}) pairs, nearest first -> the merged roster."""
+        paths = []
+        for host, data in rosters:
+            p = self.dir / (host + ".json")
+            p.write_text(json.dumps(data))
+            paths.append((host, p))
+        return self.ru.roster_union(paths)
+
+    def resolve(self, merged, name="reviewer"):
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            targets, rc = self.nr.resolve([name], merged)
+        return targets, rc, err.getvalue()
+
+    def three_rosters(self, local_basis):
+        """The reviewer's measured case: blank local, peer refusal, routable legacy."""
+        return self.union(
+            ("local", {"reviewer": {"stand": "", "room": "",
+                                    "refusal_basis": local_basis}}),
+            ("PEER_REFUSAL", {"reviewer": {"stand": "", "room": "",
+                                           "refusal_basis": PEER_REFUSAL}}),
+            ("LEGACY", {"reviewer": dict(PEER_ROUTE)}),
+        )
+
+    # --- arms 1-3: the refusal must survive a blank local field ----------
+    def test_a_blank_local_basis_does_not_route_a_refused_reviewer(self):
+        for blank in BLANKS:
+            with self.subTest(local_basis=blank):
+                targets, rc, _ = self.resolve(self.three_rosters(blank))
+                self.assertEqual(
+                    (len(targets), rc), (0, 3),
+                    "a peer stated DO NOT ROUTE and a blank local "
+                    f"{blank!r} erased it — the reviewer gets routed")
+
+    def test_the_stated_refusal_is_still_readable_in_the_union(self):
+        for blank in BLANKS:
+            with self.subTest(local_basis=blank):
+                merged = self.three_rosters(blank)
+                self.assertIn(PEER_REFUSAL, json.dumps(merged),
+                              f"refusal lost entirely; keys: {sorted(merged)}")
+
+    def test_the_refusal_reason_reaches_the_operator(self):
+        """Withholding silently reads as a data gap, and the obvious repair is to
+        fill the fields in — which converts the refusal into a route (#3468)."""
+        _, _, err = self.resolve(self.three_rosters(""))
+        self.assertIn(PEER_REFUSAL, err)
+
+    # --- arms 4-6: a real value MUST still overlay -----------------------
+    def test_a_real_local_value_still_overlays_onto_the_promoted_row(self):
+        """Blanket "never overlay" would pass arms 1-3 and fail here.
+
+        A caveat, not a note: `note` is itself a refusal, so a row carrying one
+        is never promoted over and would measure the wrong thing.
+        """
+        merged = self.union(
+            ("local", {"reviewer": {"stand": "", "room": "",
+                                    "room_caveat": "local knows this"}}),
+            ("peer", {"reviewer": dict(PEER_ROUTE)}),
+        )
+        row = merged["reviewer"]
+        self.assertEqual(row.get("room_caveat"), "local knows this")
+        self.assertEqual(row.get("stand"), PEER_ROUTE["stand"],
+                         "peer routing must still win the promotion")
+        _, _, err = self.resolve(merged)
+        self.assertIn("local knows this", err, "the overlaid caveat is not printed")
+
+    def test_allowlisted_false_still_overlays(self):
+        """`False` is a stated refusal, not an absence: a truthiness test loses it."""
+        merged = self.union(
+            ("local", {"reviewer": {"stand": "", "room": "", "allowlisted": False}}),
+            ("peer", {"reviewer": dict(PEER_ROUTE)}),
+        )
+        self.assertIs(merged["reviewer"].get("allowlisted"), False)
+        _, rc, _ = self.resolve(merged)
+        self.assertEqual(rc, 4, "off-allowlist must still be refused")
+
+    # --- arms 7-9: the same overlay, on identity -------------------------
+    def _resolved_login(self, merged, name="reviewer"):
+        self.nr._is_github_user = lambda login: True
+        return self.nr._github_login(name, merged)[0]
+
+    def test_a_blank_local_alias_does_not_erase_a_peer_identity(self):
+        for field in ("gh", "github"):
+            for blank in BLANKS:
+                with self.subTest(field=field, local=blank):
+                    merged = self.union(
+                        ("local", {"reviewer": {"stand": "", "room": "",
+                                                field: blank}}),
+                        ("peer", dict(reviewer=dict(PEER_ROUTE,
+                                                    **{field: "peer-owner"}))),
+                    )
+                    self.assertEqual(self._resolved_login(merged), "peer-owner",
+                                     "a blank alias resolved to the roster KEY; "
+                                     "capability checks then run on a collision")
+
+    def test_a_blank_local_same_actor_as_does_not_erase_the_peer_one(self):
+        for blank in BLANKS:
+            with self.subTest(local=blank):
+                merged = self.union(
+                    ("local", {"reviewer": {"stand": "", "room": "",
+                                            "same_actor_as": blank}}),
+                    ("peer", {"reviewer": dict(PEER_ROUTE,
+                                               same_actor_as="peer-owner")}),
+                )
+                self.assertEqual(self._resolved_login(merged), "peer-owner")
+
+    def test_CONTROL_a_real_local_alias_still_wins(self):
+        """The local roster is still nearest: a stated local alias must overlay."""
+        merged = self.union(
+            ("local", {"reviewer": {"stand": "", "room": "", "gh": "local-owner"}}),
+            ("peer", {"reviewer": dict(PEER_ROUTE, gh="peer-owner")}),
+        )
+        self.assertEqual(self._resolved_login(merged), "local-owner")
+
+
+class SharedPresencePredicate(unittest.TestCase):
+    """The one predicate the three sites now share, pinned directly.
+
+    Unit-level and therefore new-API-only: origin/main has no such helper, so
+    only the behavioural class above is measurable against it.
+    """
+
+    def setUp(self):
+        sys.path.insert(0, str(SCRIPTS))
+        self.addCleanup(sys.path.remove, str(SCRIPTS))
+        self.ru = _load("roster_union", "roster_union.py")
+
+    def test_declared_reads_blank_whitespace_and_non_string_as_nothing(self):
+        for value in ("", "   ", "\t\n", None, False, 0, ["x"], {"a": 1}):
+            with self.subTest(value=value):
+                self.assertEqual(self.ru.declared(value), "")
+
+    def test_declared_strips_the_text_it_returns(self):
+        self.assertEqual(self.ru.declared("  DO NOT ROUTE  "), "DO NOT ROUTE")
+
+    def test_is_declared_keeps_non_strings_that_state_something(self):
+        for value in (False, 0, ["x"], {"a": 1}, "x"):
+            with self.subTest(value=value):
+                self.assertTrue(self.ru.is_declared(value))
+
+    def test_is_declared_rejects_none_and_blank_strings(self):
+        for value in (None, "", "   ", "\t\n"):
+            with self.subTest(value=value):
+                self.assertFalse(self.ru.is_declared(value))
+
+    def test_the_readers_answer_through_the_same_predicate(self):
+        """Divergence here is the defect: one site's absence is another's data."""
+        nr = _load("notify_reviewers", "notify_reviewers.py")
+        # Non-strings included: a list-valued basis made the union call a row a
+        # refusal while the notifier printed no reason for it.
+        for value in BLANKS + (None, False, 0, ["x"], {"a": 1}):
+            with self.subTest(value=value):
+                row = {"stand": "", "room": "", "refusal_basis": value}
+                self.assertEqual(nr.stated_reason(row), "")
+                self.assertFalse(self.ru._usable(row),
+                                 "the union calls this a refusal that never prints")
+                self.assertEqual(self.ru.roster_login({"gh": value}), ("", ""))
+
+    def test_the_rule_is_spelled_exactly_once(self):
+        """`stated_reason` folds whitespace away, so a re-spelling there cannot
+        change an observable — only a source guard keeps the fourth copy out."""
+        source = (SCRIPTS / "roster_union.py").read_text()
+        spellings = re.findall(r'or ""\)\.strip\(\)|isinstance\([^)]*, str\)'
+                               r'\s+and\s+\w+\.strip\(\)|\.strip\(\) if isinstance',
+                               source)
+        self.assertEqual(len(spellings), 1,
+                         f"blank-is-absent is spelled {len(spellings)}x, not once "
+                         f"(only `declared` may spell it): {spellings}")
+
+    def test_notify_reviewers_imports_the_predicate_rather_than_restating_it(self):
+        source = (SCRIPTS / "notify_reviewers.py").read_text()
+        self.assertRegex(source, r"from roster_union import [^\n]*\bdeclared\b")
+        self.assertIn("declared(entry.get(key))", source)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/roster-union-blank-overlay.test.py
+++ b/tests/roster-union-blank-overlay.test.py
@@ -40,6 +40,10 @@ SCRIPTS = (Path(__file__).resolve().parents[1] / "skills"
 PEER_REFUSAL = "DO NOT ROUTE"
 PEER_ROUTE = {"stand": "@peer:x", "room": "!peer:x"}
 BLANKS = ("", "   ", "\t\n")
+# A text field states nothing when it holds one of these: `stated_reason` prints
+# no reason for any of them, so neither may overlay a peer's stated refusal.
+NON_STRINGS = (False, 0, ["x"], {"a": 1})
+TEXT_FIELDS = ("refusal_basis", "note")
 
 
 def _load(name, filename):
@@ -75,13 +79,13 @@ class BlankOverlay(unittest.TestCase):
             targets, rc = self.nr.resolve([name], merged)
         return targets, rc, err.getvalue()
 
-    def three_rosters(self, local_basis):
+    def three_rosters(self, local_basis, field="refusal_basis"):
         """The reviewer's measured case: blank local, peer refusal, routable legacy."""
         return self.union(
             ("local", {"reviewer": {"stand": "", "room": "",
-                                    "refusal_basis": local_basis}}),
+                                    field: local_basis}}),
             ("PEER_REFUSAL", {"reviewer": {"stand": "", "room": "",
-                                           "refusal_basis": PEER_REFUSAL}}),
+                                           field: PEER_REFUSAL}}),
             ("LEGACY", {"reviewer": dict(PEER_ROUTE)}),
         )
 
@@ -107,6 +111,43 @@ class BlankOverlay(unittest.TestCase):
         fill the fields in — which converts the refusal into a route (#3468)."""
         _, _, err = self.resolve(self.three_rosters(""))
         self.assertIn(PEER_REFUSAL, err)
+
+    # --- the same three rosters, non-string local text fields ------------
+    def test_a_NON_STRING_local_text_field_does_not_route_a_refused_reviewer(self):
+        """`is_declared` calls every non-`None` present, which is right for
+        `allowlisted` and wrong here: a list states no reason a reader can read,
+        so overlaying it leaves a refusal that prints nothing and then routes."""
+        for field in TEXT_FIELDS:
+            for value in NON_STRINGS:
+                with self.subTest(field=field, local=value):
+                    merged = self.three_rosters(value, field)
+                    targets, rc, _ = self.resolve(merged)
+                    self.assertEqual(
+                        (len(targets), rc), (0, 3),
+                        f"a peer stated {PEER_REFUSAL} and a local {value!r} "
+                        f"in {field} erased it — {targets} got routed")
+
+    def test_a_non_string_local_text_field_leaves_the_reason_readable(self):
+        for field in TEXT_FIELDS:
+            for value in NON_STRINGS:
+                with self.subTest(field=field, local=value):
+                    merged = self.three_rosters(value, field)
+                    self.assertEqual(self.nr.stated_reason(merged["reviewer"]),
+                                     PEER_REFUSAL)
+                    _, _, err = self.resolve(merged)
+                    self.assertIn(PEER_REFUSAL, err,
+                                  "the refusal withholds but states no reason, "
+                                  "so filling the fields in overrides it")
+
+    def test_the_routable_row_loses_to_the_refusal_but_is_still_kept(self):
+        """The erased refusal let a THIRD roster promote over the same key, so
+        the routable row took the bare key instead of a suffix — and the second
+        promotion overwrote the only `@local` copy of the row this host wrote."""
+        merged = self.three_rosters(False)
+        self.assertIn("reviewer@LEGACY", merged,
+                      f"the routable row won the bare key: {sorted(merged)}")
+        self.assertIs(merged["reviewer@local"].get("refusal_basis"), False,
+                      "the local row was replaced by a promoted copy")
 
     # --- arms 4-6: a real value MUST still overlay -----------------------
     def test_a_real_local_value_still_overlays_onto_the_promoted_row(self):
@@ -136,6 +177,18 @@ class BlankOverlay(unittest.TestCase):
         self.assertIs(merged["reviewer"].get("allowlisted"), False)
         _, rc, _ = self.resolve(merged)
         self.assertEqual(rc, 4, "off-allowlist must still be refused")
+
+    def test_CONTROL_a_non_string_still_overlays_a_field_that_is_not_text(self):
+        """Making the predicate strict everywhere would pass every arm above and
+        fail here — only a TEXT field asks for text."""
+        for value in NON_STRINGS:
+            with self.subTest(local=value):
+                merged = self.union(
+                    ("local", {"reviewer": {"stand": "", "room": "",
+                                            "allowlisted": value}}),
+                    ("peer", {"reviewer": dict(PEER_ROUTE, allowlisted=True)}),
+                )
+                self.assertEqual(merged["reviewer"].get("allowlisted"), value)
 
     # --- arms 7-9: the same overlay, on identity -------------------------
     def _resolved_login(self, merged, name="reviewer"):
@@ -234,6 +287,29 @@ class SharedPresencePredicate(unittest.TestCase):
         source = (SCRIPTS / "notify_reviewers.py").read_text()
         self.assertRegex(source, r"from roster_union import [^\n]*\bdeclared\b")
         self.assertIn("declared(entry.get(key))", source)
+
+    def test_states_field_asks_text_fields_for_text_and_others_for_a_value(self):
+        for field in TEXT_FIELDS:
+            for value in NON_STRINGS + BLANKS + (None,):
+                with self.subTest(field=field, value=value):
+                    self.assertFalse(self.ru.states_field(field, value))
+            self.assertTrue(self.ru.states_field(field, " x "))
+        for value in NON_STRINGS:
+            with self.subTest(field="allowlisted", value=value):
+                self.assertTrue(self.ru.states_field("allowlisted", value))
+        self.assertFalse(self.ru.states_field("allowlisted", None))
+
+    def test_the_text_fields_are_named_once_and_both_readers_use_that_name(self):
+        """A second literal list is how the union and the notifier come to
+        disagree about which fields carry a reason at all."""
+        self.assertEqual(self.ru.TEXT_FIELDS, TEXT_FIELDS)
+        union_src = (SCRIPTS / "roster_union.py").read_text()
+        notify_src = (SCRIPTS / "notify_reviewers.py").read_text()
+        literal = re.compile(r'\(\s*"refusal_basis"\s*,\s*"note"\s*,?\s*\)')
+        self.assertEqual(len(literal.findall(union_src + notify_src)), 1,
+                         "the text-field list is spelled more than once")
+        self.assertRegex(notify_src,
+                         r"from roster_union import [^\n]*\bTEXT_FIELDS\b")
 
 
 if __name__ == "__main__":

--- a/tests/roster-union-blank-overlay.test.py
+++ b/tests/roster-union-blank-overlay.test.py
@@ -44,8 +44,11 @@ BLANKS = ("", "   ", "\t\n")
 # no reason for any of them, so neither may overlay a peer's stated refusal.
 NON_STRINGS = (False, 0, ["x"], {"a": 1})
 IDENTITY_FIELDS = ("gh", "github")
-TEXT_FIELDS = ("refusal_basis", "note", "authority_caveat",
-               "same_actor_as") + IDENTITY_FIELDS
+# Spelled independently of the source so the equality arms below can disagree.
+REFUSAL_FIELDS = ("refusal_basis", "note")
+# Text-typed, but metadata: a caveat prints, a login identifies. Neither refuses.
+NON_REFUSAL_TEXT = ("authority_caveat", "same_actor_as") + IDENTITY_FIELDS
+TEXT_FIELDS = REFUSAL_FIELDS + NON_REFUSAL_TEXT
 
 
 def _load(name, filename):
@@ -119,7 +122,7 @@ class BlankOverlay(unittest.TestCase):
         """`is_declared` calls every non-`None` present, which is right for
         `allowlisted` and wrong here: a list states no reason a reader can read,
         so overlaying it leaves a refusal that prints nothing and then routes."""
-        for field in TEXT_FIELDS:
+        for field in REFUSAL_FIELDS:
             for value in NON_STRINGS:
                 with self.subTest(field=field, local=value):
                     merged = self.three_rosters(value, field)
@@ -130,7 +133,7 @@ class BlankOverlay(unittest.TestCase):
                         f"in {field} erased it — {targets} got routed")
 
     def test_a_non_string_local_text_field_leaves_the_reason_readable(self):
-        for field in TEXT_FIELDS:
+        for field in REFUSAL_FIELDS:
             for value in NON_STRINGS:
                 with self.subTest(field=field, local=value):
                     merged = self.three_rosters(value, field)
@@ -229,6 +232,37 @@ class BlankOverlay(unittest.TestCase):
             ("peer", {"reviewer": dict(PEER_ROUTE, gh="peer-owner")}),
         )
         self.assertEqual(self._resolved_login(merged), "local-owner")
+    def test_a_local_metadata_row_still_ROUTES_and_keeps_its_own_field(self):
+        """The measured regression: a local row holding only metadata must not
+        withhold the peer route. Asserts DELIVERY as well as the kept value —
+        refusing the whole row preserves the value too, so the login alone
+        cannot tell the two apart."""
+        for field in NON_REFUSAL_TEXT:
+            with self.subTest(field=field):
+                merged = self.union(
+                    ("local", {"reviewer": {"stand": None, "room": None,
+                                            field: "local-owner"}}),
+                    ("PEER", {"reviewer": dict(PEER_ROUTE)}),
+                )
+                targets, rc, _ = self.resolve(merged)
+                self.assertEqual(
+                    (len(targets), rc), (1, 0),
+                    f"a local {field!r} withheld the peer route entirely")
+                self.assertEqual(targets[0]["stand"], PEER_ROUTE["stand"])
+                kept = [r for k, r in merged.items()
+                        if k == "reviewer" or k.startswith("reviewer@")]
+                self.assertTrue(
+                    any(r.get(field) == "local-owner" for r in kept),
+                    f"the local {field!r} was dropped: {kept}")
+
+    def test_only_the_refusal_fields_can_withhold_a_route(self):
+        """Type is not intent: widening the text list must not widen refusal."""
+        self.assertEqual(self.ru.REFUSAL_FIELDS, REFUSAL_FIELDS)
+        for f in NON_REFUSAL_TEXT:
+            self.assertIn(f, self.ru.TEXT_FIELDS)
+            self.assertNotIn(f, self.ru.REFUSAL_FIELDS)
+
+
 
 
 class SharedPresencePredicate(unittest.TestCase):

--- a/tests/roster-union-empty-row-shadow.test.py
+++ b/tests/roster-union-empty-row-shadow.test.py
@@ -163,5 +163,42 @@ class UnionToResolveRegression(unittest.TestCase):
         self.assertEqual(len(targets), 1)
 
 
+class PromotionPreservesLocalAuthority(unittest.TestCase):
+    """qingyun-wu @b974e7b5: promoting a peer row wholly REPLACED the local one,
+    so `allowlisted: false` was lost. notify_reviewers checks the refusal after
+    the bare-key lookup, so the @local copy does not protect delivery."""
+
+    def _union(self, local, peer):
+        d = tempfile.mkdtemp()
+        lp, pp = pathlib.Path(d, "l.json"), pathlib.Path(d, "p.json")
+        lp.write_text(json.dumps({"r": local}))
+        pp.write_text(json.dumps({"r": peer}))
+        return _load(SRC).roster_union([("local", lp), ("peer", pp)])
+
+    FULL = {"stand": "@peer:x", "room": "!peer:x"}
+
+    def test_local_refusal_survives_promotion(self):
+        u = self._union({"stand": None, "room": None, "allowlisted": False}, self.FULL)
+        self.assertEqual(u["r"]["stand"], "@peer:x", "routing should still be promoted")
+        self.assertIs(u["r"]["allowlisted"], False,
+                      "a local allowlisted:false is a refusal and must survive promotion")
+
+    def test_local_declared_identity_survives(self):
+        u = self._union({"stand": None, "room": None, "gh": "local-login"}, self.FULL)
+        self.assertEqual(u["r"]["gh"], "local-login",
+                         "promotion must not swap the declared identity")
+
+    def test_a_partial_local_row_is_NOT_overwritten(self):
+        """A row naming a stand but no room states an identity. Promoting over it
+        would route under the peer's stand instead."""
+        u = self._union({"stand": "@local:x", "room": None}, self.FULL)
+        self.assertEqual(u["r"]["stand"], "@local:x", "partial local row must win")
+        self.assertEqual(u["r@peer"]["stand"], "@peer:x", "peer kept under its suffix")
+
+    def test_the_placeholder_case_still_gets_fixed(self):
+        u = self._union({"stand": None, "room": None}, self.FULL)
+        self.assertEqual(u["r"]["room"], "!peer:x", "the original defect must stay fixed")
+
+
 if __name__ == "__main__":
-    unittest.main(verbosity=2)
+    unittest.main()

--- a/tests/roster-union-empty-row-shadow.test.py
+++ b/tests/roster-union-empty-row-shadow.test.py
@@ -200,5 +200,43 @@ class PromotionPreservesLocalAuthority(unittest.TestCase):
         self.assertEqual(u["r"]["room"], "!peer:x", "the original defect must stay fixed")
 
 
+class IdentityIsPreservedAcrossAliases(unittest.TestCase):
+    """qingyun-wu @54b392ef: preservation was by FIELD NAME, so a local `github`
+    survived while the peer's higher-precedence `gh` outranked it and the login
+    resolved to the PEER's account. IDENTITY_FIELDS = ("gh", "github")."""
+
+    ROUTE = {"stand": "@x:y", "room": "!r:y"}
+
+    def _u(self, local, peer):
+        d = tempfile.mkdtemp()
+        lp, pp = pathlib.Path(d, "l.json"), pathlib.Path(d, "p.json")
+        lp.write_text(json.dumps({"r": local}))
+        pp.write_text(json.dumps({"r": peer}))
+        return _load(SRC), _load(SRC).roster_union([("local", lp), ("peer", pp)])["r"]
+
+    def test_local_github_beats_promoted_peer_gh(self):
+        m, row = self._u({"stand": None, "room": None, "github": "local-owner"},
+                         dict(self.ROUTE, gh="peer-owner"))
+        self.assertEqual(m.roster_login(row)[0], "local-owner",
+            "the peer's higher-precedence `gh` alias must not outrank a local `github`")
+
+    def test_local_same_actor_as_clears_the_peer_identity(self):
+        m, row = self._u({"stand": None, "room": None, "same_actor_as": "local-owner"},
+                         dict(self.ROUTE, gh="peer-owner"))
+        self.assertIsNone(row.get("gh"), "peer identity must not survive a local same_actor_as")
+        self.assertEqual(row.get("same_actor_as"), "local-owner")
+
+    def test_the_opposite_alias_pairing_also_holds(self):
+        m, row = self._u({"stand": None, "room": None, "gh": "local-owner"},
+                         dict(self.ROUTE, github="peer-owner"))
+        self.assertEqual(m.roster_login(row)[0], "local-owner")
+
+    def test_a_local_row_declaring_NO_identity_keeps_the_peers(self):
+        """The clearing is conditional: with nothing local to protect, the peer's
+        identity is the only one there and must survive."""
+        m, row = self._u({"stand": None, "room": None}, dict(self.ROUTE, gh="peer-owner"))
+        self.assertEqual(m.roster_login(row)[0], "peer-owner")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/roster-union-empty-row-shadow.test.py
+++ b/tests/roster-union-empty-row-shadow.test.py
@@ -59,6 +59,24 @@ class ShadowedByAnEmptyLocalRow(unittest.TestCase):
         u = self.m.roster_union([("local", self.local), ("peer", self.peer)])
         self.assertEqual(u["k"]["note"], "local")
 
+    def test_a_deliberate_local_REFUSAL_is_not_treated_as_a_placeholder(self):
+        """Blank stand/room PLUS refusal_basis is DO-NOT-ROUTE per schema.md, not
+        missing data. keweichen, reviewing this PR: the tie-break must not route
+        around it, or a synced peer row silently overrides an explicit refusal."""
+        self.local.write_text(json.dumps({"qingyun-wu": {
+            "stand": "", "room": "", "refusal_basis": "DO NOT ROUTE — asked off-channel"}}))
+        self.peer.write_text(json.dumps({"qingyun-wu": PEER_COMPLETE}))
+        u = self.m.roster_union([("local", self.local), ("peer", self.peer)])
+        self.assertEqual(u["qingyun-wu"].get("refusal_basis"),
+                         "DO NOT ROUTE — asked off-channel",
+                         f"the refusal lost the collision; union: {sorted(u)}")
+
+    def test_a_note_alone_also_protects_the_row(self):
+        self.local.write_text(json.dumps({"k": {"stand": None, "note": "human-only by request"}}))
+        self.peer.write_text(json.dumps({"k": {"stand": "@b:x", "room": "!b:x"}}))
+        u = self.m.roster_union([("local", self.local), ("peer", self.peer)])
+        self.assertEqual(u["k"].get("note"), "human-only by request")
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/roster-union-empty-row-shadow.test.py
+++ b/tests/roster-union-empty-row-shadow.test.py
@@ -124,7 +124,7 @@ class DiscordOnlyRowIsNotARoute(unittest.TestCase):
 
 
 class UnionToResolveRegression(unittest.TestCase):
-    """qingyun-wu's named unblock condition on #4047: drive the PRODUCTION
+    """keweichen's named unblock condition on #4047: drive the PRODUCTION
     roster_union() -> notify_reviewers.resolve() path, not just the union."""
 
     def setUp(self):

--- a/tests/roster-union-empty-row-shadow.test.py
+++ b/tests/roster-union-empty-row-shadow.test.py
@@ -87,5 +87,41 @@ class ShadowedByAnEmptyLocalRow(unittest.TestCase):
                          f"a non-dict local row shadowed a usable peer row; union: {sorted(u)}")
 
 
+class DiscordOnlyRowIsNotARoute(unittest.TestCase):
+    """keweichen on #4047: _usable counted discord_id, but resolve() builds
+    Matrix targets from stand+room alone — so a discord-only local row was
+    RETAINED as usable and then could not be addressed."""
+
+    def setUp(self):
+        self.d = tempfile.mkdtemp()
+        self.m = _load(SRC)
+
+    def _roster(self, name, data):
+        p = pathlib.Path(self.d, name)
+        p.write_text(json.dumps(data))
+        return p
+
+    def test_a_discord_only_row_is_not_usable(self):
+        self.assertFalse(self.m._usable({"discord_id": "123456789"}))
+        self.assertFalse(self.m._usable({"discord": "someone#1"}))
+
+    def test_a_discord_only_local_row_loses_to_a_routable_peer_row(self):
+        u = self.m.roster_union([
+            ("local", self._roster("l.json", {"r": {"discord_id": "123"}})),
+            ("peer",  self._roster("p.json", {"r": PEER_COMPLETE})),
+        ])
+        self.assertEqual(u["r"].get("room"), PEER_COMPLETE["room"],
+            "a discord id is not a delivery route for either consumer")
+
+    def test_a_refusal_row_still_wins_over_a_routable_peer_row(self):
+        u = self.m.roster_union([
+            ("local", self._roster("l2.json", {"r": {"stand": "", "room": "",
+                                    "refusal_basis": "owner disabled"}})),
+            ("peer",  self._roster("p2.json", {"r": PEER_COMPLETE})),
+        ])
+        self.assertEqual(u["r"].get("stand"), "")
+        self.assertEqual(u["r"].get("refusal_basis"), "owner disabled")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/roster-union-empty-row-shadow.test.py
+++ b/tests/roster-union-empty-row-shadow.test.py
@@ -77,6 +77,15 @@ class ShadowedByAnEmptyLocalRow(unittest.TestCase):
         u = self.m.roster_union([("local", self.local), ("peer", self.peer)])
         self.assertEqual(u["k"].get("note"), "human-only by request")
 
+    def test_a_NON_DICT_row_is_never_usable(self):
+        """A roster value that is not an object (a bare string, a null) must not
+        win a collision as if it were addressable — and must not crash the merge."""
+        self.local.write_text(json.dumps({"k": "just-a-string"}))
+        self.peer.write_text(json.dumps({"k": PEER_COMPLETE}))
+        u = self.m.roster_union([("local", self.local), ("peer", self.peer)])
+        self.assertEqual(u["k"], PEER_COMPLETE,
+                         f"a non-dict local row shadowed a usable peer row; union: {sorted(u)}")
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/roster-union-empty-row-shadow.test.py
+++ b/tests/roster-union-empty-row-shadow.test.py
@@ -1,0 +1,64 @@
+"""An all-null local row must not shadow a usable peer row in roster_union.
+
+Built on the host where this reproduces. Arm 1 FAILS at the parent commit; arms 2-4 pass there and must keep passing,
+because the fix is a CONDITIONAL tie-break, not a reordering.
+
+The fixture is measured, not invented: the two rows below are the shapes actually
+on disk here for `qingyun-wu` (local placeholder, peer complete).
+"""
+import importlib.util
+import json
+import pathlib
+import tempfile
+import unittest
+
+SRC = (pathlib.Path(__file__).resolve().parents[1] /
+       "skills" / "collaboration-intelligence" / "scripts" / "roster_union.py")
+
+def _load(p):
+    s = importlib.util.spec_from_file_location("ru", p)
+    m = importlib.util.module_from_spec(s)
+    s.loader.exec_module(m)
+    return m
+
+LOCAL_PLACEHOLDER = {"stand": None, "room": None, "discord": None}
+PEER_COMPLETE     = {"stand": "@sutando-qingyun-001:ag2.space", "room": "!r:ag2.space"}
+
+
+class ShadowedByAnEmptyLocalRow(unittest.TestCase):
+    def setUp(self):
+        self.d = tempfile.mkdtemp()
+        self.local = pathlib.Path(self.d, "local.json")
+        self.peer  = pathlib.Path(self.d, "peer.json")
+        self.local.write_text(json.dumps({"qingyun-wu": LOCAL_PLACEHOLDER}))
+        self.peer.write_text(json.dumps({"qingyun-wu": PEER_COMPLETE}))
+        self.m = _load(SRC)
+
+    def test_a_usable_peer_row_is_not_shadowed_by_an_empty_local_one(self):
+        u = self.m.roster_union([("local", self.local), ("peer", self.peer)])
+        row = u["qingyun-wu"]
+        self.assertTrue(row.get("stand") and row.get("room"),
+            "the bare key resolves to the placeholder; the usable row is only "
+            f"reachable as 'qingyun-wu@peer'. union keys: {sorted(u)}")
+
+    def test_the_peer_row_is_still_retained_under_its_suffix(self):
+        """The fix must not drop the losing row — that property is deliberate."""
+        u = self.m.roster_union([("local", self.local), ("peer", self.peer)])
+        self.assertTrue(any(k.startswith("qingyun-wu@") for k in u), sorted(u))
+
+    def test_origin_order_still_decides_when_BOTH_rows_are_usable(self):
+        """Completeness breaks the tie; it does not replace local-wins."""
+        self.local.write_text(json.dumps({"k": {"stand": "@a:x", "room": "!a:x"}}))
+        self.peer.write_text(json.dumps({"k": {"stand": "@b:x", "room": "!b:x"}}))
+        u = self.m.roster_union([("local", self.local), ("peer", self.peer)])
+        self.assertEqual(u["k"]["stand"], "@a:x")
+
+    def test_origin_order_still_decides_when_BOTH_rows_are_empty(self):
+        self.local.write_text(json.dumps({"k": {"stand": None, "note": "local"}}))
+        self.peer.write_text(json.dumps({"k": {"stand": None, "note": "peer"}}))
+        u = self.m.roster_union([("local", self.local), ("peer", self.peer)])
+        self.assertEqual(u["k"]["note"], "local")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/roster-union-empty-row-shadow.test.py
+++ b/tests/roster-union-empty-row-shadow.test.py
@@ -123,5 +123,45 @@ class DiscordOnlyRowIsNotARoute(unittest.TestCase):
         self.assertEqual(u["r"].get("refusal_basis"), "owner disabled")
 
 
+class UnionToResolveRegression(unittest.TestCase):
+    """qingyun-wu's named unblock condition on #4047: drive the PRODUCTION
+    roster_union() -> notify_reviewers.resolve() path, not just the union."""
+
+    def setUp(self):
+        self.d = tempfile.mkdtemp()
+        self.m = _load(SRC)
+        nr = (pathlib.Path(__file__).resolve().parents[1] / "skills" /
+              "collaboration-intelligence" / "scripts" / "notify_reviewers.py")
+        s = importlib.util.spec_from_file_location("nr", nr)
+        self.nr = importlib.util.module_from_spec(s)
+        s.loader.exec_module(self.nr)
+
+    def _roster(self, name, data):
+        p = pathlib.Path(self.d, name)
+        p.write_text(json.dumps(data))
+        return p
+
+    def test_a_local_refusal_survives_the_union_and_resolve_returns_3_no_target(self):
+        # The harm measured on origin/main was at resolve(), not at the union:
+        # a synced peer row re-enabled a reviewer the local owner had disabled.
+        merged = self.m.roster_union([
+            ("local", self._roster("l.json", {"reviewer": {
+                "stand": "", "room": "", "refusal_basis": "owner disabled routing"}})),
+            ("peer", self._roster("p.json", {"reviewer": PEER_COMPLETE})),
+        ])
+        targets, rc = self.nr.resolve(["reviewer"], merged)
+        self.assertEqual(targets, [], "a disabled reviewer must get no target")
+        self.assertEqual(rc, 3, "refusal must surface as rc 3, not a silent send")
+
+    def test_the_control_a_routable_reviewer_still_resolves(self):
+        """Without this, rc 3 could come from the path being broken for everyone."""
+        merged = self.m.roster_union([
+            ("local", self._roster("l2.json", {"reviewer": PEER_COMPLETE})),
+        ])
+        targets, rc = self.nr.resolve(["reviewer"], merged)
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(targets), 1)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/roster-union-route-owner.test.py
+++ b/tests/roster-union-route-owner.test.py
@@ -1,0 +1,162 @@
+"""Route classification has ONE owner; the union must not decide alone.
+
+The union and notify_reviewers both read a roster row and answer "what route is
+this?". While the union recognised only Matrix, a local row naming a complete
+Discord route read as a PLACEHOLDER to it and as a USABLE ROUTE to the notifier,
+so a synced peer's Matrix row promoted over it and changed the destination.
+
+Three arms FAIL at the parent commit; the rest pass there and must keep passing.
+The fix widens what counts as a route, it does not reorder precedence, and it
+leaves a lone Discord id promotable — that asymmetry is pinned here, not assumed.
+
+The composed case is the one a single-side unit test cannot show. It is asserted
+on the union's own output first, then on `declared_routes` — what the notifier
+selects its transport from once it delegates here.
+"""
+import importlib.util
+import json
+import pathlib
+import tempfile
+import unittest
+
+SRC = (pathlib.Path(__file__).resolve().parents[1] /
+       "skills" / "collaboration-intelligence" / "scripts" / "roster_union.py")
+
+
+def _load(p):
+    s = importlib.util.spec_from_file_location("ru", p)
+    m = importlib.util.module_from_spec(s)
+    s.loader.exec_module(m)
+    return m
+
+
+# Measured, not invented: the shapes the composed notifier routed on. `donly` is
+# the control row — same local fields, no peer — and must resolve identically.
+LOCAL_DISCORD = {"discord_id": "D2", "home_channel": "C2", "human": "@shadow"}
+PEER_MATRIX = {"stand": "@peer:ag2.space", "room": "!peer:ag2.space"}
+LOCAL_NULL = {"stand": None, "room": None, "discord": None}
+
+
+class RouteClassificationHasOneOwner(unittest.TestCase):
+    def setUp(self):
+        self.d = tempfile.mkdtemp()
+        self.m = _load(SRC)
+
+    def _union(self, local, peer):
+        lp = pathlib.Path(self.d, "local.json")
+        pp = pathlib.Path(self.d, "peer.json")
+        lp.write_text(json.dumps(local))
+        pp.write_text(json.dumps(peer))
+        return self.m.roster_union([("local", lp), ("zpeer", pp)])
+
+    def test_a_local_discord_route_is_not_outranked_by_a_synced_matrix_peer(self):
+        u = self._union({"shadow": LOCAL_DISCORD}, {"shadow": PEER_MATRIX})
+        row = u["shadow"]
+        self.assertEqual(
+            row.get("discord_id"), "D2",
+            "the local Discord route lost the bare key to a synced peer; it is "
+            f"only reachable as 'shadow@local'. union keys: {sorted(u)}")
+        self.assertIsNone(
+            row.get("stand"),
+            "the peer's Stand was promoted over a local row that already named "
+            f"a complete route. row={row}")
+
+    def test_a_synced_peer_does_not_change_the_transport_the_row_implies(self):
+        """The composed case: the same local row, with and without a peer sync.
+
+        Asserted on the union's own output first, so this arm FAILS at the
+        parent rather than erroring on an attribute that is not there yet.
+        """
+        alone = self._union({"donly": LOCAL_DISCORD}, {})["donly"]
+        synced = self._union({"donly": LOCAL_DISCORD},
+                             {"donly": PEER_MATRIX})["donly"]
+        self.assertEqual(
+            synced, alone,
+            "a peer that synced a Matrix row changed the route fields this row "
+            f"carries: alone={alone} synced={synced}")
+        self.assertEqual(self.m.declared_routes(synced)[:1], ("discord",))
+
+    def test_a_genuine_matrix_only_row_still_routes_to_matrix(self):
+        """The other direction, asserted so it PASSES at the parent too: making
+        Discord a route must not let a Discord peer displace a Matrix row."""
+        mx = {"stand": "@sutando-mx:ag2.space", "room": "!mx:ag2.space"}
+        u = self._union({"mxonly": mx}, {"mxonly": LOCAL_DISCORD})
+        self.assertEqual(u["mxonly"], mx,
+                         f"a Discord peer displaced a Matrix-only row: {u}")
+        self.assertTrue(self.m._usable(mx))
+
+    def test_the_owner_classifies_a_matrix_only_row_as_matrix(self):
+        mx = {"stand": "@sutando-mx:ag2.space", "room": "!mx:ag2.space"}
+        self.assertEqual(self.m.declared_routes(mx), ("matrix",))
+
+    def test_matrix_is_preferred_when_a_row_names_both_routes(self):
+        """Preference order is the owner's, and it is the order it always was."""
+        both = dict(PEER_MATRIX, **LOCAL_DISCORD)
+        self.assertEqual(self.m.declared_routes(both), ("matrix", "discord"))
+
+    def test_a_null_filled_local_row_still_loses_to_a_usable_peer(self):
+        u = self._union({"q": LOCAL_NULL}, {"q": PEER_MATRIX})
+        self.assertEqual(u["q"].get("stand"), PEER_MATRIX["stand"])
+        self.assertEqual(u["q@local"], LOCAL_NULL)
+
+    def test_promotion_keeps_peer_routing_when_a_local_field_spells_it_false(self):
+        """`false` names no route, so the row is a placeholder — but it IS a
+        declared value, and overlaying it would blank the peer's route."""
+        u = self._union({"q": {"stand": False, "discord_id": False}},
+                        {"q": PEER_MATRIX})
+        self.assertEqual(u["q"].get("stand"), PEER_MATRIX["stand"],
+                         f"a `false` local field overwrote peer routing: {u['q']}")
+        self.assertEqual(self.m.declared_routes(u["q"]), ("matrix",))
+
+    def test_promotion_does_not_let_a_false_local_field_blank_a_peer_route(self):
+        """`_promote` must exclude EVERY routing field, not just the Matrix pair:
+        a declared-but-empty local `discord_id` would erase the peer's."""
+        peer = dict(PEER_MATRIX, discord_id="D", home_channel="C")
+        u = self._union({"q": {"stand": None, "discord_id": False,
+                               "home_channel": False}}, {"q": peer})
+        self.assertEqual(self.m.declared_routes(u["q"]), ("matrix", "discord"),
+                         f"a `false` local route field blanked the peer's: {u['q']}")
+
+    def test_origin_still_wins_when_both_rows_are_usable(self):
+        u = self._union({"q": LOCAL_DISCORD}, {"q": PEER_MATRIX})
+        self.assertEqual(u["q"], LOCAL_DISCORD)
+        self.assertEqual(u["q@zpeer"], PEER_MATRIX)
+
+    def test_a_refusal_row_is_still_never_overwritten(self):
+        refusal = {"stand": "", "refusal_basis": "asked not to be pinged"}
+        u = self._union({"q": refusal}, {"q": PEER_MATRIX})
+        self.assertEqual(u["q"], refusal)
+
+    def test_the_route_contract_covers_every_spelling_the_notifier_passes(self):
+        """`stand_discord_id` and an integer id are both live roster spellings."""
+        d = self.m.declared_routes
+        self.assertEqual(d({"stand_discord_id": 42, "home_channel": "C"}),
+                         ("discord",))
+        self.assertEqual(d({"discord_id": 42, "home_channel": "C"}), ("discord",))
+        self.assertEqual(d({"discord_id": "D"}), ())
+        self.assertEqual(d({"home_channel": "C"}), ())
+        self.assertEqual(d({"stand": "@s:x"}), ())
+        self.assertEqual(d({"stand": "@s:x", "room": "   "}), ())
+        self.assertEqual(d(None), ())
+        self.assertIn("home_channel", self.m.routing_fields())
+        self.assertIn("stand", self.m.routing_fields())
+
+    def test_a_partial_stand_still_blocks_promotion(self):
+        """Unchanged: a row naming a Stand but no room states a Matrix identity,
+        and promoting over it would address the person as a different Stand."""
+        self.assertTrue(self.m.states_routing({"stand": "@s:x"}, ("matrix",)))
+        self.assertFalse(self.m.states_routing({"stand": "  ", "room": None}))
+        u = self._union({"q": {"stand": "@s:x"}}, {"q": PEER_MATRIX})
+        self.assertEqual(u["q"], {"stand": "@s:x"})
+
+    def test_a_lone_discord_id_is_still_promotable(self):
+        """Deliberately NOT symmetric, and the asymmetry is now written down: a
+        lone id names no route, so a peer's Stand is the only way to reach them."""
+        self.assertTrue(self.m.states_routing({"discord_id": "D"}))
+        self.assertFalse(self.m.states_routing({"discord_id": "D"}, ("matrix",)))
+        u = self._union({"q": {"discord_id": "D"}}, {"q": PEER_MATRIX})
+        self.assertEqual(u["q"].get("room"), PEER_MATRIX["room"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What breaks

`roster_union` merges by **origin**, not by usability. Local wins a key collision — and `{"stand": null, "room": null, "discord": null}` is a *row*, so a placeholder wins exactly as a filled row would. The usable peer row survives only under `<key>@<host>`, which `resolve()` never looks up.

## Measured on a host where it reproduces

Local rows are placeholders; the vault-carried peer roster is complete.

```
roster_paths() READ union -> 3 files, LOCAL FIRST
    Chis-Mac-mini      11 entries, 1 addressable
    <peer host>        13 entries, 7 addressable
    legacy             11 entries, 1 addressable
UNION addressable: 7

union['qingyun-wu']            -> stand=None  room=None      <- the placeholder wins
union['qingyun-wu@<peer>']     -> stand='@sutando-qingyun-001:ag2.space'

$ notify_reviewers.py --reviewers qingyun-wu,keweichen
rc=3  UNUSABLE entry 'qingyun-wu': needs both 'stand' and 'room'
      UNUSABLE entry 'keweichen': needs both 'stand' and 'room'
```

Shadowed here: **keweichen, qingyun-wu, rui, bassilkhilo-ag2** — four reviewers present in the union and unreachable by name.

**An absent row is strictly better than an empty one today**: absence takes the `key not in merged` branch and the peer row wins outright. Only a null-filled row loses the data.

## The fix is a conditional tie-break, not a reordering

Completeness decides **only when exactly one side is usable**. When both are usable, or both are empty, origin still wins — so a peer's stale row cannot override a local row its host is actively maintaining, which is the failure the current policy exists to prevent. The losing row is still retained under a suffix.

## Test

`tests/roster-union-empty-row-shadow.test.py`, 4 arms. The fixture is measured, not invented: the two row shapes are what is on disk for that login.

```
1  a usable peer row is not shadowed by an empty local one     FAILS at parent
2  the losing row is still retained under its suffix           passes at parent, must keep passing
3  origin still decides when BOTH rows are usable              passes at parent, must keep passing
4  origin still decides when BOTH rows are empty               passes at parent, must keep passing
```

Control at the parent commit:

```
AssertionError: None is not true : the bare key resolves to the placeholder;
the usable row is only reachable as 'qingyun-wu@peer'.
union keys: ['qingyun-wu', 'qingyun-wu@peer']
Ran 4 tests — FAILED (failures=1)
```

At HEAD: `Ran 4 tests — OK`. Every `notify-reviewers` / `sci-notify` suite: **all OK**. `review-checks.sh --diff`: PASS.

## Cross-host verification still owed

Arms 2–4 pin the regression, but the mirror configuration — local rows complete, peers not — exists on another fleet host, where the union today reports **21 keys, 8 addressable, 0 shadowed**. Those three numbers must be unchanged after this. That check runs there, not here, and is requested at this head.

## Not the same defect as #3509

#3509 (joint, CHANGES_REQUESTED) widens the *transport gate*. It touches 0 files under `roster_union`, and the rows shadowed here are null in all three fields, so #3509 landing would not unshadow one of them. Same symptom, different layer.
