### PR TITLE
fix(hooks): one installer merge that also prunes dead copies of the same hook

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -42,6 +42,7 @@ One entry per agent-facing module. 5 without a usable header comment.
 - **`check-pending-questions.py`** — Check pending questions and notify if unanswered.
 - **`check-pending-tasks.sh`** — Stop hook: blocks Claude from finishing when unprocessed tasks exist.
 - **`claude_config_dir.sh`** — Shared CLAUDE_CONFIG_DIR resolution for start-cli.sh and startup.sh.
+- **`claude_hooks_settings.py`** — Sutando-owned hook entries in a project-level Claude Code settings.json: install one idempotently and prune dead copies of the same hook.
 - **`cli_wedge.py`** — CLI progress detector for the core's tmux pane — advisory only.
 - **`context-drop.sh`** — Sutando context drop — triggered by macOS hotkey via Automator Quick Action.
 - **`context_resume.py`** — Extract recent conversation turns from a Claude Code transcript (.jsonl).

--- a/scripts/install-personal-claude-hook.sh
+++ b/scripts/install-personal-claude-hook.sh
@@ -43,40 +43,9 @@ if [ ! -f "$SETTINGS" ]; then
   echo '{"hooks":{}}' > "$SETTINGS"
 fi
 
-# Idempotent merge (avoids jq dependency). `python3 -` (not `/dev/stdin`):
-# /dev/stdin is a silent no-op under some sandboxed environments (caught in
-# review on this PR — the merge never ran and settings.json stayed {"hooks":{}}),
-# while `-` reads the program from stdin portably and matches the hint
-# script's own pattern.
-"$PY" - "$SETTINGS" "$HOOK_CMD" <<'PYEOF'
-import json, sys
-
-settings_path = sys.argv[1]
-hook_cmd = sys.argv[2]
-
-with open(settings_path) as f:
-    settings = json.load(f)
-
-hooks = settings.setdefault("hooks", {})
-session_start = hooks.setdefault("SessionStart", [])
-
-# Already present in any entry → no-op
-for entry in session_start:
-    for h in entry.get("hooks", []):
-        if h.get("command", "") == hook_cmd:
-            print("  ✓ PERSONAL_CLAUDE compact-reinject hook (already installed)")
-            sys.exit(0)
-
-# "compact" matcher: fire ONLY after context compaction, not on
-# startup/resume/clear — those paths already Read the file per CLAUDE.md.
-session_start.append({
-    "matcher": "compact",
-    "hooks": [{"type": "command", "command": hook_cmd}]
-})
-
-with open(settings_path, "w") as f:
-    json.dump(settings, f, indent=2)
-    f.write("\n")
-
-print("  ✓ PERSONAL_CLAUDE compact-reinject hook (installed)")
-PYEOF
+# One merge for every Sutando hook installer (src/claude_hooks_settings.py): adds this
+# entry once and removes dead copies of the SAME hook — entries whose script no longer
+# exists, e.g. left by a test run from a temp copy of the repo. Other hooks are untouched.
+"$PY" "$REPO/src/claude_hooks_settings.py" install --settings "$SETTINGS" \
+  --event SessionStart --command "$HOOK_CMD" --matcher compact \
+  --label "PERSONAL_CLAUDE compact-reinject hook"

--- a/scripts/install-session-start-hook.sh
+++ b/scripts/install-session-start-hook.sh
@@ -43,35 +43,14 @@ if [ ! -f "$SETTINGS" ]; then
   echo '{"hooks":{}}' > "$SETTINGS"
 fi
 
-# Use Python to do the idempotent merge (avoids jq dependency)
-python3 /dev/stdin "$SETTINGS" "$HOOK_CMD" <<'PYEOF'
-import json, sys
-
-settings_path = sys.argv[1]
-hook_cmd = sys.argv[2]
-
-with open(settings_path) as f:
-    settings = json.load(f)
-
-hooks = settings.setdefault("hooks", {})
-session_start = hooks.setdefault("SessionStart", [])
-
-# Check if our hook command is already present in any entry
-for entry in session_start:
-    for h in entry.get("hooks", []):
-        if h.get("command", "") == hook_cmd:
-            print("  ✓ schedule-crons SessionStart hook (already installed)")
-            sys.exit(0)
-
-# Not found — prepend our entry so it fires first
-session_start.insert(0, {
-    "matcher": "",
-    "hooks": [{"type": "command", "command": hook_cmd}]
-})
-
-with open(settings_path, "w") as f:
-    json.dump(settings, f, indent=2)
-    f.write("\n")
-
-print("  ✓ schedule-crons SessionStart hook (installed)")
-PYEOF
+# One merge for every Sutando hook installer (src/claude_hooks_settings.py): adds this
+# entry once, first so it fires first, and removes dead copies of the same hook.
+PY=""
+if [ -r "$REPO/scripts/python-binary.sh" ]; then
+  . "$REPO/scripts/python-binary.sh"
+  PY="$(resolve_python "$REPO")"
+fi
+[ -n "$PY" ] && [ -x "$PY" ] || PY="python3"
+"$PY" "$REPO/src/claude_hooks_settings.py" install --settings "$SETTINGS" \
+  --event SessionStart --command "$HOOK_CMD" --matcher "" --prepend \
+  --label "schedule-crons SessionStart hook"

--- a/src/claude_hooks_settings.py
+++ b/src/claude_hooks_settings.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Sutando-owned hook entries in a project-level Claude Code settings.json: install one idempotently and prune dead copies of the same hook.
+
+Two installers (``scripts/install-personal-claude-hook.sh``,
+``scripts/install-session-start-hook.sh``) carried their own inline merge. Each
+could add its entry but neither could remove one, so a test run from a copy of
+the repo under a temp dir left the live settings pointing at three deleted
+``/var/folders/…/repo/src/…`` scripts, and every compaction fired all four.
+
+Pruning is scoped to the SAME FAMILY as the hook being installed — entries whose
+command runs a script with the same basename — and only when that script no
+longer exists. A user's own hooks, dead or alive, are never touched.
+
+    python3 src/claude_hooks_settings.py install --settings <path> \\
+        --event SessionStart --command 'bash "<repo>/src/x.sh"' \\
+        [--matcher compact] [--prepend] [--label "x hook"]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+import sys
+from pathlib import Path
+from typing import Iterable, Optional
+
+_INTERPRETERS = {"bash", "sh", "zsh", "python", "python3", "node"}
+
+
+def script_path_of(command: str) -> Optional[str]:
+    """The script a hook command runs: the first token after an interpreter, else the first token."""
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        tokens = command.split()
+    if not tokens:
+        return None
+    for index, token in enumerate(tokens):
+        if os.path.basename(token) in _INTERPRETERS:
+            return tokens[index + 1] if index + 1 < len(tokens) else None
+        if not token.startswith("-"):
+            return token
+    return None
+
+
+def family_of(command: str) -> str:
+    path = script_path_of(command)
+    return os.path.basename(path) if path else ""
+
+
+def load(settings_path: Path) -> dict:
+    if not settings_path.is_file():
+        return {"hooks": {}}
+    data = json.loads(settings_path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{settings_path}: top level is not an object")
+    data.setdefault("hooks", {})
+    return data
+
+
+def save(settings_path: Path, settings: dict) -> None:
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = settings_path.with_suffix(settings_path.suffix + ".tmp")
+    tmp.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
+    os.replace(tmp, settings_path)
+
+
+def prune_dead(settings: dict, event: str, family: str) -> list[str]:
+    """Remove hooks under ``event`` that run a script named ``family`` which no longer exists.
+
+    Returns the removed commands. Entries left with no hooks are dropped too.
+    """
+    if not family:
+        return []
+    removed: list[str] = []
+    kept_entries = []
+    for entry in settings.get("hooks", {}).get(event, []) or []:
+        if not isinstance(entry, dict):
+            kept_entries.append(entry)
+            continue
+        kept_hooks = []
+        for hook in entry.get("hooks", []) or []:
+            command = str(hook.get("command", "")) if isinstance(hook, dict) else ""
+            path = script_path_of(command)
+            if family_of(command) == family and path and not os.path.exists(path):
+                removed.append(command)
+                continue
+            kept_hooks.append(hook)
+        if kept_hooks:
+            kept_entries.append(dict(entry, hooks=kept_hooks))
+    if removed:
+        settings.setdefault("hooks", {})[event] = kept_entries
+    return removed
+
+
+def install(
+    settings_path: Path,
+    *,
+    event: str,
+    command: str,
+    matcher: str = "",
+    prepend: bool = False,
+) -> tuple[str, list[str]]:
+    """Prune dead same-family entries, then add ``command`` once. Returns (status, removed)."""
+    settings = load(settings_path)
+    removed = prune_dead(settings, event, family_of(command))
+    entries = settings.setdefault("hooks", {}).setdefault(event, [])
+    present = any(
+        isinstance(h, dict) and h.get("command", "") == command
+        for entry in entries if isinstance(entry, dict)
+        for h in entry.get("hooks", []) or []
+    )
+    if present:
+        status = "already installed"
+    else:
+        new_entry = {"matcher": matcher, "hooks": [{"type": "command", "command": command}]}
+        if prepend:
+            entries.insert(0, new_entry)
+        else:
+            entries.append(new_entry)
+        status = "installed"
+    if status == "installed" or removed or not settings_path.is_file():
+        save(settings_path, settings)
+    return status, removed
+
+
+def _describe_removed(removed: Iterable[str], family: str) -> str:
+    items = list(removed)
+    noun = "entry" if len(items) == 1 else "entries"
+    paths = ", ".join(script_path_of(c) or c for c in items)
+    return f"  ✂ removed {len(items)} dead {family} {noun}: {paths}"
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    p = sub.add_parser("install")
+    p.add_argument("--settings", required=True)
+    p.add_argument("--event", default="SessionStart")
+    p.add_argument("--command", required=True)
+    p.add_argument("--matcher", default="")
+    p.add_argument("--prepend", action="store_true")
+    p.add_argument("--label", default=None)
+    args = parser.parse_args(argv)
+    label = args.label or f"{family_of(args.command)} {args.event} hook"
+    try:
+        status, removed = install(
+            Path(args.settings), event=args.event, command=args.command,
+            matcher=args.matcher, prepend=args.prepend,
+        )
+    except (OSError, ValueError) as exc:
+        print(f"  ✗ {label}: {exc}", file=sys.stderr)
+        return 1
+    if removed:
+        print(_describe_removed(removed, family_of(args.command)))
+    print(f"  ✓ {label} ({status})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/claude_hooks_settings.py
+++ b/src/claude_hooks_settings.py
@@ -16,7 +16,10 @@ prune (the script is merely unreachable at launch) costs ONE launch without that
 hook, because every installer re-adds its own command at the next core launch.
 A missed prune (a dead copy left in place) costs every compaction until a human
 notices — which is how this reached the owner. So the predicate stays broad and
-the blast radius is bounded by family, not by path shape.
+the blast radius is bounded by family, not by path shape — with one exception: a
+path carrying an unexpanded variable is skipped, because the installer would re-add
+its own ABSOLUTE command, never the portable one, so that false prune is permanent
+rather than costing one launch.
 
     python3 src/claude_hooks_settings.py install --settings <path> \\
         --event SessionStart --command 'bash "<repo>/src/x.sh"' \\
@@ -75,6 +78,11 @@ def save(settings_path: Path, settings: dict) -> None:
     os.replace(tmp, settings_path)
 
 
+def _judgeable(path: str) -> bool:
+    """False when the path carries an unexpanded variable, which no existence check can decide."""
+    return "$" not in path
+
+
 def _exists(path: str, project_dir: Optional[Path]) -> bool:
     """A relative script path is relative to the project the settings file belongs to."""
     candidate = Path(path)
@@ -103,7 +111,8 @@ def prune_dead(settings: dict, event: str, family: str,
         for hook in entry.get("hooks", []) or []:
             command = str(hook.get("command", "")) if isinstance(hook, dict) else ""
             path = script_path_of(command)
-            if family_of(command) == family and path and not _exists(path, project_dir):
+            if (family_of(command) == family and path and _judgeable(path)
+                    and not _exists(path, project_dir)):
                 removed.append(command)
                 continue
             kept_hooks.append(hook)

--- a/src/claude_hooks_settings.py
+++ b/src/claude_hooks_settings.py
@@ -68,10 +68,21 @@ def save(settings_path: Path, settings: dict) -> None:
     os.replace(tmp, settings_path)
 
 
-def prune_dead(settings: dict, event: str, family: str) -> list[str]:
+def _exists(path: str, project_dir: Optional[Path]) -> bool:
+    """A relative script path is relative to the project the settings file belongs to."""
+    candidate = Path(path)
+    if not candidate.is_absolute() and project_dir is not None:
+        candidate = project_dir / candidate
+    return candidate.exists()
+
+
+def prune_dead(settings: dict, event: str, family: str,
+               project_dir: Optional[Path] = None) -> list[str]:
     """Remove hooks under ``event`` that run a script named ``family`` which no longer exists.
 
-    Returns the removed commands. Entries left with no hooks are dropped too.
+    Returns the removed commands. Entries left with no hooks are dropped too. A relative
+    script path is checked against ``project_dir`` (the settings file's project), never the
+    caller's cwd, so a live relative hook cannot read as dead.
     """
     if not family:
         return []
@@ -85,7 +96,7 @@ def prune_dead(settings: dict, event: str, family: str) -> list[str]:
         for hook in entry.get("hooks", []) or []:
             command = str(hook.get("command", "")) if isinstance(hook, dict) else ""
             path = script_path_of(command)
-            if family_of(command) == family and path and not os.path.exists(path):
+            if family_of(command) == family and path and not _exists(path, project_dir):
                 removed.append(command)
                 continue
             kept_hooks.append(hook)
@@ -106,7 +117,9 @@ def install(
 ) -> tuple[str, list[str]]:
     """Prune dead same-family entries, then add ``command`` once. Returns (status, removed)."""
     settings = load(settings_path)
-    removed = prune_dead(settings, event, family_of(command))
+    # <project>/.claude/settings.json → the project is two levels up.
+    project_dir = settings_path.resolve().parent.parent
+    removed = prune_dead(settings, event, family_of(command), project_dir=project_dir)
     entries = settings.setdefault("hooks", {}).setdefault(event, [])
     present = any(
         isinstance(h, dict) and h.get("command", "") == command

--- a/src/claude_hooks_settings.py
+++ b/src/claude_hooks_settings.py
@@ -11,6 +11,13 @@ Pruning is scoped to the SAME FAMILY as the hook being installed — entries who
 command runs a script with the same basename — and only when that script no
 longer exists. A user's own hooks, dead or alive, are never touched.
 
+Why a bare existence check is enough: the two costs are asymmetric. A false
+prune (the script is merely unreachable at launch) costs ONE launch without that
+hook, because every installer re-adds its own command at the next core launch.
+A missed prune (a dead copy left in place) costs every compaction until a human
+notices — which is how this reached the owner. So the predicate stays broad and
+the blast radius is bounded by family, not by path shape.
+
     python3 src/claude_hooks_settings.py install --settings <path> \\
         --event SessionStart --command 'bash "<repo>/src/x.sh"' \\
         [--matcher compact] [--prepend] [--label "x hook"]

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -9064,7 +9064,31 @@ def apply_claude_hooks_fix(checks: list, stream=None) -> None:
     """
     out = stream if stream is not None else sys.stdout
     for c in checks:
-        if c["name"] != "claude-hooks" or not c.get("_unregistered_hooks"):
+        if c["name"] != "claude-hooks" or not (c.get("_unregistered_hooks") or c.get("_dead_hooks")):
+            continue
+        for rec in c.get("_dead_hooks") or []:
+            owner_script = _HOOK_FAMILY_INSTALLERS.get(str(rec.get("family")))
+            if not owner_script:
+                print(f"  {c['name']}: not repairing dead {rec.get('event')} hook "
+                      f"{rec.get('path')} — not a family a Sutando installer owns", file=out)
+                continue
+        for owner_script in sorted({_HOOK_FAMILY_INSTALLERS[r["family"]]
+                                    for r in c.get("_dead_hooks") or []
+                                    if r.get("family") in _HOOK_FAMILY_INSTALLERS}):
+            print(f"  {c['name']}: pruning dead entries via {Path(owner_script).name}", file=out)
+            try:
+                proc = subprocess.run(["bash", str(REPO_DIR / owner_script)],
+                                      capture_output=True, text=True, timeout=60)
+                emitted = (proc.stdout or "") + (proc.stderr or "")
+                lines = [ln for ln in emitted.splitlines() if ln.strip()]
+                print(f"  {c['name']}: " + (lines[-1].strip() if lines
+                                           else f"installer exited {proc.returncode}"), file=out)
+            except Exception as exc:  # noqa: BLE001 — a failed repair must warn, not raise
+                print(f"  {c['name']}: could not run {Path(owner_script).name} ({exc})", file=out)
+        if not c.get("_unregistered_hooks"):
+            fresh = check_claude_hook_registration()
+            c.clear()
+            c.update(fresh)
             continue
         installer = REPO_DIR / "src" / "install-claude-hooks.sh"
         # Sutando.app runs `--fix` on a 30-minute Timer, so this repair is normally
@@ -10862,6 +10886,39 @@ def check_vault_manifest_integrity(
     }
 
 
+def _hook_script_path(command: str) -> Optional[str]:
+    """The script a hook command runs; the installer module owns the parse, this is a fallback."""
+    try:
+        sys.path.insert(0, str(REPO_DIR / "src"))
+        from claude_hooks_settings import script_path_of
+        return script_path_of(command)
+    except Exception:  # noqa: BLE001 — an older checkout without the module still gets a probe
+        parts = command.split()
+        for i, tok in enumerate(parts):
+            if tok in ("bash", "sh", "python3", "python", "node"):
+                return parts[i + 1].strip("'\"") if i + 1 < len(parts) else None
+        return parts[0].strip("'\"") if parts else None
+
+
+def _runs_a_script(command: str) -> bool:
+    """True when the command hands a script FILE to an interpreter (bash/sh/python/node).
+
+    `bash -c '…'` runs inline text, not a file, and a command carrying an unexpanded `$VAR`
+    cannot be judged by path existence; both are skipped rather than read as dead.
+    """
+    parts = command.split()
+    if len(parts) < 2 or Path(parts[0]).name not in ("bash", "sh", "zsh", "python", "python3", "node"):
+        return False
+    return not parts[1].startswith("-") and "$" not in command
+
+
+#: Which installer re-adds (and, since it prunes, repairs) each Sutando-owned hook family.
+_HOOK_FAMILY_INSTALLERS = {
+    "personal-claude-compact-hint.sh": "scripts/install-personal-claude-hook.sh",
+    "schedule-crons-session-hint.sh": "scripts/install-session-start-hook.sh",
+}
+
+
 def check_claude_hook_registration(
     repo_dir: Optional[Path] = None,
 ) -> dict:
@@ -10991,10 +11048,40 @@ def check_claude_hook_registration(
             # Present, but not actually invoking this checkout's script — either aimed
             # at another checkout or carrying the path as an inert argument.
             foreign.append(f"{event}:{marker}")
-    if missing or foreign:
+    # Present-but-dead is invisible to the owned-list check above: a registered hook whose
+    # script is gone fails on every fire. Relative paths resolve against the project.
+    dead: list[str] = []
+    dead_records: list[dict] = []
+    project_dir = settings.resolve().parent.parent
+    # Owned families are judged above (present / missing / foreign); the dead scan covers
+    # the rest, and only commands that run a script through an interpreter.
+    owned_families = {Path(marker).name for _e, marker, _c in owned}
+    for event, groups in hooks.items():
+        for g in _as_list(groups):
+            if not isinstance(g, dict):
+                continue
+            for h in _as_list(g.get("hooks")):
+                if not isinstance(h, dict):
+                    continue
+                cmd = str(h.get("command", ""))
+                if not _runs_a_script(cmd):
+                    continue
+                script = _hook_script_path(cmd)
+                if not script or Path(script).name in owned_families:
+                    continue
+                target = Path(script) if Path(script).is_absolute() else project_dir / script
+                if not target.exists():
+                    family = Path(script).name
+                    dead.append(f"{event}:{family} -> {script}")
+                    dead_records.append({"event": event, "command": cmd,
+                                         "path": script, "family": family})
+    if missing or foreign or dead:
         bits = []
         if missing:
             bits.append(f"{len(missing)} NOT registered ({', '.join(missing)})")
+        if dead:
+            bits.append(f"{len(dead)} registered but the script no longer exists — every fire "
+                        f"fails 'No such file' ({', '.join(dead)})")
         if foreign:
             bits.append(f"{len(foreign)} registered but NOT running the installer's command "
                         f"— a different program, another checkout, or the path is "
@@ -11007,12 +11094,18 @@ def check_claude_hook_registration(
                   "you intend to enable it"
                   if only_archive else
                   "re-run `SUTANDO_HOOKS_OMIT_TRANSCRIPT_ARCHIVE=1 bash src/install-claude-hooks.sh`")
+        if dead and not missing and not foreign:
+            remedy = ("re-run the installer that owns each family — it prunes dead copies "
+                      "(`bash scripts/install-personal-claude-hook.sh`, "
+                      "`bash scripts/install-session-start-hook.sh`)")
         result = {"name": name, "status": "warn",
                   "detail": f"{'; '.join(bits)} in {settings} — {remedy}"}
         if missing:
             # Keyed structurally so --fix cannot fire on the warn branches the
             # installer can't repair; `foreign` excluded (displacement unverified).
             result["_unregistered_hooks"] = list(missing)
+        if dead_records:
+            result["_dead_hooks"] = dead_records
         return result
     return {"name": name, "status": "ok", "detail": f"all {len(owned)} owned hooks registered"}
 

--- a/tests/claude-hooks-autofix.test.py
+++ b/tests/claude-hooks-autofix.test.py
@@ -171,5 +171,51 @@ class DispatchWiring(unittest.TestCase):
         )
 
 
+class TestDeadHookRepair(FixHandlerGating):
+    """Dead entries are repaired by the installer that owns their family, which prunes them."""
+
+    def _dead(self, family, path="/var/folders/x/repo/src/hint.sh"):
+        return {"name": "claude-hooks", "status": "warn", "detail": "x",
+                "_dead_hooks": [{"event": "SessionStart", "command": f'bash "{path}"',
+                                 "path": path, "family": family}]}
+
+    def test_a_dead_compact_hint_runs_its_own_installer_once(self):
+        calls = self._run(self._dead("personal-claude-compact-hint.sh"))
+        self.assertEqual(len(calls), 1, calls)
+        self.assertIn("install-personal-claude-hook.sh", " ".join(map(str, calls[0])))
+
+    def test_two_dead_entries_of_one_family_run_the_installer_once(self):
+        check = self._dead("schedule-crons-session-hint.sh")
+        check["_dead_hooks"].append(dict(check["_dead_hooks"][0], path="/elsewhere/hint.sh"))
+        calls = self._run(check)
+        self.assertEqual(len(calls), 1, calls)
+        self.assertIn("install-session-start-hook.sh", " ".join(map(str, calls[0])))
+
+    def test_an_owning_installer_that_fails_warns_instead_of_raising(self):
+        import io
+        real, real_probe = subprocess.run, hc.check_claude_hook_registration
+
+        def boom(cmd, *a, **k):
+            raise OSError("bash vanished")
+
+        hc.subprocess.run = boom
+        hc.check_claude_hook_registration = lambda *a, **k: {"name": "claude-hooks", "status": "warn", "detail": "still dead"}
+        buf = io.StringIO()
+        try:
+            hc.apply_claude_hooks_fix([self._dead("personal-claude-compact-hint.sh")], stream=buf)
+        finally:
+            hc.subprocess.run = real
+            hc.check_claude_hook_registration = real_probe
+        self.assertIn("could not run install-personal-claude-hook.sh", buf.getvalue())
+        self.assertIn("bash vanished", buf.getvalue())
+
+    def test_a_foreign_family_is_reported_not_deleted(self):
+        import io
+        buf = io.StringIO()
+        calls = self._run(self._dead("someone-elses-tool.sh"), out=buf)
+        self.assertEqual(calls, [])
+        self.assertIn("not a family a Sutando installer owns", buf.getvalue())
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/claude-hooks-settings.test.py
+++ b/tests/claude-hooks-settings.test.py
@@ -91,6 +91,26 @@ with tempfile.TemporaryDirectory() as tmp:
     check(f'bash "{foreign_live}"' in cmds, "a live foreign hook is left alone")
     check(len(after["hooks"]["Stop"]) == 1, "other events are untouched even for the same family")
 
+    # ── a relative live path is judged against the project, not the cwd ──────
+    rel_proj = tmp / "relproj"
+    (rel_proj / "src").mkdir(parents=True)
+    (rel_proj / "src" / "personal-claude-compact-hint.sh").write_text("#!/bin/bash\n")
+    rel_settings = rel_proj / ".claude" / "settings.json"
+    rel_settings.parent.mkdir(parents=True)
+    rel_settings.write_text(json.dumps({"hooks": {"SessionStart": [
+        entry('bash "src/personal-claude-compact-hint.sh"'),
+        entry('bash "src/gone/personal-claude-compact-hint.sh"')]}}))
+    cwd = os.getcwd()
+    os.chdir(tmp)  # somewhere the relative path does NOT resolve from
+    try:
+        status, removed = chs.install(rel_settings, event="SessionStart", command=live_cmd, matcher="compact")
+    finally:
+        os.chdir(cwd)
+    kept_rel = [h["command"] for e in json.loads(rel_settings.read_text())["hooks"]["SessionStart"] for h in e["hooks"]]
+    check('bash "src/personal-claude-compact-hint.sh"' in kept_rel and len(removed) == 1
+          and "src/gone/" in removed[0], "a relative live path is kept and a relative dead one removed, judged from the project dir",
+          f"kept={kept_rel} removed={removed}")
+
     # ── prepend ───────────────────────────────────────────────────────────────
     first_cmd = f'bash "{foreign_live}"'
     ordered = tmp / "ordered" / ".claude" / "settings.json"

--- a/tests/claude-hooks-settings.test.py
+++ b/tests/claude-hooks-settings.test.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""claude_hooks_settings: install once, prune dead copies of the same hook, touch nothing else.
+
+The live defect: three SessionStart entries pointing at deleted /var/folders/…/repo/src/
+personal-claude-compact-hint.sh copies, left by test runs; every compaction fired all four
+and three failed "No such file". Neither installer could remove an entry.
+
+Run: python3 tests/claude-hooks-settings.test.py
+Exit: 0 = all pass, 1 = failure
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+import claude_hooks_settings as chs  # noqa: E402
+
+_pass = 0
+_fail = 0
+
+
+def ok(label):
+    global _pass
+    print(f"  PASS: {label}")
+    _pass += 1
+
+
+def fail(label, detail=""):
+    global _fail
+    print(f"  FAIL: {label}" + (f" — {detail}" if detail else ""), file=sys.stderr)
+    _fail += 1
+
+
+def check(cond, label, detail=""):
+    ok(label) if cond else fail(label, detail)
+
+
+def entry(cmd, matcher="compact"):
+    return {"matcher": matcher, "hooks": [{"type": "command", "command": cmd}]}
+
+
+with tempfile.TemporaryDirectory() as tmp:
+    tmp = Path(tmp)
+    live = tmp / "repo" / "src" / "personal-claude-compact-hint.sh"
+    live.parent.mkdir(parents=True)
+    live.write_text("#!/bin/bash\n")
+    live_cmd = f'bash "{live}"'
+    dead_cmds = [f'bash "{tmp}/gone{i}/repo/src/personal-claude-compact-hint.sh"' for i in range(3)]
+    foreign_dead = f'bash "{tmp}/gone/other-tool.sh"'
+    foreign_live = tmp / "mine.sh"
+    foreign_live.write_text("#!/bin/bash\n")
+
+    # ── script_path_of / family_of ────────────────────────────────────────────
+    check(chs.script_path_of(live_cmd) == str(live), "script path parsed from a quoted bash command")
+    check(chs.script_path_of("python3 '/x/y/z.py' --flag") == "/x/y/z.py", "script path parsed after an interpreter")
+    check(chs.family_of(dead_cmds[0]) == "personal-claude-compact-hint.sh", "family is the script basename")
+    check(chs.family_of("") == "", "an empty command has no family")
+
+    # ── fresh install ─────────────────────────────────────────────────────────
+    settings = tmp / "fresh" / ".claude" / "settings.json"
+    status, removed = chs.install(settings, event="SessionStart", command=live_cmd, matcher="compact")
+    data = json.loads(settings.read_text())
+    check(status == "installed" and removed == [], "fresh install reports installed, removes nothing")
+    check(data["hooks"]["SessionStart"] == [entry(live_cmd)], "fresh install writes one entry with the matcher")
+
+    # ── idempotent ────────────────────────────────────────────────────────────
+    status, removed = chs.install(settings, event="SessionStart", command=live_cmd, matcher="compact")
+    check(status == "already installed" and len(json.loads(settings.read_text())["hooks"]["SessionStart"]) == 1,
+          "a second install is a no-op")
+
+    # ── prune dead same-family entries, keep everything else ──────────────────
+    polluted = tmp / "polluted" / ".claude" / "settings.json"
+    polluted.parent.mkdir(parents=True)
+    polluted.write_text(json.dumps({"hooks": {
+        "SessionStart": [entry(live_cmd)] + [entry(c) for c in dead_cmds]
+                        + [entry(foreign_dead, matcher="")] + [entry(f'bash "{foreign_live}"', matcher="")],
+        "Stop": [entry('bash "/nowhere/personal-claude-compact-hint.sh"', matcher="")],
+    }}))
+    status, removed = chs.install(polluted, event="SessionStart", command=live_cmd, matcher="compact")
+    after = json.loads(polluted.read_text())
+    cmds = [h["command"] for e in after["hooks"]["SessionStart"] for h in e["hooks"]]
+    check(status == "already installed", "the live entry is recognised as present")
+    check(sorted(removed) == sorted(dead_cmds), "exactly the three dead same-family entries are removed",
+          f"removed={removed}")
+    check(live_cmd in cmds, "the live same-family entry stays")
+    check(foreign_dead in cmds, "a dead hook of ANOTHER family is left alone")
+    check(f'bash "{foreign_live}"' in cmds, "a live foreign hook is left alone")
+    check(len(after["hooks"]["Stop"]) == 1, "other events are untouched even for the same family")
+
+    # ── prepend ───────────────────────────────────────────────────────────────
+    first_cmd = f'bash "{foreign_live}"'
+    ordered = tmp / "ordered" / ".claude" / "settings.json"
+    chs.install(ordered, event="SessionStart", command=f'bash "{live}"', matcher="")
+    chs.install(ordered, event="SessionStart", command=first_cmd, matcher="", prepend=True)
+    data = json.loads(ordered.read_text())
+    check(data["hooks"]["SessionStart"][0]["hooks"][0]["command"] == first_cmd, "prepend puts the entry first")
+
+    # ── CLI ───────────────────────────────────────────────────────────────────
+    cli_settings = tmp / "cli" / ".claude" / "settings.json"
+    cli_settings.parent.mkdir(parents=True)
+    cli_settings.write_text(json.dumps({"hooks": {"SessionStart": [entry(dead_cmds[0])]}}))
+    r = subprocess.run([sys.executable, str(REPO / "src" / "claude_hooks_settings.py"), "install",
+                        "--settings", str(cli_settings), "--command", live_cmd, "--matcher", "compact",
+                        "--label", "PERSONAL_CLAUDE compact-reinject hook"],
+                       capture_output=True, text=True, timeout=30)
+    check(r.returncode == 0 and "removed 1 dead personal-claude-compact-hint.sh entry" in r.stdout
+          and "PERSONAL_CLAUDE compact-reinject hook (installed)" in r.stdout,
+          "the CLI names what it removed and what it installed", r.stdout + r.stderr)
+
+    # ── malformed settings fail loudly, never silently succeed ────────────────
+    bad = tmp / "bad" / ".claude" / "settings.json"
+    bad.parent.mkdir(parents=True)
+    bad.write_text("[]")
+    r = subprocess.run([sys.executable, str(REPO / "src" / "claude_hooks_settings.py"), "install",
+                        "--settings", str(bad), "--command", live_cmd], capture_output=True, text=True)
+    check(r.returncode == 1 and "not an object" in r.stderr, "a malformed settings file is refused with a reason")
+
+    # ── the real installer prunes too (it is what runs on every core launch) ──
+    work = tmp / "work"
+    (work / ".claude").mkdir(parents=True)
+    (work / ".claude" / "settings.json").write_text(json.dumps({"hooks": {
+        "SessionStart": [entry(c) for c in dead_cmds]}}))
+    env = dict(os.environ, SUTANDO_CLAUDE_WORKING_DIR=str(work))
+    r = subprocess.run(["bash", str(REPO / "scripts" / "install-personal-claude-hook.sh")],
+                       capture_output=True, text=True, env=env, timeout=30)
+    data = json.loads((work / ".claude" / "settings.json").read_text())
+    fam = [h["command"] for e in data["hooks"]["SessionStart"] for h in e["hooks"]
+           if "personal-claude-compact-hint.sh" in h["command"]]
+    check(r.returncode == 0 and len(fam) == 1 and str(REPO) in fam[0] and "removed 3 dead" in r.stdout,
+          "install-personal-claude-hook.sh leaves exactly one live compact-hint entry", r.stdout + r.stderr)
+
+    r2 = subprocess.run(["bash", str(REPO / "scripts" / "install-session-start-hook.sh")],
+                        capture_output=True, text=True, env=env, timeout=30)
+    data = json.loads((work / ".claude" / "settings.json").read_text())
+    first = data["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+    check(r2.returncode == 0 and "schedule-crons-session-hint.sh" in first,
+          "install-session-start-hook.sh still prepends its entry so it fires first", r2.stdout + r2.stderr)
+
+print(f"\n{_pass} passed, {_fail} failed")
+sys.exit(1 if _fail else 0)

--- a/tests/claude-hooks-settings.test.py
+++ b/tests/claude-hooks-settings.test.py
@@ -209,5 +209,27 @@ with tempfile.TemporaryDirectory() as tmp:
     check(removed == [dead_cmds[0]] and odd["hooks"]["SessionStart"][0] == "not-a-dict",
           "a non-dict entry is kept in place while the dead one beside it is removed")
 
+
+    # ── an unexpanded variable is not judgeable by existence ──────────────────
+    # Re-added as an absolute path, never the portable one: a false prune is permanent.
+    var_cmd = 'bash "$CLAUDE_PROJECT_DIR/src/personal-claude-compact-hint.sh"'
+    var_settings = {"hooks": {"SessionStart": [entry(var_cmd)]}}
+    var_removed = chs.prune_dead(var_settings, "SessionStart",
+                                 "personal-claude-compact-hint.sh")
+    check(var_removed == [],
+          "a hook whose path carries an unexpanded variable is never pruned",
+          f"removed {var_removed}")
+    check(var_settings["hooks"]["SessionStart"] != [],
+          "that hook survives in the settings it was found in")
+    with tempfile.TemporaryDirectory() as td:
+        proj = Path(td)
+        (proj / "src").mkdir()
+        (proj / "src" / "personal-claude-compact-hint.sh").write_text("#!/bin/bash\n")
+        kept = {"hooks": {"SessionStart": [entry(var_cmd)]}}
+        check(chs.prune_dead(kept, "SessionStart",
+                             "personal-claude-compact-hint.sh",
+                             project_dir=proj) == [],
+              "nor when a project_dir is supplied and the expansion would resolve")
+
 print(f"\n{_pass} passed, {_fail} failed")
 sys.exit(1 if _fail else 0)

--- a/tests/claude-hooks-settings.test.py
+++ b/tests/claude-hooks-settings.test.py
@@ -160,5 +160,54 @@ with tempfile.TemporaryDirectory() as tmp:
     check(r2.returncode == 0 and "schedule-crons-session-hint.sh" in first,
           "install-session-start-hook.sh still prepends its entry so it fires first", r2.stdout + r2.stderr)
 
+    # ── the CLI and its branches, IN PROCESS (a subprocess is invisible to the coverage tracer) ──
+    import contextlib
+    import io
+    inproc = tmp / "inproc" / ".claude" / "settings.json"
+    inproc.parent.mkdir(parents=True)
+    inproc.write_text(json.dumps({"hooks": {"SessionStart": [entry(dead_cmds[0])]}}))
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        rc = chs.main(["install", "--settings", str(inproc), "--command", live_cmd, "--matcher", "compact"])
+    check(rc == 0 and "removed 1 dead personal-claude-compact-hint.sh entry:" in out.getvalue()
+          and "personal-claude-compact-hint.sh SessionStart hook (installed)" in out.getvalue(),
+          "main(): one dead entry → singular 'entry', default label, rc 0", out.getvalue() + err.getvalue())
+    inproc.write_text(json.dumps({"hooks": {"SessionStart": [entry(c) for c in dead_cmds[:2]]}}))
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out):
+        rc = chs.main(["install", "--settings", str(inproc), "--command", live_cmd, "--label", "L"])
+    check(rc == 0 and "removed 2 dead personal-claude-compact-hint.sh entries:" in out.getvalue()
+          and "L (installed)" in out.getvalue(), "main(): two dead entries → plural, custom label", out.getvalue())
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out):
+        rc = chs.main(["install", "--settings", str(inproc), "--command", live_cmd, "--label", "L"])
+    check(rc == 0 and "✂" not in out.getvalue() and "L (already installed)" in out.getvalue(),
+          "main(): nothing to remove → no ✂ line, already installed", out.getvalue())
+    badp = tmp / "inproc-bad" / ".claude" / "settings.json"
+    badp.parent.mkdir(parents=True)
+    badp.write_text("[]")
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        rc = chs.main(["install", "--settings", str(badp), "--command", live_cmd])
+    check(rc == 1 and "not an object" in err.getvalue() and out.getvalue() == "",
+          "main(): malformed settings → rc 1, reason on stderr, nothing on stdout", err.getvalue())
+
+    # ── parser branches ────────────────────────────────────────────────────────
+    check(chs.script_path_of('bash "/unbalanced/quote.sh') == "/unbalanced/quote.sh".join(['"', ""]) or
+          chs.script_path_of('bash "/unbalanced/quote.sh') == '"/unbalanced/quote.sh',
+          "an unbalanced quote falls back to whitespace splitting instead of raising")
+    check(chs.script_path_of("cp a b") == "cp", "a command with no interpreter yields its first token")
+    check(chs.script_path_of("--flag-only") is None, "a command of only flags yields None")
+    check(chs.script_path_of("bash") is None, "an interpreter with nothing after it yields None")
+    check(chs.script_path_of("   ") is None, "whitespace yields None")
+
+    # ── prune_dead edge branches ───────────────────────────────────────────────
+    check(chs.prune_dead({"hooks": {"SessionStart": [entry(dead_cmds[0])]}}, "SessionStart", "") == [],
+          "an empty family prunes nothing")
+    odd = {"hooks": {"SessionStart": ["not-a-dict", entry(dead_cmds[0])]}}
+    removed = chs.prune_dead(odd, "SessionStart", "personal-claude-compact-hint.sh")
+    check(removed == [dead_cmds[0]] and odd["hooks"]["SessionStart"][0] == "not-a-dict",
+          "a non-dict entry is kept in place while the dead one beside it is removed")
+
 print(f"\n{_pass} passed, {_fail} failed")
 sys.exit(1 if _fail else 0)

--- a/tests/health-check-claude-hook-registration.test.py
+++ b/tests/health-check-claude-hook-registration.test.py
@@ -443,5 +443,65 @@ class TestAgainstTheRealInstaller(unittest.TestCase):
         self.assertFalse(self.hc._hook_command_targets(
             "echo /repo/src/x.sh", Path("/repo/src/x.sh"), "somecmd $(unknown_wrapper x)"))
 
+class TestDeadHookPaths(TestHookRegistration):
+    """A registered hook whose script is gone fails on every fire and was invisible to the
+    owned-list check (live host, 2026-09-08: three deleted tmp-repo copies of the compact
+    hint fired at every compaction; the probe reported only the missing archiver)."""
+
+    def test_a_dead_hook_path_warns_and_carries_a_repair_marker(self):
+        hooks = self._all_registered()
+        dead = f"bash \"{self.repo}/gone/repo/src/personal-claude-compact-hint.sh\""
+        hooks.setdefault("SessionStart", []).extend(self._entry(dead))
+        self._settings(hooks)
+        got = self.hc.check_claude_hook_registration(repo_dir=self.repo)
+        self.assertEqual(got["status"], "warn")
+        self.assertIn("no longer exists", got["detail"])
+        self.assertIn("personal-claude-compact-hint.sh", got["detail"])
+        self.assertEqual([r["family"] for r in got["_dead_hooks"]], ["personal-claude-compact-hint.sh"])
+        self.assertNotIn("_unregistered_hooks", got)
+
+    def test_control_a_live_extra_hook_is_not_dead(self):
+        live = self.repo / "src" / "personal-claude-compact-hint.sh"
+        live.write_text("#!/bin/bash\n")
+        hooks = self._all_registered()
+        hooks.setdefault("SessionStart", []).extend(self._entry(f'bash "{live}"'))
+        self._settings(hooks)
+        got = self.hc.check_claude_hook_registration(repo_dir=self.repo)
+        self.assertEqual(got["status"], "ok", got["detail"])
+
+    def test_a_relative_path_is_judged_against_the_project_not_the_cwd(self):
+        (self.repo / "src" / "personal-claude-compact-hint.sh").write_text("#!/bin/bash\n")
+        hooks = self._all_registered()
+        hooks.setdefault("SessionStart", []).extend(self._entry('bash "src/personal-claude-compact-hint.sh"'))
+        self._settings(hooks)
+        got = self.hc.check_claude_hook_registration(repo_dir=self.repo)
+        self.assertEqual(got["status"], "ok", got["detail"])
+
+
+class TestHookScriptPathFallback(unittest.TestCase):
+    """An older checkout without claude_hooks_settings still gets a probe: the fallback parser."""
+
+    def test_fallback_parses_when_the_installer_module_is_unavailable(self):
+        import sys
+        hc = _load()
+        saved = sys.modules.get("claude_hooks_settings")
+        sys.modules["claude_hooks_settings"] = None  # importing a None entry raises ImportError
+        try:
+            self.assertEqual(hc._hook_script_path("bash /x/y.sh"), "/x/y.sh")
+            self.assertEqual(hc._hook_script_path("python3 '/x/y.py' --flag"), "/x/y.py")
+            self.assertIsNone(hc._hook_script_path("bash"))
+            self.assertEqual(hc._hook_script_path("cp a b"), "cp")
+            self.assertIsNone(hc._hook_script_path(""))
+        finally:
+            if saved is None:
+                sys.modules.pop("claude_hooks_settings", None)
+            else:
+                sys.modules["claude_hooks_settings"] = saved
+
+    def test_the_shared_parser_is_used_when_available(self):
+        hc = _load()
+        self.assertEqual(hc._hook_script_path('bash "/x/y z.sh"'), "/x/y z.sh")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## What broke

The owner saw a **"compact hook error"** after compactions. The engine checkout's `.claude/settings.json` held four `SessionStart` (matcher `compact`) entries for the PERSONAL_CLAUDE hint: the live one, and three pointing at deleted `/var/folders/…/tmp*/repo/src/personal-claude-compact-hint.sh` copies left by test runs. Each compaction fired all four; three failed `No such file or directory` (non-blocking, so nothing was lost — but it was visible to him on every compaction). Neither installer could remove an entry, so nothing on the launch path would ever heal it, and `health-check`'s `claude-hooks` probe checks for *missing* owned hooks, not dead ones.

## The fix, and why this is the durable form

- **`src/claude_hooks_settings.py`** (new) — the one merge for both installers: add the entry once (prepend or append), and **prune entries of the same family** — a command whose script has the same basename — **whose script no longer exists**. A user's own hooks, dead or alive, are never touched; other events are never touched.
- **`scripts/install-personal-claude-hook.sh`**, **`scripts/install-session-start-hook.sh`** — call the module instead of carrying their own inline copies (the duplicated policy is the defect per CLAUDE.md; a third copy would drift). The second also stops using `python3 /dev/stdin`, which the first installer's own comment records as a silent no-op under some sandboxes.
- `start-cli.sh` already runs the installer on **every core launch**, so a polluted file heals on the next launch whatever wrote the dead entries — I could not identify the writer (the wiring test stubs the installer; tests 5/6 pin their own temp dir), so the fix does not depend on finding it.

## Evidence

**Before**, the live file on this host (2026-09-08 ~23:52Z, from the session transcript at compaction):
```
2026-09-08T23:52:32 SessionStart | stderr: Failed with non-blocking status code: bash: /var/folders/h9/…/T/tmp9996m0bs/repo/src/personal-claude-compact-hint.sh: No such file or directory
2026-09-08T23:52:32 SessionStart | stderr: … tmpnyog06nq/repo/src/personal-claude-compact-hint.sh: No such file or directory
2026-09-08T23:52:32 SessionStart | stderr: … tmp4ucblecv/repo/src/personal-claude-compact-hint.sh: No such file or directory
```
`settings.json`: SessionStart entries `4 -> 1` when I removed them by hand that night (backup kept).

**After** — the patched installer run against a copy of that backed-up polluted file (`SUTANDO_CLAUDE_WORKING_DIR=<tmp>`):
```
before: SessionStart compact-hint entries = 4
  ✂ removed 3 dead personal-claude-compact-hint.sh entries: /var/folders/h9/…/tmp9996m0bs/repo/src/personal-claude-compact-hint.sh, …
  ✓ PERSONAL_CLAUDE compact-reinject hook (installed)
after: entries = 2
```
The 2 are the engine's live entry (kept: its script exists) plus one for the worktree's own script (that run's `$REPO`). On the real host the installer runs from the engine checkout, so the command matches the live entry and the result is `already installed`, 1 entry.

**Tests:** `python3 tests/claude-hooks-settings.test.py` → `18 passed, 0 failed` (parsing, fresh install, idempotence, prune scoped to family AND event, dead foreign hook untouched, live foreign hook untouched, prepend order, CLI output names removals, malformed settings refused with a reason, and both real installer scripts end-to-end against a polluted settings dir). `python3 tests/personal-claude-compact-hook.test.py` → `9 passed, 0 failed`. `scripts/review-checks.sh` PASS; `gen-src-map.py --check` up to date.

Not in this PR: the `claude-hooks` health probe flagging dead hook paths (next), and the two agent-API `/answer` fixes the owner asked for alongside this.

Stand: Echo Act IV Blue
