### PR TITLE
feat(web-client): the Answer form sends resolve: true explicitly

### DIFF
--- a/src/web-client.ts
+++ b/src/web-client.ts
@@ -2920,10 +2920,11 @@ document.addEventListener('keydown', function(e) {
 function answerQuestion(qid, answer) {
   if (!answer || !answer.trim()) return;
   const apiBase = 'http://' + location.hostname + ':7843';
+  // This form means "answer": say so, so the API's default can flip to keep-open (#4066).
   fetch(apiBase + '/answer', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({id: qid, answer: answer.trim()})
+    body: JSON.stringify({id: qid, answer: answer.trim(), resolve: true})
   }).then(r => r.json()).then(d => {
     if (d.ok) {
       // Show answered state on the question briefly before removing

--- a/tests/web-client-answer-sends-resolve-true.test.py
+++ b/tests/web-client-answer-sends-resolve-true.test.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""The dashboard's Answer form must say it means an answer.
+
+POST /answer keeps an item open for resolve=false (a Reply, or a question back) and
+resolves for resolve=true; its default is true only because this form used to send no
+flag. Sending the flag explicitly is the first condition for flipping that default to
+the recoverable side (keep open). See PR #4066's "When the default flips".
+
+Run: python3 tests/web-client-answer-sends-resolve-true.test.py
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SOURCE = (REPO / "src" / "web-client.ts").read_text()
+
+failures = []
+
+
+def check(name, cond, detail=""):
+    print(("  ok   " if cond else "  FAIL ") + name + (f" — {detail}" if detail and not cond else ""))
+    if not cond:
+        failures.append(name)
+
+
+calls = [m for m in re.finditer(r"fetch\(apiBase \+ '/answer',(.*?)\}\)\.then", SOURCE, re.S)]
+check("exactly one /answer call in the client", len(calls) == 1, f"found {len(calls)}")
+body = calls[0].group(1) if calls else ""
+check("the body carries resolve: true", "resolve: true" in body, body[:200])
+check("the body still carries the id and the trimmed answer",
+      "id: qid" in body and "answer: answer.trim()" in body, body[:200])
+check("no other /answer caller omits the flag",
+      all("resolve" in m.group(1) for m in calls))
+
+print(f"\n{len(failures)} failed")
+sys.exit(1 if failures else 0)


### PR DESCRIPTION
Follow-up to #4066 (`/answer` keeps an item open for `resolve: false`; a question back never resolves). Its default stays `true` only because this form — the one flagless client — means "answer". Sending `resolve: true` explicitly is **condition (1)** of the two named in #4066's *When the default flips* section; condition (2) is this change reaching the **shipped web-client artifact** — checkable on a host against the built bundle (`grep -c 'resolve: true' <engine>/dist/web-client*.js`), not against the repo. Merging this PR satisfies (1) at the source; it does not put the line in anyone's running client until the artifact ships. Once both hold, the default flips to keep-open in a one-line PR.

Change: one line in `src/web-client.ts` (`answerQuestion`) plus a two-line comment. Behaviour today is unchanged (the API already treats a missing flag as `true`), so this is safe to ship before or after #4066.

Test: `tests/web-client-answer-sends-resolve-true.test.py` — exactly one `/answer` caller in the client, and its body carries `resolve: true` with the id and trimmed answer intact. `scripts/review-checks.sh` PASS.

Not stacked (base `main`); independent of #4066's merge order.

Stand: Echo Act IV Blue
