### PR TITLE
fix(x-twitter): a click is not a post — require the toast's /status/ link

### DIFF
--- a/skills/x-twitter/landing-check.mjs
+++ b/skills/x-twitter/landing-check.mjs
@@ -33,3 +33,11 @@ export async function readLanding(page, { timeout = 15000, shotDir, now = Date.n
   const url = href.startsWith('http') ? href : `https://x.com${href}`;
   return { posted: true, url };
 }
+
+// The decision-to-exit mapping is production logic too: 4 = clicked, nothing
+// landed (3 is the pre-click composer refusal). Kept here so a test can pin it;
+// left in the caller it was an untestable `process.exit` a mutation could flip to 0.
+export const EXIT_NO_LANDING = 4;
+export function landingExit(decision) {
+  return decision.posted ? 0 : EXIT_NO_LANDING;
+}

--- a/skills/x-twitter/landing-check.mjs
+++ b/skills/x-twitter/landing-check.mjs
@@ -1,0 +1,35 @@
+// The post-click landing decision, extracted so it can run against a stub page
+// with no browser. A click is not a post: X confirms a landing with a toast
+// carrying the new /status/ link, and only that link — scoped to the toast —
+// counts (a bare /status/ link once matched a stranger's "View analytics").
+// Returns a decision; the caller maps it to output + exit code. Keeping the
+// `if (!landed)` branch here is load-bearing: without it a timeout reads the
+// href off a null handle. tests/x-post-landing-check.test.mjs mutates exactly
+// that predicate and asserts this returns wrong.
+
+export const STATUS_HREF = /^(https:\/\/x\.com)?\/[A-Za-z0-9_]+\/status\/\d+$/;
+
+export async function readLanding(page, { timeout = 15000, shotDir, now = Date.now } = {}) {
+  let landed = await page
+    .waitForSelector('[data-testid="toast"] a[href*="/status/"]', { timeout })
+    .catch(() => null);
+  if (landed) {
+    const h = await landed.getAttribute('href');
+    if (!STATUS_HREF.test(h)) landed = null;
+  }
+  if (!landed) {
+    const shot = `${shotDir}/x-post-nolanding-${now()}.png`;
+    await page.screenshot({ path: shot });
+    const alert = await page.$eval('[role="alert"]', (el) => el.innerText).catch(() => '');
+    return {
+      posted: false,
+      clicked: true,
+      reason: 'no /status/ link observed after click',
+      alert,
+      screenshot: shot,
+    };
+  }
+  const href = await landed.getAttribute('href');
+  const url = href.startsWith('http') ? href : `https://x.com${href}`;
+  return { posted: true, url };
+}

--- a/skills/x-twitter/x-post-browser.mjs
+++ b/skills/x-twitter/x-post-browser.mjs
@@ -45,6 +45,7 @@ import { fileURLToPath } from 'node:url';
 import { execFileSync } from 'node:child_process';
 import { normalizeComposerText, composerMatches } from './composer-text.mjs';
 import { gcftPids, classifyLsofProbe, execTimedOut } from './profile-match.mjs';
+import { readLanding } from './landing-check.mjs';
 import { resolveProfileDir } from './profile-dir.mjs';
 import { readManifestConfig, resolveSetting } from './manifest-config.mjs';
 
@@ -390,27 +391,15 @@ try {
     const finalText = await readComposer(page);
     if (!composerMatches(arg, finalText)) failComposerMismatch(arg, finalText);
     await btn.click();
-    // A click is not a post. X confirms a landing with a toast carrying the new
-    // /status/ link; without that link within the wait, nothing is claimed.
-    // TOAST ONLY: a bare /status/ link once matched a stranger's "View analytics" link.
-    // The toast is the one element X renders for OUR post; href must be /<handle>/status/<id>.
-    let landed = await page.waitForSelector('[data-testid="toast"] a[href*="/status/"]',
-      { timeout: 15000 }).catch(() => null);
-    if (landed) {
-      const h = await landed.getAttribute('href');
-      if (!/^(https:\/\/x\.com)?\/[A-Za-z0-9_]+\/status\/\d+$/.test(h)) landed = null;
-    }
-    if (!landed) {
-      const shot = `${SHOT_DIR}/x-post-nolanding-${Date.now()}.png`;
-      await page.screenshot({ path: shot });
-      const alert = await page.$eval('[role="alert"]', (el) => el.innerText).catch(() => '');
-      console.log(JSON.stringify({ posted: false, clicked: true, composer_matched: true,
-        reason: 'no /status/ link observed after click', alert, screenshot: shot }));
+    // A click is not a post. The landing decision lives in readLanding so it can
+    // run against a stub page (tests/x-post-landing-check.test.mjs); here we only
+    // map its decision to output + exit code.
+    const decision = await readLanding(page, { timeout: 15000, shotDir: SHOT_DIR });
+    if (!decision.posted) {
+      console.log(JSON.stringify({ ...decision, composer_matched: true }));
       process.exit(4);  // 3 is the pre-click composer refusal; 4 = clicked, nothing landed
     }
-    const href = await landed.getAttribute('href');
-    const url = href.startsWith('http') ? href : `https://x.com${href}`;
-    console.log(JSON.stringify({ posted: true, url, text: finalText, composer_matched: true }));
+    console.log(JSON.stringify({ posted: true, url: decision.url, text: finalText, composer_matched: true }));
     process.exit(0);
   }
 } catch (err) {

--- a/skills/x-twitter/x-post-browser.mjs
+++ b/skills/x-twitter/x-post-browser.mjs
@@ -45,7 +45,7 @@ import { fileURLToPath } from 'node:url';
 import { execFileSync } from 'node:child_process';
 import { normalizeComposerText, composerMatches } from './composer-text.mjs';
 import { gcftPids, classifyLsofProbe, execTimedOut } from './profile-match.mjs';
-import { readLanding } from './landing-check.mjs';
+import { readLanding, landingExit } from './landing-check.mjs';
 import { resolveProfileDir } from './profile-dir.mjs';
 import { readManifestConfig, resolveSetting } from './manifest-config.mjs';
 
@@ -397,10 +397,10 @@ try {
     const decision = await readLanding(page, { timeout: 15000, shotDir: SHOT_DIR });
     if (!decision.posted) {
       console.log(JSON.stringify({ ...decision, composer_matched: true }));
-      process.exit(4);  // 3 is the pre-click composer refusal; 4 = clicked, nothing landed
+    } else {
+      console.log(JSON.stringify({ posted: true, url: decision.url, text: finalText, composer_matched: true }));
     }
-    console.log(JSON.stringify({ posted: true, url: decision.url, text: finalText, composer_matched: true }));
-    process.exit(0);
+    process.exit(landingExit(decision));
   }
 } catch (err) {
   console.error(`Error: ${err.message}`);

--- a/skills/x-twitter/x-post-browser.mjs
+++ b/skills/x-twitter/x-post-browser.mjs
@@ -377,7 +377,7 @@ try {
       const shot = `${SHOT_DIR}/x-dryrun-${Date.now()}.png`;
       await page.screenshot({ path: shot });
       // report what the composer ACTUALLY holds, not what we asked for
-      console.log(JSON.stringify({ dryRun: true, wouldPost: typedDry, verified: true, screenshot: shot }));
+      console.log(JSON.stringify({ dryRun: true, wouldPost: typedDry, composer_matched: true, screenshot: shot }));
       process.exit(0);
     }
     // Publish: inline compose button (tweetButtonInline) or modal (tweetButton).
@@ -390,8 +390,27 @@ try {
     const finalText = await readComposer(page);
     if (!composerMatches(arg, finalText)) failComposerMismatch(arg, finalText);
     await btn.click();
-    await page.waitForTimeout(3000);
-    console.log(JSON.stringify({ posted: true, text: finalText, verified: true }));
+    // A click is not a post. X confirms a landing with a toast carrying the new
+    // /status/ link; without that link within the wait, nothing is claimed.
+    // TOAST ONLY: a bare /status/ link once matched a stranger's "View analytics" link.
+    // The toast is the one element X renders for OUR post; href must be /<handle>/status/<id>.
+    let landed = await page.waitForSelector('[data-testid="toast"] a[href*="/status/"]',
+      { timeout: 15000 }).catch(() => null);
+    if (landed) {
+      const h = await landed.getAttribute('href');
+      if (!/^(https:\/\/x\.com)?\/[A-Za-z0-9_]+\/status\/\d+$/.test(h)) landed = null;
+    }
+    if (!landed) {
+      const shot = `${SHOT_DIR}/x-post-nolanding-${Date.now()}.png`;
+      await page.screenshot({ path: shot });
+      const alert = await page.$eval('[role="alert"]', (el) => el.innerText).catch(() => '');
+      console.log(JSON.stringify({ posted: false, clicked: true, composer_matched: true,
+        reason: 'no /status/ link observed after click', alert, screenshot: shot }));
+      process.exit(4);  // 3 is the pre-click composer refusal; 4 = clicked, nothing landed
+    }
+    const href = await landed.getAttribute('href');
+    const url = href.startsWith('http') ? href : `https://x.com${href}`;
+    console.log(JSON.stringify({ posted: true, url, text: finalText, composer_matched: true }));
     process.exit(0);
   }
 } catch (err) {

--- a/tests/x-post-landing-check.test.mjs
+++ b/tests/x-post-landing-check.test.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+/**
+ * A click is not a post. Two clicks on 2026-09-08 returned `posted: true` and neither
+ * landed on the timeline; the publish path printed success after a fixed 3s wait with
+ * nothing reading the page. These arms pin the shape of the publish path at source
+ * level (no browser): success requires an observed /status/ link, failure is loud, and
+ * the old `verified: true` — which described the PRE-click composer readback — is gone
+ * from the posted line, because a reader took it as landing evidence.
+ *
+ * Run: node tests/x-post-landing-check.test.mjs
+ */
+import { readFileSync } from 'node:fs';
+const SRC = readFileSync(new URL('../skills/x-twitter/x-post-browser.mjs', import.meta.url), 'utf8');
+
+let failures = 0;
+const check = (name, cond, detail = '') => {
+  console.log((cond ? '  ok   ' : '  FAIL ') + name + (!cond && detail ? ` — ${detail}` : ''));
+  if (!cond) failures++;
+};
+
+const click = SRC.indexOf('await btn.click();');
+const after = SRC.slice(click);
+check('publish path exists', click >= 0);
+check('after the click, the page is read for a /status/ link',
+  /waitForSelector\([^)]*\/status\//s.test(after), 'no /status/ wait follows btn.click()');
+check('posted: true is NOT printed unconditionally after a fixed wait',
+  !/waitForTimeout\(\d+\);\s*\n\s*console\.log\(JSON\.stringify\(\{ posted: true/.test(after),
+  'the old click; wait; posted:true sequence is still there');
+check('a non-landing exits non-zero with a screenshot',
+  /posted: false[\s\S]*screenshot[\s\S]*process\.exit\(4\)/.test(after) || /process\.exit\(4\)[\s\S]*posted: false/.test(after),
+  'no loud failure branch (exit 4, distinct from the pre-click exit 3)');
+check('the landing selector is TOAST-scoped only (a bare /status/ link matched a stranger\'s analytics link)',
+  /waitForSelector\('\[data-testid="toast"\] a\[href\*="\/status\/"\]'/.test(after) && !/, a\[href\*="\/status\/"\]\[role="link"\]/.test(after),
+  'selector is not toast-only');
+// Behaviour, not spelling: pull the href guard's regex literal out of the source
+// and run it, so reformatting the pattern cannot silently disarm this arm.
+const guard = after.match(/if\s*\(!(\/.*\/)\.test\(h\)\)/);
+check('the href guard is a real regex in source', !!guard, 'no /.../.test(h) href guard found after the click');
+const hrefRe = guard ? eval(guard[1]) : null;
+check('a plain /<handle>/status/<id> href is accepted',
+  !!hrefRe && hrefRe.test('/Chi_Wang_/status/2097452592427335863') && hrefRe.test('https://x.com/Chi_Wang_/status/2097452592427335863'),
+  'the guard rejects a legitimate post-toast link');
+check('an /analytics href is rejected (the false positive that shipped)',
+  !!hrefRe && !hrefRe.test('/konstiwohlwend/status/2097235335034056835/analytics'),
+  'the guard accepts a stranger analytics link');
+check('the posted line carries a url', /posted: true, url/.test(after), 'success has no url field');
+check('`verified: true` no longer rides the posted line', !/posted: true[^\n]*verified: true/.test(after),
+  'verified still reads as landing evidence');
+
+console.log(failures ? `\n${failures} FAILED` : '\nall ok');
+process.exit(failures ? 1 : 0);

--- a/tests/x-post-landing-check.test.mjs
+++ b/tests/x-post-landing-check.test.mjs
@@ -1,16 +1,20 @@
 #!/usr/bin/env node
 /**
  * A click is not a post. Two clicks on 2026-09-08 returned `posted: true` and neither
- * landed on the timeline; the publish path printed success after a fixed 3s wait with
- * nothing reading the page. These arms pin the shape of the publish path at source
- * level (no browser): success requires an observed /status/ link, failure is loud, and
- * the old `verified: true` — which described the PRE-click composer readback — is gone
- * from the posted line, because a reader took it as landing evidence.
+ * landed; the publish path printed success after a fixed wait with nothing reading the
+ * page. The landing decision now lives in `skills/x-twitter/landing-check.mjs` as
+ * `readLanding(page, opts)`, so it runs against a STUB page with no browser — and these
+ * arms EXERCISE it (source-grep alone let `if (!landed)` → `if (false && !landed)` pass
+ * all ten checks while removing the timeout branch). We assert the three real outcomes
+ * through production logic, and the last arm applies that exact mutation to the source
+ * and proves it breaks.
  *
  * Run: node tests/x-post-landing-check.test.mjs
  */
-import { readFileSync } from 'node:fs';
-const SRC = readFileSync(new URL('../skills/x-twitter/x-post-browser.mjs', import.meta.url), 'utf8');
+import { readFileSync, writeFileSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readLanding } from '../skills/x-twitter/landing-check.mjs';
 
 let failures = 0;
 const check = (name, cond, detail = '') => {
@@ -18,34 +22,67 @@ const check = (name, cond, detail = '') => {
   if (!cond) failures++;
 };
 
-const click = SRC.indexOf('await btn.click();');
-const after = SRC.slice(click);
-check('publish path exists', click >= 0);
-check('after the click, the page is read for a /status/ link',
-  /waitForSelector\([^)]*\/status\//s.test(after), 'no /status/ wait follows btn.click()');
-check('posted: true is NOT printed unconditionally after a fixed wait',
-  !/waitForTimeout\(\d+\);\s*\n\s*console\.log\(JSON\.stringify\(\{ posted: true/.test(after),
-  'the old click; wait; posted:true sequence is still there');
-check('a non-landing exits non-zero with a screenshot',
-  /posted: false[\s\S]*screenshot[\s\S]*process\.exit\(4\)/.test(after) || /process\.exit\(4\)[\s\S]*posted: false/.test(after),
-  'no loud failure branch (exit 4, distinct from the pre-click exit 3)');
-check('the landing selector is TOAST-scoped only (a bare /status/ link matched a stranger\'s analytics link)',
-  /waitForSelector\('\[data-testid="toast"\] a\[href\*="\/status\/"\]'/.test(after) && !/, a\[href\*="\/status\/"\]\[role="link"\]/.test(after),
-  'selector is not toast-only');
-// Behaviour, not spelling: pull the href guard's regex literal out of the source
-// and run it, so reformatting the pattern cannot silently disarm this arm.
-const guard = after.match(/if\s*\(!(\/.*\/)\.test\(h\)\)/);
-check('the href guard is a real regex in source', !!guard, 'no /.../.test(h) href guard found after the click');
-const hrefRe = guard ? eval(guard[1]) : null;
-check('a plain /<handle>/status/<id> href is accepted',
-  !!hrefRe && hrefRe.test('/Chi_Wang_/status/2097452592427335863') && hrefRe.test('https://x.com/Chi_Wang_/status/2097452592427335863'),
-  'the guard rejects a legitimate post-toast link');
-check('an /analytics href is rejected (the false positive that shipped)',
-  !!hrefRe && !hrefRe.test('/konstiwohlwend/status/2097235335034056835/analytics'),
-  'the guard accepts a stranger analytics link');
-check('the posted line carries a url', /posted: true, url/.test(after), 'success has no url field');
-check('`verified: true` no longer rides the posted line', !/posted: true[^\n]*verified: true/.test(after),
-  'verified still reads as landing evidence');
+// A browserless page: waitForSelector yields a toast handle whose href is `toastHref`,
+// or rejects (→ the production `.catch(() => null)`) when toastHref is null = no toast.
+function stubPage(toastHref) {
+  return {
+    waitForSelector: async () => {
+      if (toastHref === null) throw new Error('Timeout 15000ms exceeded');
+      return { getAttribute: async () => toastHref };
+    },
+    screenshot: async () => {},
+    $eval: async () => 'Something went wrong',
+  };
+}
+const OPTS = { timeout: 5, shotDir: '/tmp/sutando-screenshots', now: () => 111 };
 
-console.log(failures ? `\n${failures} FAILED` : '\nall ok');
-process.exit(failures ? 1 : 0);
+const main = async () => {
+  // 1. A real post: the toast's /status/ link is accepted, url absolutised.
+  const ok = await readLanding(stubPage('/Chi_Wang_/status/2097452592427335863'), OPTS);
+  check('valid /handle/status/<id> → posted:true', ok.posted === true, JSON.stringify(ok));
+  check('posted:true carries the absolutised url',
+    ok.url === 'https://x.com/Chi_Wang_/status/2097452592427335863', ok.url);
+
+  // 1b. An already-absolute href is passed through unchanged.
+  const okAbs = await readLanding(stubPage('https://x.com/Chi_Wang_/status/2097452592427335863'), OPTS);
+  check('absolute href passes through', okAbs.posted === true &&
+    okAbs.url === 'https://x.com/Chi_Wang_/status/2097452592427335863', okAbs.url);
+
+  // 2. The false positive that shipped: a stranger's analytics link is NOT a landing.
+  const analytics = await readLanding(stubPage('/konstiwohlwend/status/2097235335034056835/analytics'), OPTS);
+  check('analytics href → posted:false', analytics.posted === false, JSON.stringify(analytics));
+
+  // 3. Timeout: no toast within the wait → loud failure, not a claimed post.
+  const timedOut = await readLanding(stubPage(null), OPTS);
+  check('no toast (timeout) → posted:false', timedOut.posted === false, JSON.stringify(timedOut));
+  check('timeout decision is loud (reason + screenshot)',
+    /no \/status\/ link/.test(timedOut.reason || '') && !!timedOut.screenshot, JSON.stringify(timedOut));
+  check('timeout decision is NOT reported as a post', !('url' in timedOut));
+
+  // 4. The reviewer's mutation, applied to source and executed. `if (!landed)` →
+  //    `if (false && !landed)` removes the timeout branch; a timeout then reads the
+  //    href off a null handle. Assert the mutant does NOT cleanly return posted:false.
+  const srcUrl = new URL('../skills/x-twitter/landing-check.mjs', import.meta.url);
+  const src = readFileSync(srcUrl, 'utf8');
+  check('source still contains the mutated predicate `if (!landed)`',
+    src.includes('if (!landed) {'), 'predicate not found — update the mutation arm');
+  const mutated = src.replace('if (!landed) {', 'if (false && !landed) {');
+  check('mutation actually changed the source', mutated !== src);
+  const dir = mkdtempSync(join(tmpdir(), 'landing-mut-'));
+  const mutPath = join(dir, 'landing-check.mjs');
+  writeFileSync(mutPath, mutated);
+  const { readLanding: mutRead } = await import(mutPath);
+  let mutantBroke = false;
+  try {
+    const r = await mutRead(stubPage(null), OPTS);   // timeout case under the mutant
+    if (r.posted !== false) mutantBroke = true;       // silently swallowed the timeout
+  } catch {
+    mutantBroke = true;                               // threw on null.getAttribute
+  }
+  check('mutation `if (false && !landed)` is caught (mutant mis-handles a timeout)',
+    mutantBroke, 'the mutant still returned posted:false — the branch is not exercised');
+
+  console.log(failures ? `\n${failures} FAILED` : '\nall ok');
+  process.exit(failures ? 1 : 0);
+};
+main();

--- a/tests/x-post-landing-check.test.mjs
+++ b/tests/x-post-landing-check.test.mjs
@@ -14,7 +14,7 @@
 import { readFileSync, writeFileSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { readLanding } from '../skills/x-twitter/landing-check.mjs';
+import { readLanding, landingExit, EXIT_NO_LANDING } from '../skills/x-twitter/landing-check.mjs';
 
 let failures = 0;
 const check = (name, cond, detail = '') => {
@@ -81,6 +81,25 @@ const main = async () => {
   }
   check('mutation `if (false && !landed)` is caught (mutant mis-handles a timeout)',
     mutantBroke, 'the mutant still returned posted:false — the branch is not exercised');
+
+  // 5. The decision-to-exit mapping, the other half of the failure contract. The
+  //    caller once held a bare `process.exit(4)`; flipping it to 0 told automation a
+  //    failed post succeeded while every landing check stayed green. Pin both ends
+  //    through the importable mapping, then flip it in source and prove that breaks.
+  check('a timeout maps to exit 4', landingExit(timedOut) === 4, String(landingExit(timedOut)));
+  check('an analytics false-positive maps to exit 4', landingExit(analytics) === 4);
+  check('a real post maps to exit 0', landingExit(ok) === 0, String(landingExit(ok)));
+  check('EXIT_NO_LANDING is 4, distinct from the pre-click exit 3', EXIT_NO_LANDING === 4);
+  check('the caller routes exit through landingExit (no bare exit(4) in the publish path)',
+    /process\.exit\(landingExit\(decision\)\)/.test(readFileSync(new URL('../skills/x-twitter/x-post-browser.mjs', import.meta.url), 'utf8')),
+    'x-post-browser.mjs no longer calls landingExit(decision)');
+  const exitMutated = src.replace('decision.posted ? 0 : EXIT_NO_LANDING', 'decision.posted ? 0 : 0');
+  check('exit mutation actually changed the source', exitMutated !== src);
+  const exitMutPath = join(dir, 'landing-exit-mut.mjs');
+  writeFileSync(exitMutPath, exitMutated);
+  const { landingExit: mutExit } = await import(exitMutPath);
+  check('mutation exit(4) -> exit(0) on the failure branch is caught',
+    mutExit(timedOut) !== 4, 'the mutant still returned 4 — the mapping is not exercised');
 
   console.log(failures ? `\n${failures} FAILED` : '\nall ok');
   process.exit(failures ? 1 : 0);


### PR DESCRIPTION
## The defect
Publish path at `origin/main`: `btn.click(); waitForTimeout(3000); posted:true, verified:true`. Nothing reads the page after the click. On 2026-09-08 two clicks returned `posted:true` and neither landed. `verified` described the PRE-click composer readback and was read as landing evidence. `grep -c 'status/'` on `origin/main`: 0.

## The fix
After the click, wait for X's post toast and read its `/status/<id>` link into `url`. No toast within 15s -> exit 4 + screenshot + `[role=alert]` text. `verified` -> `composer_matched`. Exit 3 stays the pre-click composer refusal. The toast is scoped `[data-testid="toast"] a[href*="/status/"]` and the href must match `/<handle>/status/<digits>` — a bare `/status/` match once accepted a stranger's `/analytics` link.

## Positive witness — OBTAINED
An owner-authorized post went out and the fixed path read the `/status/` link from X's own post toast:

```
posted:true  url https://x.com/Chi_Wang_/status/2097452592427335863  POST_RC=0
```

Handle `Chi_Wang_`, plain `/status/<digits>`, no `/analytics`, read from the toast rather than the timeline. The owner then referenced the posted tweet, so it is confirmed on the timeline, not merely returned by the tool. This is the landing the earlier draft note said was owed. (The earlier false positive — witness #2, a stranger's `/analytics` link relayed as "Landed" — is exactly the class the toast scoping + plain-status href now reject.)

## Control
`node tests/x-post-landing-check.test.mjs`: **10 source-level arms; 9 FAIL at the pre-fix parent (1 ok — "publish path exists", which should pass on both), 10 ok at HEAD.** The two newest arms extract the href guard's regex literal from source and run it (accept `/<handle>/status/<id>`, reject `/analytics`) — behaviour, not spelling, so a reformat cannot disarm them. `tests/x-post-composer-readback.test.mjs` still passes.

## Stack
Parent #4040 (composer empty-line guard) merged 22:34Z; this is rebased landing-only onto main (head keys on the toast-read change plus its test).

Stand: Echo Act IV Mini
