### PR TITLE
fix(room-ops): the exit code follows the result's own ok

### DIFF
--- a/skills/agent-room-ops/room_ops.py
+++ b/skills/agent-room-ops/room_ops.py
@@ -222,6 +222,8 @@ def _main(argv):
                    help="disable the grant (authoritative=false); leaves other policy fields intact")
     p.add_argument("--agent", dest="agent_mxid", default=os.environ.get("AGENT_MXID"))
 
+    ap.add_argument("--strict", action="store_true",
+                    help="exit 1 on ok:false; must precede the subcommand (default: always 0)")
     a = ap.parse_args(argv)
     if a.cmd == "read":
         res = _read.read_room(a.room_id, a.agent_mxid, a.limit, before=a.before,
@@ -284,9 +286,11 @@ def _main(argv):
         fn = _react.react if a.cmd == "react" else _react.unreact
         res = fn(a.room_id, a.event_id, key, a.agent_mxid)
     print(json.dumps(res, indent=2))
-    # The result's own `ok` decides the exit code. Printing a failure while
-    # exiting 0 makes every `&&` chain and `set -e` caller read it as delivered.
-    return 1 if isinstance(res, dict) and res.get("ok") is False else 0
+    # Default stays 0 on a failed op: callers batch these and read `ok`.
+    # --strict is for shell callers, where exit 0 reads as delivered.
+    if a.strict and isinstance(res, dict) and res.get("ok") is False:
+        return 1
+    return 0
 
 
 if __name__ == "__main__":

--- a/skills/agent-room-ops/room_ops.py
+++ b/skills/agent-room-ops/room_ops.py
@@ -23,7 +23,9 @@ graceful-degrade); this file is the unified CLI that dispatches to them.
 
 Every subcommand prints a structured JSON result and **exits 0** for any
 structured result (a graceful `ok:false` "no context / no-op" is not a failed
-task); usage errors exit 2. See SKILL.md for the boundary + the parity epic.
+task); usage errors exit 2. `--strict`, placed BEFORE the subcommand, is the
+opt-in exception: it exits 1 on `ok:false`, for shell callers that gate on the
+exit code. The default is unchanged. See SKILL.md for the boundary + the parity epic.
 `events stream` is the one JSONL surface: one compact JSON line per delivered
 event (journal-friendly), then a one-line summary.
 """
@@ -46,9 +48,16 @@ import members as _members # noqa: E402
 import events as _events   # noqa: E402
 
 
+def _strict_rc(res, strict):
+    """Default stays 0 on a failed op: callers batch these and read `ok`.
+    --strict is for shell callers, where exit 0 reads as delivered."""
+    return 1 if strict and isinstance(res, dict) and res.get("ok") is False else 0
+
+
 def _events_stream(a):
     """`events stream`: one compact JSON line per event (journal-friendly), a
-    one-line JSON summary last. Exits 0 for any structured outcome — a
+    one-line JSON summary last. Exits 0 for any structured outcome unless
+    --strict, which exits 1 on ok:false — a
     disconnect without --cursor-file is a structured ok:false, not a crash.
     With --cursor-file the durable-cursor wrapper reconnects forever (#184);
     without it, one connection is made and its end is reported."""
@@ -71,7 +80,7 @@ def _events_stream(a):
     except (_events.StreamDisconnected, RuntimeError) as e:
         out = {"ok": False, "events": seen["n"], "cursor": seen["cursor"], "reason": str(e)}
     print(json.dumps(out, ensure_ascii=False), flush=True)
-    return 0
+    return _strict_rc(out, getattr(a, "strict", False))
 
 
 def _dispatch_events(a):
@@ -286,11 +295,7 @@ def _main(argv):
         fn = _react.react if a.cmd == "react" else _react.unreact
         res = fn(a.room_id, a.event_id, key, a.agent_mxid)
     print(json.dumps(res, indent=2))
-    # Default stays 0 on a failed op: callers batch these and read `ok`.
-    # --strict is for shell callers, where exit 0 reads as delivered.
-    if a.strict and isinstance(res, dict) and res.get("ok") is False:
-        return 1
-    return 0
+    return _strict_rc(res, a.strict)
 
 
 if __name__ == "__main__":

--- a/skills/agent-room-ops/room_ops.py
+++ b/skills/agent-room-ops/room_ops.py
@@ -284,7 +284,9 @@ def _main(argv):
         fn = _react.react if a.cmd == "react" else _react.unreact
         res = fn(a.room_id, a.event_id, key, a.agent_mxid)
     print(json.dumps(res, indent=2))
-    return 0
+    # The result's own `ok` decides the exit code. Printing a failure while
+    # exiting 0 makes every `&&` chain and `set -e` caller read it as delivered.
+    return 1 if isinstance(res, dict) and res.get("ok") is False else 0
 
 
 if __name__ == "__main__":

--- a/tests/room-ops-exit-code.test.py
+++ b/tests/room-ops-exit-code.test.py
@@ -16,6 +16,7 @@ import io
 import json
 import pathlib
 import unittest
+from unittest import mock
 
 SRC = (pathlib.Path(__file__).resolve().parents[1] /
        "skills" / "agent-room-ops" / "room_ops.py")
@@ -29,38 +30,29 @@ def _load():
 
 
 class StrictIsOptIn(unittest.TestCase):
+    """Behavioural only. keweichen mutated the predicate from `is False` to
+    `is not None` and all six replica-based tests still passed."""
+
     def setUp(self):
-        self.src = SRC.read_text()
+        self.m = _load()
 
-    def test_the_flag_exists(self):
-        self.assertIn('"--strict"', self.src)
+    def _rc(self, res, strict):
+        return self.m._strict_rc(res, strict)
 
-    def test_the_return_is_guarded_by_the_flag(self):
-        tail = self.src[self.src.rindex("print(json.dumps(res"):]
-        self.assertIn("a.strict", tail,
-            "the nonzero exit must be reachable only with --strict")
-        self.assertIn('res.get("ok")', tail)
-
-    def test_default_stays_zero_and_strict_maps_false_to_one(self):
-        ns: dict = {}
-        exec("def rc(res, strict):\n"
-             "    if strict and isinstance(res, dict) and res.get('ok') is False:\n"
-             "        return 1\n"
-             "    return 0", ns)
-        rc = ns["rc"]
+    def test_a_false_ok_exits_1_only_under_strict(self):
         bad = {"ok": False, "reason": "file not found"}
-        self.assertEqual(rc(bad, False), 0, "default contract must not change")
-        self.assertEqual(rc(bad, True), 1)
-        self.assertEqual(rc({"ok": True}, True), 0)
+        self.assertEqual(self._rc(bad, True), 1)
+        self.assertEqual(self._rc(bad, False), 0, "the default contract must not change")
 
-    def test_a_result_without_an_ok_key_stays_zero_even_strict(self):
-        ns: dict = {}
-        exec("def rc(res, strict):\n"
-             "    if strict and isinstance(res, dict) and res.get('ok') is False:\n"
-             "        return 1\n"
-             "    return 0", ns)
-        self.assertEqual(ns["rc"]({"rooms": []}, True), 0)
-        self.assertEqual(ns["rc"](None, True), 0)
+    def test_a_TRUE_ok_exits_0_even_under_strict(self):
+        """The mutation that survived: `is not None` would return 1 here."""
+        self.assertEqual(self._rc({"ok": True, "event_id": "$x"}, True), 0)
+
+    def test_a_result_without_an_ok_key_exits_0_even_under_strict(self):
+        """No `ok` key: `is not None` leaves this at 0, so the ok:true case
+        above is the one that kills that mutation. Pinned for the contract."""
+        self.assertEqual(self._rc({"rooms": []}, True), 0)
+        self.assertEqual(self._rc(None, True), 0)
 
 
 class MainActuallyReturnsTheCode(unittest.TestCase):
@@ -85,6 +77,31 @@ class MainActuallyReturnsTheCode(unittest.TestCase):
         rc, out = self._run(["send", "!r:x", "/nope/missing.png"])
         self.assertEqual(rc, 0, "the default contract must not change")
         self.assertIs(json.loads(out)["ok"], False)
+
+
+    def test_events_stream_honours_strict_through_real_main(self):
+        """keweichen: the stream branch returned before the strict mapping, so
+        `--strict events stream --once` reported ok:false with rc 0.
+
+        Stubbed, never dialled: calling it live BLOCKS on a real connection —
+        I hung a terminal proving that before writing it this way.
+        """
+        buf = io.StringIO()
+        with mock.patch.object(self.m._events, "stream",
+                               side_effect=self.m._events.StreamDisconnected("no gateway configured")):
+            with contextlib.redirect_stdout(buf):
+                rc = self.m._main(["--strict", "events", "stream", "--once"])
+        out = json.loads([l for l in buf.getvalue().strip().split("\n") if l.strip()][-1])
+        self.assertIs(out["ok"], False, "the stub must produce the failure shape")
+        self.assertEqual(rc, 1, "a failed stream must not exit 0 under --strict")
+
+    def test_events_stream_still_exits_0_on_that_failure_WITHOUT_strict(self):
+        buf = io.StringIO()
+        with mock.patch.object(self.m._events, "stream",
+                               side_effect=self.m._events.StreamDisconnected("no gateway configured")):
+            with contextlib.redirect_stdout(buf):
+                rc = self.m._main(["events", "stream", "--once"])
+        self.assertEqual(rc, 0, "the default contract must not change")
 
 
 if __name__ == "__main__":

--- a/tests/room-ops-exit-code.test.py
+++ b/tests/room-ops-exit-code.test.py
@@ -1,13 +1,12 @@
-"""room_ops must exit nonzero when its own result says ok:false.
+"""`--strict` makes room_ops' exit code follow its own ok; the default does not.
 
-Measured 2026-09-08 on a live host: `room_ops send <room> "<a message body>"`
-(send takes a PATH, not a body) printed {"ok": false, "reason": "file not
-found"} and exited 0. A caller gating on the exit code — every `&&` chain and
-every `set -e` script — reads that as a delivered message. `say` to an
-unreachable room does the same with reason "HTTP 502".
+Measured 2026-09-08: `room_ops send <room> "<a message body>"` (send takes a PATH)
+printed {"ok": false, "reason": "file not found"} and exited 0, so a shell caller
+gating on the exit code read a failed send as delivered. It cost a real post.
 
-notify_reviewers.py guards by reading `ok` explicitly, so it is unaffected;
-the exposure is shell callers, which is the interface the skill documents.
+The DEFAULT stays 0 — skills/agent-room-ops/test_room_ops.py pins that across
+read/send/rooms/events (8 assertions), and notify_reviewers.py reads `ok`
+explicitly rather than the exit code. --strict is for shell callers only.
 """
 from __future__ import annotations
 
@@ -26,41 +25,39 @@ def _load():
     return m
 
 
-class ExitCodeFollowsOk(unittest.TestCase):
-    """The exit code is derived from res['ok'], not hardcoded."""
-
+class StrictIsOptIn(unittest.TestCase):
     def setUp(self):
         self.src = SRC.read_text()
 
-    def test_main_does_not_hardcode_a_zero_return(self):
-        tail = self.src[self.src.rindex("print(json.dumps(res"):]
-        self.assertNotIn("\n    return 0\n", tail,
-            "_main returns 0 unconditionally; a printed ok:false still exits 0")
+    def test_the_flag_exists(self):
+        self.assertIn('"--strict"', self.src)
 
-    def test_the_return_consults_ok(self):
+    def test_the_return_is_guarded_by_the_flag(self):
         tail = self.src[self.src.rindex("print(json.dumps(res"):]
-        self.assertIn('res.get("ok")', tail,
-            "the exit code must be derived from the result's own verdict")
+        self.assertIn("a.strict", tail,
+            "the nonzero exit must be reachable only with --strict")
+        self.assertIn('res.get("ok")', tail)
 
-    def test_a_false_ok_maps_to_nonzero_and_true_to_zero(self):
+    def test_default_stays_zero_and_strict_maps_false_to_one(self):
         ns: dict = {}
-        exec("def rc(res):\n"
-             "    return 1 if isinstance(res, dict) and res.get('ok') is False else 0",
-             ns)
+        exec("def rc(res, strict):\n"
+             "    if strict and isinstance(res, dict) and res.get('ok') is False:\n"
+             "        return 1\n"
+             "    return 0", ns)
         rc = ns["rc"]
-        self.assertEqual(rc({"ok": False, "reason": "file not found"}), 1)
-        self.assertEqual(rc({"ok": False, "reason": "HTTP 502"}), 1)
-        self.assertEqual(rc({"ok": True, "event_id": "$x"}), 0)
+        bad = {"ok": False, "reason": "file not found"}
+        self.assertEqual(rc(bad, False), 0, "default contract must not change")
+        self.assertEqual(rc(bad, True), 1)
+        self.assertEqual(rc({"ok": True}, True), 0)
 
-    def test_a_result_without_an_ok_key_still_exits_zero(self):
-        """Only an explicit False fails: commands whose result carries no `ok`
-        must keep their previous exit code, or this fix breaks them."""
+    def test_a_result_without_an_ok_key_stays_zero_even_strict(self):
         ns: dict = {}
-        exec("def rc(res):\n"
-             "    return 1 if isinstance(res, dict) and res.get('ok') is False else 0",
-             ns)
-        self.assertEqual(ns["rc"]({"rooms": []}), 0)
-        self.assertEqual(ns["rc"](None), 0)
+        exec("def rc(res, strict):\n"
+             "    if strict and isinstance(res, dict) and res.get('ok') is False:\n"
+             "        return 1\n"
+             "    return 0", ns)
+        self.assertEqual(ns["rc"]({"rooms": []}, True), 0)
+        self.assertEqual(ns["rc"](None, True), 0)
 
 
 if __name__ == "__main__":

--- a/tests/room-ops-exit-code.test.py
+++ b/tests/room-ops-exit-code.test.py
@@ -10,7 +10,10 @@ explicitly rather than the exit code. --strict is for shell callers only.
 """
 from __future__ import annotations
 
+import contextlib
 import importlib.util
+import io
+import json
 import pathlib
 import unittest
 
@@ -58,6 +61,30 @@ class StrictIsOptIn(unittest.TestCase):
              "    return 0", ns)
         self.assertEqual(ns["rc"]({"rooms": []}, True), 0)
         self.assertEqual(ns["rc"](None, True), 0)
+
+
+class MainActuallyReturnsTheCode(unittest.TestCase):
+    """Execute the real _main. The assertions above read source text and an
+    exec'd replica, so line 292 (the --strict return) never ran under them."""
+
+    def setUp(self):
+        self.m = _load()
+
+    def _run(self, argv):
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            rc = self.m._main(argv)
+        return rc, buf.getvalue()
+
+    def test_strict_returns_1_on_a_failed_op(self):
+        rc, out = self._run(["--strict", "send", "!r:x", "/nope/missing.png"])
+        self.assertEqual(rc, 1)
+        self.assertIs(json.loads(out)["ok"], False)
+
+    def test_the_default_returns_0_on_the_same_failed_op(self):
+        rc, out = self._run(["send", "!r:x", "/nope/missing.png"])
+        self.assertEqual(rc, 0, "the default contract must not change")
+        self.assertIs(json.loads(out)["ok"], False)
 
 
 if __name__ == "__main__":

--- a/tests/room-ops-exit-code.test.py
+++ b/tests/room-ops-exit-code.test.py
@@ -1,0 +1,67 @@
+"""room_ops must exit nonzero when its own result says ok:false.
+
+Measured 2026-09-08 on a live host: `room_ops send <room> "<a message body>"`
+(send takes a PATH, not a body) printed {"ok": false, "reason": "file not
+found"} and exited 0. A caller gating on the exit code — every `&&` chain and
+every `set -e` script — reads that as a delivered message. `say` to an
+unreachable room does the same with reason "HTTP 502".
+
+notify_reviewers.py guards by reading `ok` explicitly, so it is unaffected;
+the exposure is shell callers, which is the interface the skill documents.
+"""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import unittest
+
+SRC = (pathlib.Path(__file__).resolve().parents[1] /
+       "skills" / "agent-room-ops" / "room_ops.py")
+
+
+def _load():
+    s = importlib.util.spec_from_file_location("ro", SRC)
+    m = importlib.util.module_from_spec(s)
+    s.loader.exec_module(m)
+    return m
+
+
+class ExitCodeFollowsOk(unittest.TestCase):
+    """The exit code is derived from res['ok'], not hardcoded."""
+
+    def setUp(self):
+        self.src = SRC.read_text()
+
+    def test_main_does_not_hardcode_a_zero_return(self):
+        tail = self.src[self.src.rindex("print(json.dumps(res"):]
+        self.assertNotIn("\n    return 0\n", tail,
+            "_main returns 0 unconditionally; a printed ok:false still exits 0")
+
+    def test_the_return_consults_ok(self):
+        tail = self.src[self.src.rindex("print(json.dumps(res"):]
+        self.assertIn('res.get("ok")', tail,
+            "the exit code must be derived from the result's own verdict")
+
+    def test_a_false_ok_maps_to_nonzero_and_true_to_zero(self):
+        ns: dict = {}
+        exec("def rc(res):\n"
+             "    return 1 if isinstance(res, dict) and res.get('ok') is False else 0",
+             ns)
+        rc = ns["rc"]
+        self.assertEqual(rc({"ok": False, "reason": "file not found"}), 1)
+        self.assertEqual(rc({"ok": False, "reason": "HTTP 502"}), 1)
+        self.assertEqual(rc({"ok": True, "event_id": "$x"}), 0)
+
+    def test_a_result_without_an_ok_key_still_exits_zero(self):
+        """Only an explicit False fails: commands whose result carries no `ok`
+        must keep their previous exit code, or this fix breaks them."""
+        ns: dict = {}
+        exec("def rc(res):\n"
+             "    return 1 if isinstance(res, dict) and res.get('ok') is False else 0",
+             ns)
+        self.assertEqual(ns["rc"]({"rooms": []}), 0)
+        self.assertEqual(ns["rc"](None), 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)

--- a/tests/room-ops-grant.test.py
+++ b/tests/room-ops-grant.test.py
@@ -228,7 +228,9 @@ class CliDispatchTests(unittest.TestCase):
 
         with mock.patch.object(gr, "grant_room", boom):
             rc = self._run(["grant", ROOM, "--tier", "@u:hs=admin"])
-        self.assertEqual(rc, 0)          # bad input is a clean result, not a crash
+        # rc follows `ok` for every subcommand, so a rejected grant cannot read
+        # as an applied one. Nonzero is not a crash; the JSON still explains why.
+        self.assertEqual(rc, 1)
         self.assertEqual(called["n"], 0)  # never reached the network call
 
 

--- a/tests/room-ops-grant.test.py
+++ b/tests/room-ops-grant.test.py
@@ -228,9 +228,7 @@ class CliDispatchTests(unittest.TestCase):
 
         with mock.patch.object(gr, "grant_room", boom):
             rc = self._run(["grant", ROOM, "--tier", "@u:hs=admin"])
-        # rc follows `ok` for every subcommand, so a rejected grant cannot read
-        # as an applied one. Nonzero is not a crash; the JSON still explains why.
-        self.assertEqual(rc, 1)
+        self.assertEqual(rc, 0)          # bad input is a clean result, not a crash
         self.assertEqual(called["n"], 0)  # never reached the network call
 
 


### PR DESCRIPTION
## What breaks

`room_ops` prints a structured failure and exits 0, so a **shell** caller gating on the exit code reads a failed operation as delivered.

Measured, and it cost a real send: a news-briefing post to an ag2space room ran `room_ops send <room> "<body>"` — `send` takes a PATH — got `{"ok": false, "reason": "file not found"}` with exit 0, and the room simply never received the briefing.

## The fix is OPT-IN, and the first version of this PR was wrong

My first commit made the exit code follow `ok` unconditionally and described that as *one* contract change. **CI failed it, and CI was right: it is at least nine.**

`skills/agent-room-ops/test_room_ops.py` — which lives **beside the module**, not under `tests/`, so my `grep tests/*.py` suite selection never ran it — pins exits-zero across `read`, `send`, `rooms` and `events`. Eight failures. One of them, `test_send_exits_zero_on_no_context`, asserts that `send` with a nonexistent path exits 0: the exact case I had called a bug.

That is a deliberate fail-soft contract, not an oversight in one place. Rewriting eight assertions to suit my patch would be the wrong direction, so the default is restored and the new behaviour is behind `--strict`:

```
room_ops.py --strict send <room> /nope   exit=1
room_ops.py --strict rooms               exit=0
room_ops.py send <room> /nope            exit=0   <- default, unchanged
```

`--strict` must precede the subcommand (argparse top-level option); its help says so.

## Why this is still worth having

`notify_reviewers.py` is unaffected either way — it reads `ok` explicitly at `:287` ("`ok` is the instrument's own verdict"). The exposure is shell callers, which is the interface the skill documents, since it prints the exact `room_ops` commands for an operator to run. Those callers now have something to gate on without changing anything for the batch callers the default protects.

## Verification

```
skills/agent-room-ops/test_room_ops.py   150 tests  OK
tests/room-ops-grant.test.py              20 tests  OK   (restored to origin/main)
tests/room-ops-exit-code.test.py           4 tests  OK   (rewritten to the opt-in contract)
review-checks --diff                       PASS
```

A note on the restore, since it nearly hid the problem: my first attempt used `git checkout <path>`, which reads **my** HEAD — so it kept the very edit I was trying to revert, and the suite still failed. `git checkout origin/main -- <path>` is what actually reverts it.
