### PR TITLE
fix(obs): SessionEnd hook carries `reason`, not `end_reason` — logout was never recorded

### DIFF
--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -258,7 +258,7 @@
    ],
    "status": "canonical",
    "canonical_for": "Claude Code hook event mapping and privacy contract",
-   "last_verified": "2026-07-27"
+   "last_verified": "2026-09-08"
   },
   "docs/slack-bridge.md": {
    "title": "Slack bridge",

--- a/src/observability/claude/cc-hooks.ts
+++ b/src/observability/claude/cc-hooks.ts
@@ -81,7 +81,8 @@ export interface SessionStartHook extends HookCommon {
 
 export interface SessionEndHook extends HookCommon {
 	hook_event_name: 'SessionEnd';
-	end_reason?: string;
+	// Real payload field (clear | resume | logout | prompt_input_exit | other).
+	reason?: string;
 }
 
 export interface PreCompactHook extends HookCommon {

--- a/src/observability/claude/hook-map.ts
+++ b/src/observability/claude/hook-map.ts
@@ -84,7 +84,7 @@ export function hookMap(hook: ClaudeCodeHook, ctx: MapContext): MapResult {
 			events.push(ev('cc.hook.session_start', 'ok', { source: hook.source, model: hook.model }));
 			break;
 		case 'SessionEnd':
-			events.push(ev('cc.hook.session_end', 'ok', { end_reason: hook.end_reason }));
+			events.push(ev('cc.hook.session_end', 'ok', { end_reason: hook.reason }));
 			break;
 		case 'PreCompact':
 			events.push(ev('cc.hook.pre_compact', 'ok', { trigger: hook.trigger }));

--- a/tests/observability/claude/hook-map.test.ts
+++ b/tests/observability/claude/hook-map.test.ts
@@ -26,10 +26,17 @@ describe('hookMap — obs only, with file-op pairing', () => {
 		assert.equal((fe!.data as Record<string, unknown>).op, 'written');
 	});
 
-	it('SessionEnd → cc.hook.session_end with end_reason', () => {
-		const out = hookMap({ hook_event_name: 'SessionEnd', session_id: 'sess-9', end_reason: 'clear' }, ctx);
+	it('SessionEnd → cc.hook.session_end with end_reason taken from the raw `reason`', () => {
+		// Claude Code sends `reason` (clear | resume | logout | prompt_input_exit | other);
+		// the persisted key stays `end_reason` so downstream readers do not move.
+		const out = hookMap({ hook_event_name: 'SessionEnd', session_id: 'sess-9', reason: 'logout' }, ctx);
 		assert.equal(out.events[0].kind, 'cc.hook.session_end');
-		assert.equal((out.events[0].data as Record<string, unknown>).end_reason, 'clear');
+		assert.equal((out.events[0].data as Record<string, unknown>).end_reason, 'logout');
+	});
+
+	it('SessionEnd without a reason persists no end_reason key (clean() drops undefined)', () => {
+		const out = hookMap({ hook_event_name: 'SessionEnd', session_id: 'sess-9' }, ctx);
+		assert.equal('end_reason' in (out.events[0].data as Record<string, unknown>), false);
 	});
 
 	it('unknown event → forward-compatible cc.hook.<snake> default branch', () => {

--- a/tests/observability/claude/hooks/hook-registry.test.ts
+++ b/tests/observability/claude/hooks/hook-registry.test.ts
@@ -46,7 +46,7 @@ const FIXTURES: Record<string, ClaudeCodeHook> = {
 	PostToolUseFailure: { hook_event_name: 'PostToolUseFailure', session_id: 's', tool_name: 'Bash', tool_input: { command: 'ls' }, error: 'boom' },
 	Stop: { hook_event_name: 'Stop', session_id: 's' },
 	SessionStart: { hook_event_name: 'SessionStart', session_id: 's', source: 'startup', model: 'm' },
-	SessionEnd: { hook_event_name: 'SessionEnd', session_id: 's', end_reason: 'clear' },
+	SessionEnd: { hook_event_name: 'SessionEnd', session_id: 's', reason: 'clear' },
 	PreCompact: { hook_event_name: 'PreCompact', session_id: 's', trigger: 'auto' },
 	Notification: { hook_event_name: 'Notification', session_id: 's', notification_type: 'permission' },
 	SubagentStart: { hook_event_name: 'SubagentStart', session_id: 's', agent_type: 'Explore' },


### PR DESCRIPTION
## What changed, and why?

Claude Code's `SessionEnd` hook payload field is **`reason`** (`clear | resume | logout | prompt_input_exit | other`). `src/observability/claude/cc-hooks.ts` typed it as `end_reason` and `hook-map.ts` read `hook.end_reason`, so `clean()` dropped the undefined key and every `cc.hook.session_end` event in the collector floor shipped with **no reason at all** — a `/logout` was indistinguishable from any other session end. Exactly the class of bug the file's own header warns about ("field names are verified against REAL Claude Code payloads; the docs were wrong on several").

Fix: read the raw `reason`; keep the **persisted** key `end_reason` so the registry (`persisted: ["end_reason"]`), the contract doc and any downstream reader do not move.

## Files to look at first

- `src/observability/claude/cc-hooks.ts` — `SessionEndHook.reason`
- `src/observability/claude/hook-map.ts` — `{ end_reason: hook.reason }`
- `tests/observability/claude/hook-map.test.ts` — the two new cases; `hook-registry.test.ts` fixture

## What bug does this prove?

`/logout` (and every other end reason) now lands in `logs/events-*.jsonl` as `cc.hook.session_end` with `data.end_reason`. This is the first half of "detect logout / login-required in the observability stream"; the login-required side (no CC hook exists for it) is a separate PR.

## Feature/documentation consistency

`docs/runtime/claude-hook-contract-v1.md` §3 defers the field list to `cc-hooks.ts` ("that file is the authoritative field list"), so no prose change; `docs/catalog.json` `last_verified` bumped to 2026-09-08. Registry `persisted`/`normalizedKinds` unchanged (conformance test still green).

## Before/after evidence

Field name, from the installed CLI bundle (`~/.local/share/claude/versions/2.1.265`):
```
$ grep -ao 'hook_event_name:"SessionEnd",[^}]\{0,40\}' <bundle>
hook_event_name:"SessionEnd",reason:n
$ grep -c end_reason <bundle>
0
```

Before — the new test run against `origin/main` (`git worktree add … origin/main`, same test file copied in):
```
not ok 1 - hookMap — obs only, with file-op pairing
      expected: 'logout'     # data.end_reason was undefined (dropped by clean())
# pass 5
# fail 1
```

After (HEAD):
```
$ npx tsx --test --test-force-exit tests/observability/claude/hook-map.test.ts tests/observability/claude/hooks/hook-registry.test.ts
# tests 12
# pass 12
# fail 0
$ npx tsc --noEmit | grep observability/claude     → (nothing)
```

## Tests run

The two suites above (12/12). `npm run lint` could not run locally (`@eslint/js` missing in this checkout's node_modules) — CI covers it.

Not a live path (pure mapper; the hook script and registration are untouched), so no restart round trip is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PKcXzpBUM8rFz62K7SDs1
