### PR TITLE
docs(review-preflight): say why the preflight is a script and not a reminder

### DIFF
--- a/skills/review-preflight/SKILL.md
+++ b/skills/review-preflight/SKILL.md
@@ -11,8 +11,8 @@ Two tools, invoked by path; neither is a boot dependency of the core.
 **Why the preflight exists, and why it is a script rather than a reminder.** Consulting the review
 criteria used to rely on memory, so it was skipped exactly where it felt safe to skip -- small diffs
 -- and a readiness verdict with the criteria unread is an over-claim rather than a fast review. The
-owner caught that same miss more than once (2026-07-24 "did you use the review skill?"; earlier on
-\#2177/\#2180 "did you follow the reviewer's guide?"). Successive "be more careful" fixes did not hold,
+owner caught that same miss more than once and asked directly whether the review skill had been
+used. Successive "be more careful" fixes did not hold,
 because the failure is not inattention: a reviewer who believes the diff is small has no prompt to
 re-read anything. Printing the criteria and the PR's live gate state is what makes the step
 unskippable, so the guarantee is structural rather than disciplinary.

--- a/skills/review-preflight/SKILL.md
+++ b/skills/review-preflight/SKILL.md
@@ -8,6 +8,15 @@ user-invocable: true
 
 Two tools, invoked by path; neither is a boot dependency of the core.
 
+**Why the preflight exists, and why it is a script rather than a reminder.** Consulting the review
+criteria used to rely on memory, so it was skipped exactly where it felt safe to skip -- small diffs
+-- and a readiness verdict with the criteria unread is an over-claim rather than a fast review. The
+owner caught that same miss more than once (2026-07-24 "did you use the review skill?"; earlier on
+\#2177/\#2180 "did you follow the reviewer's guide?"). Successive "be more careful" fixes did not hold,
+because the failure is not inattention: a reviewer who believes the diff is small has no prompt to
+re-read anything. Printing the criteria and the PR's live gate state is what makes the step
+unskippable, so the guarantee is structural rather than disciplinary.
+
 ```bash
 python3 skills/review-preflight/scripts/review-preflight.py <PR>      # run before reviewing; reads <repo>/REVIEW.md
 python3 skills/review-preflight/scripts/ci-triage.py <PR> [--repo o/n] # a red check is a pointer into the record: search its SUBJECT, not its name


### PR DESCRIPTION
The skill file documents **what** the two tools do and carries no record of **why** the gate exists.

That rationale was not lost in the abstract — it lived in an older copy of this same `SKILL.md`, which survived only as an unlinked real directory in one host's installed-skills tree, six weeks behind the repo (`mtime 2026-07-25` against #3902 on `2026-09-04`), and missing its `scripts/` entirely. I found it because a health probe flagged the directory as diverged, not because anything pointed at it.

### Before / after

Measured on `origin/main`, not described:

```
$ git grep -c -i "unskippable"                          origin/main -- '*.md'   ->  0
$ git grep -c -i "felt-confidence"                      origin/main -- '*.md'   ->  0
$ git grep -c -i "structural rather than disciplinary"  origin/main -- '*.md'   ->  0
$ git grep -c -i "did you use the review skill"         origin/main -- '*.md'   ->  0

$ grep -c "structural rather than disciplinary" skills/review-preflight/SKILL.md   ->  1   (this branch)

skills/review-preflight/SKILL.md   1220 B  ->  1985 B
```

So the argument for the step being mechanical was recoverable only from a stale artifact no reader would think to open. A later edit could have removed the preflight as ceremony without ever meeting the case for it.

### What this does and does not change

- **Docs only.** No script, no test, no behaviour. `scripts/` is untouched.
- **Paths corrected on the way in.** The old copy still pointed at `workspace/scripts/review-preflight.py` and `workspace/notes/reviewers-guide.md`; both were superseded by #3902 and by `REVIEW.md`. I carried the reasoning, not the stale paths.
- **Frontmatter preserved** — asserted after the edit, since that is what makes the skill user-invocable.

Not related to #3781, which is @john-the-dev's and touches only `scripts/review-preflight.py` and its test — different author, different files, different concern, so this is a separate single-concern PR rather than a push to that branch.

@sonichi flagging you as owner. This is a documentation recovery, so the thing worth checking is whether the reasoning is one you still hold — the wording attributes two specific catches to you (2026-07-24, and #2177/#2180) and I carried them from the stale copy rather than from the original exchanges.