### PR TITLE
fix(health-check): the claude-hooks probe flags registered hooks whose script no longer exists

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -11048,10 +11048,8 @@ def check_claude_hook_registration(
             # Present, but not actually invoking this checkout's script — either aimed
             # at another checkout or carrying the path as an inert argument.
             foreign.append(f"{event}:{marker}")
-    # A registered hook whose script no longer exists fails on every fire ("No such file")
-    # and is invisible to the owned-list check above, which only asks whether OUR hooks are
-    # present. Scanned over every event and every entry; judged by path existence alone,
-    # a relative path resolving against the settings file's project.
+    # Present-but-dead is invisible to the owned-list check above: a registered hook whose
+    # script is gone fails on every fire. Relative paths resolve against the project.
     dead: list[str] = []
     dead_records: list[dict] = []
     project_dir = settings.resolve().parent.parent

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -9064,7 +9064,31 @@ def apply_claude_hooks_fix(checks: list, stream=None) -> None:
     """
     out = stream if stream is not None else sys.stdout
     for c in checks:
-        if c["name"] != "claude-hooks" or not c.get("_unregistered_hooks"):
+        if c["name"] != "claude-hooks" or not (c.get("_unregistered_hooks") or c.get("_dead_hooks")):
+            continue
+        for rec in c.get("_dead_hooks") or []:
+            owner_script = _HOOK_FAMILY_INSTALLERS.get(str(rec.get("family")))
+            if not owner_script:
+                print(f"  {c['name']}: not repairing dead {rec.get('event')} hook "
+                      f"{rec.get('path')} — not a family a Sutando installer owns", file=out)
+                continue
+        for owner_script in sorted({_HOOK_FAMILY_INSTALLERS[r["family"]]
+                                    for r in c.get("_dead_hooks") or []
+                                    if r.get("family") in _HOOK_FAMILY_INSTALLERS}):
+            print(f"  {c['name']}: pruning dead entries via {Path(owner_script).name}", file=out)
+            try:
+                proc = subprocess.run(["bash", str(REPO_DIR / owner_script)],
+                                      capture_output=True, text=True, timeout=60)
+                emitted = (proc.stdout or "") + (proc.stderr or "")
+                lines = [ln for ln in emitted.splitlines() if ln.strip()]
+                print(f"  {c['name']}: " + (lines[-1].strip() if lines
+                                           else f"installer exited {proc.returncode}"), file=out)
+            except Exception as exc:  # noqa: BLE001 — a failed repair must warn, not raise
+                print(f"  {c['name']}: could not run {Path(owner_script).name} ({exc})", file=out)
+        if not c.get("_unregistered_hooks"):
+            fresh = check_claude_hook_registration()
+            c.clear()
+            c.update(fresh)
             continue
         installer = REPO_DIR / "src" / "install-claude-hooks.sh"
         # Sutando.app runs `--fix` on a 30-minute Timer, so this repair is normally
@@ -10862,6 +10886,39 @@ def check_vault_manifest_integrity(
     }
 
 
+def _hook_script_path(command: str) -> Optional[str]:
+    """The script a hook command runs; the installer module owns the parse, this is a fallback."""
+    try:
+        sys.path.insert(0, str(REPO_DIR / "src"))
+        from claude_hooks_settings import script_path_of
+        return script_path_of(command)
+    except Exception:  # noqa: BLE001 — an older checkout without the module still gets a probe
+        parts = command.split()
+        for i, tok in enumerate(parts):
+            if tok in ("bash", "sh", "python3", "python", "node"):
+                return parts[i + 1].strip("'\"") if i + 1 < len(parts) else None
+        return parts[0].strip("'\"") if parts else None
+
+
+def _runs_a_script(command: str) -> bool:
+    """True when the command hands a script FILE to an interpreter (bash/sh/python/node).
+
+    `bash -c '…'` runs inline text, not a file, and a command carrying an unexpanded `$VAR`
+    cannot be judged by path existence; both are skipped rather than read as dead.
+    """
+    parts = command.split()
+    if len(parts) < 2 or Path(parts[0]).name not in ("bash", "sh", "zsh", "python", "python3", "node"):
+        return False
+    return not parts[1].startswith("-") and "$" not in command
+
+
+#: Which installer re-adds (and, since it prunes, repairs) each Sutando-owned hook family.
+_HOOK_FAMILY_INSTALLERS = {
+    "personal-claude-compact-hint.sh": "scripts/install-personal-claude-hook.sh",
+    "schedule-crons-session-hint.sh": "scripts/install-session-start-hook.sh",
+}
+
+
 def check_claude_hook_registration(
     repo_dir: Optional[Path] = None,
 ) -> dict:
@@ -10991,10 +11048,42 @@ def check_claude_hook_registration(
             # Present, but not actually invoking this checkout's script — either aimed
             # at another checkout or carrying the path as an inert argument.
             foreign.append(f"{event}:{marker}")
-    if missing or foreign:
+    # A registered hook whose script no longer exists fails on every fire ("No such file")
+    # and is invisible to the owned-list check above, which only asks whether OUR hooks are
+    # present. Scanned over every event and every entry; judged by path existence alone,
+    # a relative path resolving against the settings file's project.
+    dead: list[str] = []
+    dead_records: list[dict] = []
+    project_dir = settings.resolve().parent.parent
+    # Owned families are judged above (present / missing / foreign); the dead scan covers
+    # the rest, and only commands that run a script through an interpreter.
+    owned_families = {Path(marker).name for _e, marker, _c in owned}
+    for event, groups in hooks.items():
+        for g in _as_list(groups):
+            if not isinstance(g, dict):
+                continue
+            for h in _as_list(g.get("hooks")):
+                if not isinstance(h, dict):
+                    continue
+                cmd = str(h.get("command", ""))
+                if not _runs_a_script(cmd):
+                    continue
+                script = _hook_script_path(cmd)
+                if not script or Path(script).name in owned_families:
+                    continue
+                target = Path(script) if Path(script).is_absolute() else project_dir / script
+                if not target.exists():
+                    family = Path(script).name
+                    dead.append(f"{event}:{family} -> {script}")
+                    dead_records.append({"event": event, "command": cmd,
+                                         "path": script, "family": family})
+    if missing or foreign or dead:
         bits = []
         if missing:
             bits.append(f"{len(missing)} NOT registered ({', '.join(missing)})")
+        if dead:
+            bits.append(f"{len(dead)} registered but the script no longer exists — every fire "
+                        f"fails 'No such file' ({', '.join(dead)})")
         if foreign:
             bits.append(f"{len(foreign)} registered but NOT running the installer's command "
                         f"— a different program, another checkout, or the path is "
@@ -11007,12 +11096,18 @@ def check_claude_hook_registration(
                   "you intend to enable it"
                   if only_archive else
                   "re-run `SUTANDO_HOOKS_OMIT_TRANSCRIPT_ARCHIVE=1 bash src/install-claude-hooks.sh`")
+        if dead and not missing and not foreign:
+            remedy = ("re-run the installer that owns each family — it prunes dead copies "
+                      "(`bash scripts/install-personal-claude-hook.sh`, "
+                      "`bash scripts/install-session-start-hook.sh`)")
         result = {"name": name, "status": "warn",
                   "detail": f"{'; '.join(bits)} in {settings} — {remedy}"}
         if missing:
             # Keyed structurally so --fix cannot fire on the warn branches the
             # installer can't repair; `foreign` excluded (displacement unverified).
             result["_unregistered_hooks"] = list(missing)
+        if dead_records:
+            result["_dead_hooks"] = dead_records
         return result
     return {"name": name, "status": "ok", "detail": f"all {len(owned)} owned hooks registered"}
 

--- a/tests/claude-hooks-autofix.test.py
+++ b/tests/claude-hooks-autofix.test.py
@@ -191,6 +191,24 @@ class TestDeadHookRepair(FixHandlerGating):
         self.assertEqual(len(calls), 1, calls)
         self.assertIn("install-session-start-hook.sh", " ".join(map(str, calls[0])))
 
+    def test_an_owning_installer_that_fails_warns_instead_of_raising(self):
+        import io
+        real, real_probe = subprocess.run, hc.check_claude_hook_registration
+
+        def boom(cmd, *a, **k):
+            raise OSError("bash vanished")
+
+        hc.subprocess.run = boom
+        hc.check_claude_hook_registration = lambda *a, **k: {"name": "claude-hooks", "status": "warn", "detail": "still dead"}
+        buf = io.StringIO()
+        try:
+            hc.apply_claude_hooks_fix([self._dead("personal-claude-compact-hint.sh")], stream=buf)
+        finally:
+            hc.subprocess.run = real
+            hc.check_claude_hook_registration = real_probe
+        self.assertIn("could not run install-personal-claude-hook.sh", buf.getvalue())
+        self.assertIn("bash vanished", buf.getvalue())
+
     def test_a_foreign_family_is_reported_not_deleted(self):
         import io
         buf = io.StringIO()

--- a/tests/claude-hooks-autofix.test.py
+++ b/tests/claude-hooks-autofix.test.py
@@ -171,5 +171,33 @@ class DispatchWiring(unittest.TestCase):
         )
 
 
+class TestDeadHookRepair(FixHandlerGating):
+    """Dead entries are repaired by the installer that owns their family, which prunes them."""
+
+    def _dead(self, family, path="/var/folders/x/repo/src/hint.sh"):
+        return {"name": "claude-hooks", "status": "warn", "detail": "x",
+                "_dead_hooks": [{"event": "SessionStart", "command": f'bash "{path}"',
+                                 "path": path, "family": family}]}
+
+    def test_a_dead_compact_hint_runs_its_own_installer_once(self):
+        calls = self._run(self._dead("personal-claude-compact-hint.sh"))
+        self.assertEqual(len(calls), 1, calls)
+        self.assertIn("install-personal-claude-hook.sh", " ".join(map(str, calls[0])))
+
+    def test_two_dead_entries_of_one_family_run_the_installer_once(self):
+        check = self._dead("schedule-crons-session-hint.sh")
+        check["_dead_hooks"].append(dict(check["_dead_hooks"][0], path="/elsewhere/hint.sh"))
+        calls = self._run(check)
+        self.assertEqual(len(calls), 1, calls)
+        self.assertIn("install-session-start-hook.sh", " ".join(map(str, calls[0])))
+
+    def test_a_foreign_family_is_reported_not_deleted(self):
+        import io
+        buf = io.StringIO()
+        calls = self._run(self._dead("someone-elses-tool.sh"), out=buf)
+        self.assertEqual(calls, [])
+        self.assertIn("not a family a Sutando installer owns", buf.getvalue())
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/health-check-claude-hook-registration.test.py
+++ b/tests/health-check-claude-hook-registration.test.py
@@ -478,5 +478,30 @@ class TestDeadHookPaths(TestHookRegistration):
         self.assertEqual(got["status"], "ok", got["detail"])
 
 
+class TestHookScriptPathFallback(unittest.TestCase):
+    """An older checkout without claude_hooks_settings still gets a probe: the fallback parser."""
+
+    def test_fallback_parses_when_the_installer_module_is_unavailable(self):
+        import sys
+        hc = _load()
+        saved = sys.modules.get("claude_hooks_settings")
+        sys.modules["claude_hooks_settings"] = None  # importing a None entry raises ImportError
+        try:
+            self.assertEqual(hc._hook_script_path("bash /x/y.sh"), "/x/y.sh")
+            self.assertEqual(hc._hook_script_path("python3 '/x/y.py' --flag"), "/x/y.py")
+            self.assertIsNone(hc._hook_script_path("bash"))
+            self.assertEqual(hc._hook_script_path("cp a b"), "cp")
+            self.assertIsNone(hc._hook_script_path(""))
+        finally:
+            if saved is None:
+                sys.modules.pop("claude_hooks_settings", None)
+            else:
+                sys.modules["claude_hooks_settings"] = saved
+
+    def test_the_shared_parser_is_used_when_available(self):
+        hc = _load()
+        self.assertEqual(hc._hook_script_path('bash "/x/y z.sh"'), "/x/y z.sh")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/health-check-claude-hook-registration.test.py
+++ b/tests/health-check-claude-hook-registration.test.py
@@ -443,5 +443,40 @@ class TestAgainstTheRealInstaller(unittest.TestCase):
         self.assertFalse(self.hc._hook_command_targets(
             "echo /repo/src/x.sh", Path("/repo/src/x.sh"), "somecmd $(unknown_wrapper x)"))
 
+class TestDeadHookPaths(TestHookRegistration):
+    """A registered hook whose script is gone fails on every fire and was invisible to the
+    owned-list check (live host, 2026-09-08: three deleted tmp-repo copies of the compact
+    hint fired at every compaction; the probe reported only the missing archiver)."""
+
+    def test_a_dead_hook_path_warns_and_carries_a_repair_marker(self):
+        hooks = self._all_registered()
+        dead = f"bash \"{self.repo}/gone/repo/src/personal-claude-compact-hint.sh\""
+        hooks.setdefault("SessionStart", []).extend(self._entry(dead))
+        self._settings(hooks)
+        got = self.hc.check_claude_hook_registration(repo_dir=self.repo)
+        self.assertEqual(got["status"], "warn")
+        self.assertIn("no longer exists", got["detail"])
+        self.assertIn("personal-claude-compact-hint.sh", got["detail"])
+        self.assertEqual([r["family"] for r in got["_dead_hooks"]], ["personal-claude-compact-hint.sh"])
+        self.assertNotIn("_unregistered_hooks", got)
+
+    def test_control_a_live_extra_hook_is_not_dead(self):
+        live = self.repo / "src" / "personal-claude-compact-hint.sh"
+        live.write_text("#!/bin/bash\n")
+        hooks = self._all_registered()
+        hooks.setdefault("SessionStart", []).extend(self._entry(f'bash "{live}"'))
+        self._settings(hooks)
+        got = self.hc.check_claude_hook_registration(repo_dir=self.repo)
+        self.assertEqual(got["status"], "ok", got["detail"])
+
+    def test_a_relative_path_is_judged_against_the_project_not_the_cwd(self):
+        (self.repo / "src" / "personal-claude-compact-hint.sh").write_text("#!/bin/bash\n")
+        hooks = self._all_registered()
+        hooks.setdefault("SessionStart", []).extend(self._entry('bash "src/personal-claude-compact-hint.sh"'))
+        self._settings(hooks)
+        got = self.hc.check_claude_hook_registration(repo_dir=self.repo)
+        self.assertEqual(got["status"], "ok", got["detail"])
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
**Stacked on #4065** (base = its branch); merge order: #4065 first, then this.

## What broke
The `claude-hooks` probe asked one question — are OUR owned hooks present? — so on 2026-09-08 three `SessionStart` entries pointing at deleted `/var/folders/…/repo/src/personal-claude-compact-hint.sh` copies fired at every compaction ("No such file", visible to the owner) while the probe reported only the opt-in transcript archiver as missing. Present-but-dead was invisible to it.

## The fix
- The probe scans every registered hook that hands a **script file** to an interpreter and warns when the script does not exist, naming `event:family -> path`. Skipped on purpose: `bash -c '…'` inline text, commands carrying an unexpanded `$VAR` (not judgeable by path), and the owned families the existing present/missing/foreign logic already judges. A relative path is resolved against the settings file's project, never the cwd. Structured marker `_dead_hooks`.
- `--fix` repairs a dead entry by running the installer that **owns its family** (`personal-claude-compact-hint.sh` → `install-personal-claude-hook.sh`, `schedule-crons-session-hint.sh` → `install-session-start-hook.sh`), which prunes dead same-family copies since #4065; one run per installer however many dead entries. A family no Sutando installer owns is **reported, never deleted**.
- The script-path parse is the installer module's (`claude_hooks_settings.script_path_of`) with a fallback for older checkouts.

## Evidence
Tests: `tests/health-check-claude-hook-registration.test.py` → OK (3 new: a dead path warns with the marker; a live extra hook is not dead; a relative path judged against the project). `tests/claude-hooks-autofix.test.py` → OK (3 new: dead compact hint runs its own installer once; two dead entries of one family run it once; a foreign family is reported, not deleted). `tests/claude-hooks-settings.test.py` 19/19. `scripts/review-checks.sh` PASS.

Before/after on this host: the probe read `1 NOT registered (PreCompact:sutando-conversations/)` while three dead SessionStart entries fired every compaction; with this change and the polluted backup restored into a temp project the probe reports `3 registered but the script no longer exists — every fire fails 'No such file' (SessionStart:personal-claude-compact-hint.sh -> /var/folders/…)`.

Stand: Echo Act IV Blue

## The same predicate in two places, and why that is acceptable here

The probe and the pruner (#4065) share one parse (`claude_hooks_settings.script_path_of`) and each applies the same existence rule: a relative script path resolves against the **settings file's project directory**, never the caller's cwd — tested at both sites (`test_a_relative_path_is_judged_against_the_project_not_the_cwd` in `tests/health-check-claude-hook-registration.test.py`; the check labelled "a relative live path is kept and a relative dead one removed, judged from the project dir" in `tests/claude-hooks-settings.test.py`). The failure modes are asymmetric, which is why the same predicate is fine in a reporter while the deleter needs its bound: a false positive here costs a warning line; and `--fix` reruns the owning installer, which re-adds its own live entry, so even that is self-correcting for Sutando families and does nothing to foreign ones.

Reviewer note (stacked PR): read `fix/hook-installer-prune-dead-and-test-target...fix/health-check-dead-hook-paths`, not the child alone; a moved parent head moves this one.
