### PR TITLE
feat(proactive-loop): name the PR state where nothing blocks and nobody was asked

### DIFF
--- a/skills/proactive-loop/scripts/recruit-gap-check.py
+++ b/skills/proactive-loop/scripts/recruit-gap-check.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Name the PR state where nothing blocks and nobody has been asked.
+
+A cleared CHANGES_REQUESTED and a satisfied approval bar look identical from every
+surface that reports "no blocker": reviewDecision goes quiet and mergeStateStatus
+stops saying BLOCKED, while an approval is still missing and no one is queued.
+
+The bar comes from the branch RULESET. `branches/<b>/protection` answers 404
+"Branch not protected" for a ruleset-protected branch, which reads as "no rule".
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+
+BLOCKED, RECRUIT, THIN, MET = "blocked", "recruit", "thin", "met"
+
+
+def latest_states(reviews):
+    """Newest non-COMMENTED state per reviewer.
+
+    A COMMENTED review cannot move reviewDecision, so counting it would let a
+    remark stand in for a verdict.
+    """
+    out = {}
+    for r in reviews:
+        state = r.get("state")
+        if state == "COMMENTED":
+            continue
+        login = (r.get("user") or {}).get("login")
+        if login:
+            out[login] = state
+    return out
+
+
+def classify(required, latest, shared_logins):
+    """Pure verdict. A shared login is counted by GitHub but identifies no one.
+
+    Two shortfalls, never one: `github` decides mergeability, `distinct` decides
+    whether anyone outside the shared logins actually vouched. This repo has more
+    than one such account, so the parameter is a SET -- a single-login version
+    scores the second shared account as a distinct party.
+    """
+    shared = {shared_logins} if isinstance(shared_logins, str) else set(shared_logins)
+    blocking = sorted(u for u, s in latest.items() if s == "CHANGES_REQUESTED")
+    counted = sorted(u for u, s in latest.items() if s == "APPROVED")
+    distinct = [u for u in counted if u not in shared]
+    github_short = max(0, required - len(counted))
+    distinct_short = max(0, required - len(distinct))
+    if blocking:
+        verdict = BLOCKED
+    elif github_short:
+        verdict = RECRUIT
+    elif distinct_short:
+        verdict = THIN
+    else:
+        verdict = MET
+    return {
+        "verdict": verdict, "required": required, "blocking": blocking,
+        "counted": counted, "distinct": distinct,
+        "github_short_by": github_short, "distinct_short_by": distinct_short,
+    }
+
+
+def render(pr, v, shared_logins):
+    n, req = len(v["counted"]), v["required"]
+    if v["verdict"] == BLOCKED:
+        return (f"#{pr}: still blocked by {', '.join(v['blocking'])} "
+                f"({n}/{req} approvals) -- recruiting is premature")
+    if v["verdict"] == RECRUIT:
+        return (f"#{pr}: RECRUIT -- nothing blocks, {n}/{req} approvals, short by "
+                f"{v['github_short_by']}. Approved: {', '.join(v['counted']) or 'nobody'}")
+    if v["verdict"] == THIN:
+        return (f"#{pr}: mergeable but thin -- {n}/{req} ({', '.join(v['counted'])}), yet only "
+                f"{len(v['distinct'])} are outside the shared logins "
+                f"({', '.join(sorted(shared_logins))})")
+    return f"#{pr}: bar met ({n}/{req}), nobody to recruit"
+
+
+def _gh(args):
+    p = subprocess.run(["gh", "api"] + args, capture_output=True, text=True)
+    if p.returncode != 0:
+        raise RuntimeError(f"gh api {' '.join(args)}: {p.stderr.strip()[:200]}")
+    return json.loads(p.stdout)
+
+
+def required_approvals(repo, branch):
+    for rule in _gh([f"repos/{repo}/rules/branches/{branch}"]):
+        if rule.get("type") == "pull_request":
+            return int(rule["parameters"].get("required_approving_review_count", 0))
+    return 0
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repo", required=True)
+    ap.add_argument("--shared-login", required=True, action="append", dest="shared_logins",
+                    help="login shared by several agents; counted by GitHub, identifies no one. "
+                         "Repeatable -- this repo has more than one such account.")
+    ap.add_argument("--branch", default="main")
+    ap.add_argument("prs", nargs="+")
+    a = ap.parse_args(argv)
+    rc = 0
+    try:
+        required = required_approvals(a.repo, a.branch)
+    except Exception as exc:
+        print(f"cannot answer: {exc}")
+        return 2
+    for pr in a.prs:
+        try:
+            reviews = _gh([f"repos/{a.repo}/pulls/{pr}/reviews", "--paginate"])
+        except Exception as exc:
+            print(f"#{pr}: cannot answer -- {exc}")
+            rc = max(rc, 2)
+            continue
+        v = classify(required, latest_states(reviews), a.shared_logins)
+        print(render(pr, v, a.shared_logins))
+        if v["verdict"] == RECRUIT:
+            rc = max(rc, 1)
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/proactive-loop-recruit-gap-check.test.py
+++ b/tests/proactive-loop-recruit-gap-check.test.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Contract for the recruit gap check: nothing blocks and nobody has been asked."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+MOD = REPO / "skills" / "proactive-loop" / "scripts" / "recruit-gap-check.py"
+spec = importlib.util.spec_from_file_location("recruit_gap_check", MOD)
+g = importlib.util.module_from_spec(spec)
+sys.modules["recruit_gap_check"] = g
+spec.loader.exec_module(g)
+
+SHARED = ["shared-login", "other-shared"]
+
+
+def rv(login, state, ts="2026-09-01T00:00:00Z"):
+    return {"submitted_at": ts, "state": state, "user": {"login": login}}
+
+
+class LatestStates(unittest.TestCase):
+    def test_newest_state_per_reviewer_wins(self):
+        got = g.latest_states([rv("a", "CHANGES_REQUESTED"), rv("a", "APPROVED")])
+        self.assertEqual(got, {"a": "APPROVED"})
+
+    def test_commented_is_not_a_verdict(self):
+        """A remark must not stand in for a state: reviewDecision ignores COMMENTED."""
+        got = g.latest_states([rv("a", "APPROVED"), rv("a", "COMMENTED")])
+        self.assertEqual(got, {"a": "APPROVED"})
+
+    def test_a_reviewer_with_only_comments_is_absent(self):
+        self.assertEqual(g.latest_states([rv("a", "COMMENTED")]), {})
+
+    def test_missing_user_is_skipped_not_crashed(self):
+        self.assertEqual(g.latest_states([{"state": "APPROVED", "user": {}}]), {})
+
+
+class Classify(unittest.TestCase):
+    def test_a_standing_block_outranks_a_short_count(self):
+        v = g.classify(2, {"a": "CHANGES_REQUESTED"}, SHARED)
+        self.assertEqual(v["verdict"], g.BLOCKED)
+        self.assertEqual(v["blocking"], ["a"])
+
+    def test_nothing_blocking_and_short_is_the_recruit_case(self):
+        v = g.classify(2, {"a": "APPROVED"}, SHARED)
+        self.assertEqual(v["verdict"], g.RECRUIT)
+        self.assertEqual(v["github_short_by"], 1)
+
+    def test_zero_approvals_and_no_block_still_recruits(self):
+        v = g.classify(2, {}, SHARED)
+        self.assertEqual(v["verdict"], g.RECRUIT)
+        self.assertEqual(v["github_short_by"], 2)
+
+    def test_the_shared_login_COUNTS_for_github_but_identifies_nobody(self):
+        """The bar is met, so it is not a blocker -- but only one party vouched."""
+        v = g.classify(2, {"a": "APPROVED", SHARED[0]: "APPROVED"}, SHARED)
+        self.assertEqual(v["verdict"], g.THIN)
+        self.assertEqual(v["github_short_by"], 0, "GitHub counts the shared login")
+        self.assertEqual(v["distinct_short_by"], 1, "but one of the two is not a distinct party")
+
+    def test_a_SECOND_shared_login_is_also_not_a_distinct_party(self):
+        """#3482: more than one account is shared, so a single-login check miscounts."""
+        v = g.classify(2, {"shared-login": "APPROVED", "other-shared": "APPROVED"}, SHARED)
+        self.assertEqual(v["github_short_by"], 0, "GitHub counts both")
+        self.assertEqual(v["distinct_short_by"], 2, "neither identifies a party")
+        self.assertEqual(v["verdict"], g.THIN)
+
+    def test_a_plain_string_is_accepted_as_one_shared_login(self):
+        v = g.classify(2, {"a": "APPROVED", "s": "APPROVED"}, "s")
+        self.assertEqual(v["distinct"], ["a"])
+
+    def test_two_distinct_approvals_meet_the_bar(self):
+        v = g.classify(2, {"a": "APPROVED", "b": "APPROVED"}, SHARED)
+        self.assertEqual(v["verdict"], g.MET)
+        self.assertEqual((v["github_short_by"], v["distinct_short_by"]), (0, 0))
+
+    def test_a_block_beside_enough_approvals_is_still_blocked(self):
+        v = g.classify(2, {"a": "APPROVED", "b": "APPROVED", "c": "CHANGES_REQUESTED"}, SHARED)
+        self.assertEqual(v["verdict"], g.BLOCKED)
+
+    def test_a_zero_bar_never_recruits(self):
+        self.assertEqual(g.classify(0, {}, SHARED)["verdict"], g.MET)
+
+
+class Render(unittest.TestCase):
+    def test_every_verdict_names_the_pr_and_the_counts(self):
+        for latest in ({"a": "CHANGES_REQUESTED"}, {"a": "APPROVED"},
+                       {"a": "APPROVED", SHARED[0]: "APPROVED"},
+                       {"a": "APPROVED", "b": "APPROVED"}):
+            line = g.render(99, g.classify(2, latest, SHARED), SHARED)
+            self.assertIn("#99", line)
+            self.assertIn("/2", line, f"the bar must be visible in: {line}")
+
+    def test_the_recruit_line_says_who_approved(self):
+        line = g.render(7, g.classify(2, {"a": "APPROVED"}, SHARED), SHARED)
+        self.assertIn("RECRUIT", line)
+        self.assertIn("a", line)
+
+    def test_the_recruit_line_names_nobody_when_nobody_approved(self):
+        line = g.render(7, g.classify(2, {}, SHARED), SHARED)
+        self.assertIn("nobody", line)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)

--- a/tests/proactive-loop-recruit-gap-check.test.py
+++ b/tests/proactive-loop-recruit-gap-check.test.py
@@ -104,5 +104,95 @@ class Render(unittest.TestCase):
         self.assertIn("nobody", line)
 
 
+class Gh(unittest.TestCase):
+    """The subprocess boundary: a non-zero gh must raise, never return a partial answer."""
+
+    def _run(self, rc, out="", err=""):
+        class R:
+            returncode, stdout, stderr = rc, out, err
+        return lambda *a, **k: R()
+
+    def test_a_clean_call_returns_parsed_json(self):
+        orig = g.subprocess.run
+        g.subprocess.run = self._run(0, '[{"type": "pull_request"}]')
+        try:
+            self.assertEqual(g._gh(["x"]), [{"type": "pull_request"}])
+        finally:
+            g.subprocess.run = orig
+
+    def test_a_failing_call_raises_rather_than_returning_empty(self):
+        orig = g.subprocess.run
+        g.subprocess.run = self._run(1, "", "Not Found")
+        try:
+            with self.assertRaises(RuntimeError) as cm:
+                g._gh(["x"])
+            self.assertIn("Not Found", str(cm.exception))
+        finally:
+            g.subprocess.run = orig
+
+
+class RequiredApprovals(unittest.TestCase):
+    def _with(self, payload):
+        orig = g._gh
+        g._gh = lambda args: payload
+        self.addCleanup(lambda: setattr(g, "_gh", orig))
+
+    def test_it_reads_the_count_off_the_pull_request_rule(self):
+        self._with([{"type": "deletion", "parameters": {}},
+                    {"type": "pull_request",
+                     "parameters": {"required_approving_review_count": 2}}])
+        self.assertEqual(g.required_approvals("o/r", "main"), 2)
+
+    def test_no_pull_request_rule_means_no_bar(self):
+        self._with([{"type": "deletion", "parameters": {}}])
+        self.assertEqual(g.required_approvals("o/r", "main"), 0)
+
+
+class Main(unittest.TestCase):
+    def _stub(self, rules, reviews_by_pr):
+        orig = g._gh
+
+        def fake(args):
+            if "rules/branches" in args[0]:
+                return rules
+            pr = args[0].split("/pulls/")[1].split("/")[0]
+            got = reviews_by_pr.get(pr)
+            if isinstance(got, Exception):
+                raise got
+            return got
+        g._gh = fake
+        self.addCleanup(lambda: setattr(g, "_gh", orig))
+
+    RULES = [{"type": "pull_request", "parameters": {"required_approving_review_count": 2}}]
+
+    def test_recruit_exits_1(self):
+        self._stub(self.RULES, {"7": [rv("a", "APPROVED")]})
+        self.assertEqual(g.main(["--repo", "o/r", "--shared-login", SHARED[0], "7"]), 1)
+
+    def test_a_met_bar_exits_0(self):
+        self._stub(self.RULES, {"7": [rv("a", "APPROVED"), rv("b", "APPROVED")]})
+        self.assertEqual(g.main(["--repo", "o/r", "--shared-login", SHARED[0], "7"]), 0)
+
+    def test_a_blocked_pr_exits_0_because_recruiting_is_premature(self):
+        self._stub(self.RULES, {"7": [rv("a", "CHANGES_REQUESTED")]})
+        self.assertEqual(g.main(["--repo", "o/r", "--shared-login", SHARED[0], "7"]), 0)
+
+    def test_an_unreadable_pr_exits_2_and_does_not_abort_the_rest(self):
+        self._stub(self.RULES, {"7": RuntimeError("boom"), "8": [rv("a", "APPROVED")]})
+        self.assertEqual(g.main(["--repo", "o/r", "--shared-login", SHARED[0], "7", "8"]), 2)
+
+    def test_an_unreadable_RULESET_exits_2_without_reading_any_pr(self):
+        orig = g.required_approvals
+        g.required_approvals = lambda *a: (_ for _ in ()).throw(RuntimeError("404"))
+        self.addCleanup(lambda: setattr(g, "required_approvals", orig))
+        self.assertEqual(g.main(["--repo", "o/r", "--shared-login", SHARED[0], "7"]), 2)
+
+    def test_repeatable_shared_login_reaches_classify(self):
+        self._stub(self.RULES, {"7": [rv(SHARED[0], "APPROVED"), rv(SHARED[1], "APPROVED")]})
+        rc = g.main(["--repo", "o/r", "--shared-login", SHARED[0],
+                     "--shared-login", SHARED[1], "7"])
+        self.assertEqual(rc, 0, "the bar is met, so it is thin -- not a recruit")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=1)


### PR DESCRIPTION
## What

One script + its test. `skills/proactive-loop/scripts/recruit-gap-check.py` names the PR state where **nothing blocks and nobody has been asked**.

## Why

A cleared `CHANGES_REQUESTED` and a satisfied approval bar look identical from every surface that reports "no blocker": `reviewDecision` goes quiet, `mergeStateStatus` stops saying BLOCKED, and nothing anywhere says an approval is still missing. I hit this on #3860 — I deferred recruiting a second approver while a block stood, wrote the resume condition as prose in a notes file, and had no way to notice when it came true.

## Evidence — measured on this repo, not described

```
$ gh pr list --state open --limit 60 --json number --jq '.[].number' \
  | xargs python3 skills/proactive-loop/scripts/recruit-gap-check.py \
      --repo sonichi/sutando --shared-login sonichi --shared-login qingyun-wu
...
rc=1   10 rows "RECRUIT"
```

Three verdicts on live PRs, at the current heads:

```
#3860: still blocked by keweichen (1/2 approvals) -- recruiting is premature
#3316: mergeable but thin -- 2/2 (john-the-dev, sonichi), yet only 1 are outside
       the shared logins (qingyun-wu, sonichi)
#3924: bar met (2/2), nobody to recruit
```

**Two shortfalls, never one.** The first draft excluded the shared login and reported #3316 as "1/2, RECRUIT" — which is **false**: GitHub counts `john-the-dev` + `sonichi` and reports `merge=CLEAN`. So the check now reports `github_short_by` (decides mergeability) beside `distinct_short_by` (decides whether anyone outside the shared logins actually vouched), and #3316 lands as *thin*, which is a judgement rather than a blocker.

**`--shared-login` is repeatable**, because #3482 established that `qingyun-wu` is shared by several agents too. A single-login version scores the second shared account as a distinct party — the same miscount one layer up.

**The bar comes from the RULESET.** `gh api repos/sonichi/sutando/branches/main/protection` answers `404 "Branch not protected"`, which reads as "no rule"; `rules/branches/main` returns `required_approving_review_count: 2`.

## Perturbation

A checker never observed failing is not a validated checker:

```
drop the shared-login exclusion   -> 1 test red
count COMMENTED as a verdict      -> 2 tests red
restored                          -> 16 pass
ruff: All checks passed
review-checks --diff: PASS (hardcoded-paths + root-artifacts + prose-cap)
```

## Scope limit, stated so the "10" does not oversell

The check fires on **any** unblocked-and-short PR, which merges two situations: "a CHANGES_REQUESTED cleared and the count is still short" (the case it was written for) and "nobody has reviewed this yet". Separating them needs review *history*, not current state. So 10 is a queue depth, not 10 instances of the defect.

## Not wired

This adds the script and its contract only — no caller. Wiring it into the loop's per-pass body is a follow-up, deliberately separate so the mechanism can be reviewed before it starts emitting.

@sonichi — flagging you, this is mine (Echo Act IV Pro).
