### PR TITLE
fix(agent-api): a reply is not an answer — /answer keeps the item open unless it resolves

### DIFF
--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -1349,7 +1349,12 @@ class Handler(http.server.BaseHTTPRequestHandler):
                         None,
                     )
                     if match:
-                        pq_file.write_text(answer_pending_question(content, match, answer, resolve=resolve))
+                        # Both readers read this one file: write it whole or not at all, so
+                        # neither can see a truncated state between them.
+                        rewritten = answer_pending_question(content, match, answer, resolve=resolve)
+                        tmp_pq = pq_file.with_suffix(pq_file.suffix + ".tmp")
+                        tmp_pq.write_text(rewritten)
+                        os.replace(tmp_pq, pq_file)
                         ts = int(datetime.now().timestamp() * 1000)
                         safe_qid = re.sub(r'[^a-zA-Z0-9_\-.]', '', qid)
                         if safe_qid:

--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -316,16 +316,28 @@ def parse_pending_questions(content: str) -> list[dict]:
     return questions
 
 
-def answer_pending_question(content: str, question: dict, answer: str) -> str:
-    """Return `content` with `question`'s section marked answered.
+def is_question_back(answer: str) -> bool:
+    """A reply that ends in a question mark asks the agent something; it decides nothing."""
+    return " ".join((answer or "").split()).endswith("?")
+
+
+def answer_pending_question(content: str, question: dict, answer: str, *, resolve: bool = True) -> str:
+    """Return `content` with `question`'s section marked answered, or — with ``resolve=False`` —
+    carrying the owner's reply while staying open.
 
     The resolution has to land on a **Status:** line: check-pending-questions.py
     treats a status-less section as unanswered (its free-form convention), so a
     [RESOLVED] title prefix alone would silence this API's own reader while the
-    notifier kept re-asking the owner hourly.
+    notifier kept re-asking the owner hourly. A reply that is not a decision (the
+    triage card's Reply, or a question back) must NOT resolve: `**Status:** open`
+    is the prefix both readers keep listing (check-pending-questions `section_is_waiting`,
+    and PQ_ANSWERED_RE here does not match it).
     """
     section = content[question["start"]:question["end"]]
-    status = f"**Status:** Answered {datetime.now().strftime('%Y-%m-%d')} — {' '.join(answer.split())}"
+    today = datetime.now().strftime('%Y-%m-%d')
+    text = ' '.join(answer.split())
+    status = (f"**Status:** Answered {today} — {text}" if resolve
+              else f"**Status:** open — owner replied {today}: {text}")
     if PQ_STATUS_RE.search(section):
         # A function repl, not a string: a raw answer may contain \1-style escapes.
         new_section = PQ_STATUS_RE.sub(lambda _m: status, section, count=1)
@@ -1325,6 +1337,9 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 if not qid or not answer:
                     self.send_json(400, {"error": "id and answer required"})
                     return
+                # A reply is the owner's words to the agent, not a decision: the triage card
+                # sends resolve=false, and a question back can never be an answer.
+                resolve = data.get("resolve", True) is not False and not is_question_back(answer)
                 pq_file = Path(personal_path("pending-questions.md", WORKSPACE_DIR))
                 if pq_file.exists():
                     content = pq_file.read_text()
@@ -1334,7 +1349,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
                         None,
                     )
                     if match:
-                        pq_file.write_text(answer_pending_question(content, match, answer))
+                        pq_file.write_text(answer_pending_question(content, match, answer, resolve=resolve))
                         ts = int(datetime.now().timestamp() * 1000)
                         safe_qid = re.sub(r'[^a-zA-Z0-9_\-.]', '', qid)
                         if safe_qid:
@@ -1346,8 +1361,11 @@ class Handler(http.server.BaseHTTPRequestHandler):
                                 os.path.join(task_dir_real, f"answer-{safe_qid}-{ts}.txt")
                             )
                             if task_file_str.startswith(task_dir_real + os.sep):
-                                Path(task_file_str).write_text(f"User answered {safe_qid}: {confine_user_content(answer)}")
-                        self.send_json(200, {"ok": True, "id": qid, "answer": answer})
+                                verb = "answered" if resolve else "replied on"
+                                note = "" if resolve else " (the item stays open)"
+                                Path(task_file_str).write_text(
+                                    f"User {verb} {safe_qid}{note}: {confine_user_content(answer)}")
+                        self.send_json(200, {"ok": True, "id": qid, "answer": answer, "resolved": resolve})
                     else:
                         self.send_json(404, {"error": f"question {qid} not found or already answered"})
                 else:

--- a/tests/agent-api-answer-e2e.test.py
+++ b/tests/agent-api-answer-e2e.test.py
@@ -182,6 +182,31 @@ still_open = [q["id"] for q in data.get("questions", [])]
 check("answered question no longer listed", target["id"] not in still_open)
 check("unanswered question still listed", len(still_open) == 1, f"got {still_open}")
 
+# 3b. A reply is not an answer. The triage card's Reply sends resolve=false; a question
+#     back is treated the same whatever the flag says. Either way the item stays open.
+other = still_open[0] if still_open else None
+other_text = next((q["text"] for q in data.get("questions", []) if q["id"] == other), None)
+code, data = req("POST", "/answer", {"id": other, "answer": "before I decide: which two?", "resolve": False})
+check("POST /answer resolve=false → 200 and resolved=false", code == 200 and data.get("resolved") is False,
+      f"got {code} {data}")
+code, data = req("GET", "/tasks/active")
+# Ids are content hashes, so the replied section gets a NEW id (by design: a stale id must
+# never resolve to a neighbour). The question itself must still be listed.
+check("a replied question is STILL listed (under its new content id)",
+      other_text in [q["text"] for q in data.get("questions", [])], f"got {[q['text'] for q in data.get('questions', [])]}")
+body = PQ_FILE.read_text()
+check("the reply lands on an open Status line", "**Status:** open — owner replied" in body
+      and "which two?" in body)
+replies = [t for t in (tmp / "tasks").glob("answer-*.txt") if "replied on" in t.read_text()]
+check("the agent task says replied, and that the item stays open",
+      len(replies) == 1 and "stays open" in replies[0].read_text(), f"got {[t.name for t in replies]}")
+new_id = next((q["id"] for q in data.get("questions", [])), None)
+code, data = req("POST", "/answer", {"id": new_id, "answer": "and what does B cost?"})
+check("a question back never resolves, even without the flag",
+      code == 200 and data.get("resolved") is False, f"got {code} {data}")
+code, data = req("GET", "/tasks/active")
+check("still listed after the question back", len(data.get("questions", [])) == 1)
+
 # 4. Genuine 404s — the message now only fires when it's true.
 code, data = req("POST", "/answer", {"id": target["id"], "answer": "again"})
 check("re-answering the same id → 404 (already answered)", code == 404, f"got {code}")

--- a/tests/agent-api-pending-questions.test.py
+++ b/tests/agent-api-pending-questions.test.py
@@ -393,6 +393,41 @@ class TestAnswer(unittest.TestCase):
             self.assertNotIn(qs[0]["text"], waiting)
             self.assertIn("❓ Rebuild the Swift menu-bar app?", waiting)
 
+    def test_a_reply_keeps_the_question_open_for_both_readers(self):
+        """The owner's Reply is his words to the agent, not a decision. On 2026-09-08 his
+        counter-question ("decide what?") landed as an answer and CLOSED the item: the
+        notifier dropped it and the triage list lost it. A reply must stay open in the
+        agent API's own parse AND in check-pending-questions."""
+        with tempfile.TemporaryDirectory() as tmp:
+            pq = Path(tmp) / "pending-questions.md"
+            qs = api.parse_pending_questions(FREE_FORM)
+            updated = api.answer_pending_question(FREE_FORM, qs[0], "decide what?", resolve=False)
+            self.assertIn("**Status:** open — owner replied", updated)
+            self.assertIn("decide what?", updated)
+            self.assertNotIn("**Status:** Answered", updated)
+            still = [q["text"] for q in api.parse_pending_questions(updated)]
+            self.assertIn(qs[0]["text"], still)
+            pq.write_text(updated)
+            cpq.PQ_FILE = pq
+            waiting = [q["title"] for q in cpq.get_waiting_questions()]
+            self.assertIn(qs[0]["text"], waiting)
+
+    def test_a_second_reply_replaces_the_status_line_and_a_real_answer_still_closes(self):
+        qs = api.parse_pending_questions(FREE_FORM)
+        once = api.answer_pending_question(FREE_FORM, qs[0], "which one?", resolve=False)
+        twice = api.answer_pending_question(once, api.parse_pending_questions(once)[0], "and why?",
+                                            resolve=False)
+        self.assertEqual(twice.count("**Status:**"), 1)
+        self.assertIn("and why?", twice)
+        closed = api.answer_pending_question(twice, api.parse_pending_questions(twice)[0], "B")
+        self.assertNotIn(qs[0]["text"], [q["text"] for q in api.parse_pending_questions(closed)])
+
+    def test_a_question_back_is_recognised(self):
+        self.assertTrue(api.is_question_back("decide what?"))
+        self.assertTrue(api.is_question_back("  which one ?  "))
+        self.assertFalse(api.is_question_back("B, and ship it."))
+        self.assertFalse(api.is_question_back(""))
+
     def test_structured_status_line_is_updated_in_place(self):
         qs = api.parse_pending_questions(STRUCTURED)
         updated = api.answer_pending_question(STRUCTURED, qs[0], "Later")

--- a/tests/agent-api-pending-questions.test.py
+++ b/tests/agent-api-pending-questions.test.py
@@ -435,6 +435,52 @@ class TestAnswer(unittest.TestCase):
         kept = api.answer_pending_question(FREE_FORM, qs[0], "say more", resolve=False)
         self.assertIn("**Status:** open — owner replied", kept)
 
+    def test_the_rewrite_moves_no_structural_marker_and_the_readers_count_moves_by_exactly_what_it_should(self):
+        """The control this seam actually needs (peer measurement, 2026-09-09: one moved
+        `# Resolved` divider took check-pending-questions from 115 waiting to 1 while the
+        file read perfectly). A rewrite may add one Status line inside one section and
+        nothing else: the divider count and its line stay, no heading-like line appears, and
+        BOTH readers' counts move by exactly -1 (answer) or 0 (reply) — asserted on the
+        LAST active section, the one adjacent to the divider."""
+        doc = ("# Pending Questions\n\n## ❓ First?\nBody one.\n\n## ❓ Second?\nBody two.\n\n"
+               "## ❓ Last before the divider?\nBody three.\n\n# Resolved\n\n## ❓ Archived\nDone.\n")
+
+        def divider(text):
+            lines = text.splitlines()
+            idx = [i for i, ln in enumerate(lines) if ln == "# Resolved"]
+            return len(idx), idx[0] if idx else None
+
+        def heading_lines(text):
+            return sum(1 for ln in text.splitlines() if ln.startswith("## "))
+
+        def waiting(text):
+            with tempfile.TemporaryDirectory() as tmp:
+                pq = Path(tmp) / "pending-questions.md"
+                pq.write_text(text)
+                cpq.PQ_FILE = pq
+                return len(cpq.get_waiting_questions())
+
+        qs = api.parse_pending_questions(doc)
+        last = qs[-1]
+        self.assertEqual(last["text"], "❓ Last before the divider?")
+        n_api, n_cpq = len(qs), waiting(doc)
+        self.assertEqual((n_api, n_cpq), (3, 3))
+
+        # A reply that tries to smuggle structure: newlines, a heading, a divider.
+        reply = api.answer_pending_question(doc, last, "hm\n## fake heading\n# Resolved\nwhich two?",
+                                            resolve=False)
+        self.assertEqual(divider(reply)[0], 1, "divider duplicated or lost")
+        self.assertEqual(divider(reply)[1], divider(doc)[1] + 1, "divider moved by other than the one added line")
+        self.assertEqual(heading_lines(reply), heading_lines(doc), "a heading-like line appeared")
+        self.assertEqual(len(api.parse_pending_questions(reply)), n_api, "agent API count changed on a reply")
+        self.assertEqual(waiting(reply), n_cpq, "notifier count changed on a reply")
+
+        answered = api.answer_pending_question(doc, last, "B\n# Resolved")
+        self.assertEqual(divider(answered)[0], 1)
+        self.assertEqual(heading_lines(answered), heading_lines(doc))
+        self.assertEqual(len(api.parse_pending_questions(answered)), n_api - 1, "agent API count on an answer")
+        self.assertEqual(waiting(answered), n_cpq - 1, "notifier count on an answer")
+
     def test_a_question_back_is_recognised(self):
         self.assertTrue(api.is_question_back("decide what?"))
         self.assertTrue(api.is_question_back("  which one ?  "))

--- a/tests/agent-api-pending-questions.test.py
+++ b/tests/agent-api-pending-questions.test.py
@@ -422,6 +422,19 @@ class TestAnswer(unittest.TestCase):
         closed = api.answer_pending_question(twice, api.parse_pending_questions(twice)[0], "B")
         self.assertNotIn(qs[0]["text"], [q["text"] for q in api.parse_pending_questions(closed)])
 
+    def test_the_heuristic_errs_toward_closing_and_says_so(self):
+        """Stated, not hidden: without the flag, a reply that is not phrased as a question
+        ("say more") RESOLVES. That is the expensive direction (a silent close), and it is
+        reachable only from a client that sends no `resolve` — today the dashboard's Answer
+        form, where the human means an answer. The triage card always sends resolve=false."""
+        self.assertFalse(api.is_question_back("say more"))
+        qs = api.parse_pending_questions(FREE_FORM)
+        closed = api.answer_pending_question(FREE_FORM, qs[0], "say more",
+                                             resolve=not api.is_question_back("say more"))
+        self.assertIn("**Status:** Answered", closed)
+        kept = api.answer_pending_question(FREE_FORM, qs[0], "say more", resolve=False)
+        self.assertIn("**Status:** open — owner replied", kept)
+
     def test_a_question_back_is_recognised(self):
         self.assertTrue(api.is_question_back("decide what?"))
         self.assertTrue(api.is_question_back("  which one ?  "))


### PR DESCRIPTION
## What broke

On 2026-09-08 the owner clicked **Reply** on a triage item and typed a counter-question — *"decide what? btw do you keep track of the source and know how to handle it?"*. It reached `POST /answer`, which wrote `**Status:** Answered 2026-09-08 — decide what? …` and **closed the item**: `check-pending-questions` dropped it from the waiting list, the triage list lost it, and the owner believed it was still tracked. I noticed only because the waiting count was wrong. A reply is the owner's words to the agent; it decides nothing.

## The fix

- `POST /answer` takes **`resolve`** (default `true`, so existing callers are unchanged). With `resolve: false` — what the triage card's Reply sends — **or when the text is a question back** (ends with `?`, whatever the flag says), the section gets `**Status:** open — owner replied <date>: <text>` instead of `Answered`.
- `open` is the prefix **both** readers keep listing: `check-pending-questions.section_is_waiting` (`unanswered|waiting|open`) and this API's `PQ_ANSWERED_RE` (which does not match it). Pinned by tests against both.
- The agent task file reads `User replied on <id> (the item stays open): …`; the response carries `resolved`.
- A second reply replaces the status line (one per section); a real answer afterwards still closes.
- A replied section gets a **new content id**, as any edit does (the #2103 property: a stale id must never resolve to a neighbour). The e2e test asserts the question stays listed by text; clients re-list, as the triage card already does.

## Evidence

**Before** (live host, 2026-09-08 ~23:50Z): `get_waiting_questions()` went 18 → 17 when the counter-question landed as an answer; restoring the item by hand brought it back to 18. `PQ_ANSWERED_RE` matched the line the old writer produced.

**After:**
```
python3 tests/agent-api-pending-questions.test.py   → OK (3 new tests in TestAnswer)
python3 tests/agent-api-answer-e2e.test.py          → 28/28 passed (6 new checks, step 3b)
```
New e2e checks: `resolve=false → 200, resolved=false`; the replied question is still listed by `/tasks/active`; the reply lands on an open Status line; the task file says *replied on … stays open*; a `?` answer without the flag also returns `resolved=false` and stays listed.

`scripts/review-checks.sh` PASS.

Companion (sutando-life, mine to merge, after this lands): the card's Reply sends `resolve: false`; until then a question back is already protected by the heuristic here.

Stand: Echo Act IV Blue


## When the default flips (a named trigger, not "for now")

`resolve` defaults to **true** today because the only client that sends no flag is the dashboard's Answer form (`src/web-client.ts:2923`), whose meaning *is* "answer", and it ships in a built artifact. The default flips to **false** (the recoverable side: a missed close leaves a visible item, a missed keep-open silently loses one) when both hold:

1. `src/web-client.ts` sends `resolve: true` explicitly — follow-up PR, opened after this lands;
2. that change is in the **shipped web-client artifact**, not just the repo: checkable on a host by the built bundle under `dist/` containing the explicit `resolve: true` send (`grep -c 'resolve: true' <engine>/dist/web-client*.js`). Merged-is-not-deployed: between (1) merging and the artifact shipping, hosts still run the old client and still send no flag. The web client and this API ship in the same engine artifact, so the flip PR itself is safe once it is in a release **after** (1) — a host running the flipped API is running the flag-sending client — with one residue: a browser holding a cached old bundle for a few minutes after an update.

Flipping before (2) would silently stop dashboard answers from closing on every host still on an older build. The flip itself is a one-line PR referencing this section.

