### PR TITLE
test(gitignore): the tool-cache suite passes with the repo rules absent

### DIFF
--- a/tests/gitignore-tests-tool-caches.test.sh
+++ b/tests/gitignore-tests-tool-caches.test.sh
@@ -7,20 +7,43 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
 FIXTURE="$(mktemp -d -t gitignore-tool-cache-test.XXXXXX)"
-trap 'rm -rf "$FIXTURE"' EXIT
+
+# Ambient excludes must not supply what the repo's own rules are meant to prove.
+# Nulling the config is not enough: unset core.excludesFile falls back to XDG,
+# command scope outranks the generated global, `git init` copies
+# GIT_TEMPLATE_DIR's info/exclude, and check-ignore consults the index.
+FIXCFG="$FIXTURE.gitconfig"
+printf '[core]\n\texcludesFile = /dev/null\n' > "$FIXCFG"
+export GIT_CONFIG_GLOBAL="$FIXCFG"
+export GIT_CONFIG_SYSTEM=/dev/null
+unset GIT_CONFIG_COUNT GIT_TEMPLATE_DIR
+EMPTY_TEMPLATE="$FIXTURE.template"
+mkdir -p "$EMPTY_TEMPLATE"
+trap 'rm -rf "$FIXTURE" "$FIXCFG" "$EMPTY_TEMPLATE"' EXIT
 
 # The fixture is a fresh repo; nothing here can outlive the trap or collide with
 # the checkout, so `rm -rf` is safe in a way it is not on a shared tests/ dir.
-git init -q "$FIXTURE"
+git init -q --template="$EMPTY_TEMPLATE" "$FIXTURE"
 cp "$REPO/.gitignore" "$FIXTURE/.gitignore"
 cd "$FIXTURE"
+
+# Hermeticity precondition. Asserts the OUTCOME rather than enumerating sources,
+# so an exclude channel nobody listed still trips it.
+mv .gitignore .gitignore.held
+if git -c core.excludesFile=/dev/null check-ignore --no-index -q tests/__pycache__/_probe 2>/dev/null; then
+    echo "FATAL: a tests/ tool-cache path is ignored with NO .gitignore present —" >&2
+    echo "an ambient exclude source is supplying the rules, so this suite would" >&2
+    echo "pass with the repo fix absent." >&2
+    exit 2
+fi
+mv .gitignore.held .gitignore
 
 pass=0
 fail=0
 
 check_ignored() {
     local path="$1" desc="$2"
-    if git check-ignore -q "$path" 2>/dev/null; then
+    if git -c core.excludesFile=/dev/null check-ignore --no-index -q "$path" 2>/dev/null; then
         echo "OK: $desc"; pass=$((pass + 1))
     else
         echo "FAIL: $desc — '$path' is NOT ignored, so \`add -A\` would stage it"
@@ -29,7 +52,7 @@ check_ignored() {
 }
 refute_ignored() {
     local path="$1" desc="$2"
-    if git check-ignore -q "$path" 2>/dev/null; then
+    if git -c core.excludesFile=/dev/null check-ignore --no-index -q "$path" 2>/dev/null; then
         echo "FAIL: $desc — '$path' IS ignored; the fix over-denied and hides real tests"
         fail=$((fail + 1))
     else


### PR DESCRIPTION
`tests/gitignore-tests-tool-caches.test.sh` passes on `main` today with the repository's own rules contributing nothing. A developer whose global `core.excludesFile` happens to carry the same patterns gets 9/9 either way.

## Measured, three arms

```
                                                     rc   result
A  repo .gitignore present  (control)                 0   9 pass, 0 fail
B  repo .gitignore emptied  (must be red)             1   2 pass, 7 fail
C  emptied + ambient core.excludesFile supplies them  0   9 pass, 0 fail   <-- false green
```

Arm B is what makes the suite worth having; arm C is the suite reporting success about rules it never consulted. Arm A matters too — a fix that broke it would trade a false green for a false red.

## After

```
A  repo .gitignore present                            0   9 pass, 0 fail   (unchanged)
B  repo .gitignore emptied                            1   2 pass, 7 fail   (unchanged)
C  emptied + ambient core.excludesFile                1   2 pass, 7 fail   <-- closed
```

## What changed

The same channels #3445 closed for the swap-file suite, applied here, plus one that PR did not have:

- generated global config pinning `core.excludesFile = /dev/null`, and `GIT_CONFIG_SYSTEM=/dev/null` — nulling the config alone is not enough, unset falls back to XDG
- `unset GIT_CONFIG_COUNT GIT_TEMPLATE_DIR` — command scope outranks the generated global, and `git init` copies the template's `info/exclude`
- `git init --template=<empty dir>` so no `info/exclude` is copied
- `--no-index` on both matcher calls — `check-ignore` consults the index, so a tracked path answers instead of the rules. Verified minimally: untracked+ignored → IGNORED; the same path tracked → NOT IGNORED; with `--no-index` → IGNORED again. (Channel found by @keweichen on #3445.)
- a hermeticity precondition that asserts the **outcome** — move `.gitignore` aside, assert a tool-cache path is *not* ignored, exit 2 naming the cause. That catches a channel nobody enumerated, including the next one.

## Scope

Test-only; no production file touched. `tests/vault-carrier-excludes-render-intermediates.test.sh` already passes `--no-index`, and `tests/health-check-carrier-set-enforced.test.py` already pins the reason in an assertion, so this file was the remaining one — searched `check-ignore` across the repo rather than assuming.

Related: #3445 closes the same class for the editor-swap-file suite and is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
