### PR TITLE
fix(team-guard): collaborator config lives in `groups` only, not a `channels` section

### DIFF
--- a/src/discord-bridge.py
+++ b/src/discord-bridge.py
@@ -3051,10 +3051,9 @@ def channel_allows_collaborator_attachments(access_data, channel_id) -> bool:
     """Per-channel owner opt-in: a COLLABORATOR's result may carry [file:]/
     [attach:] markers here. Path authorization stays with the transport
     allowlist; [channel:] redirects stay blocked regardless. Default off."""
-    for section in ("groups", "channels"):
-        cfg = (access_data.get(section) or {}).get(str(channel_id))
-        if isinstance(cfg, dict):
-            return cfg.get("collaboratorAttachments") is True
+    cfg = (access_data.get("groups") or {}).get(str(channel_id))
+    if isinstance(cfg, dict):
+        return cfg.get("collaboratorAttachments") is True
     return False
 
 

--- a/tests/collaborator-attachment-gate.test.py
+++ b/tests/collaborator-attachment-gate.test.py
@@ -140,6 +140,12 @@ class BridgeWiring(unittest.TestCase):
         self.assertFalse(fn({"groups": {"123": True}}, "123"))          # bool cfg, no dict
         self.assertTrue(fn({"groups": {"123": {"collaboratorAttachments": True}}}, "123"))
         self.assertFalse(fn({"groups": {"123": {"collaboratorAttachments": "yes"}}}, "123"))  # is True only
+        # `channels` is NOT a config section: only `groups` is consulted. This
+        # assertion FAILS on the pre-fix code, which looped ("groups","channels").
+        self.assertFalse(fn({"channels": {"123": {"collaboratorAttachments": True}}}, "123"))
+        # and a groups entry still wins when both are present
+        self.assertTrue(fn({"groups": {"123": {"collaboratorAttachments": True}},
+                            "channels": {"123": {"collaboratorAttachments": False}}}, "123"))
 
 
 class QuarantineRecord(unittest.TestCase):


### PR DESCRIPTION
## What

`channel_allows_collaborator_attachments` (`src/discord-bridge.py:3054`) looped `("groups", "channels")`, which made `channels` look like a valid per-channel config section. It is the **only** reader of that section in the entire codebase.

## Why it is a defect

Every other per-channel lookup reads `groups` alone — `resolve_is_collaborator` and the four `groups[...]` readers at `:975 / :994 / :1015 / :1077`. And **nothing writes** a `channels` section: `scripts/access-mutate.py`'s only group writer sets `groups[id] = {"requireMention", "allowFrom"}`, and there is no `setdefault('channels')` anywhere in `src/` or `scripts/`.

So the section was a plausible destination that silently does nothing. Measured on one host: three channels had `collaborators` arrays filed under `channels`, and **none took effect** — `resolve_is_collaborator` returned False for every listed id, so those senders were tiered `guest` and sandboxed.

It also had an early return: for any channel present in `groups`, the loop answered from `groups` and never reached `channels` — so even its own feature was only reachable for channels missing from `groups`.

## Before / after

Pre-fix code, new assertion:

```
AssertionError: True is not false
Ran 28 tests in 0.062s
FAILED (failures=1)
```

Post-fix:

```
Ran 28 tests in 0.066s
OK
```

The added assertion is discriminating, not decorative: a `collaboratorAttachments: true` under `channels` must not be honoured, and a `groups` entry still wins when both are present.

## Suites

49 suites run (`tests/discord-bridge*.test.py` + `tests/*collaborator*.test.py`), **0 failing**.

## Scope

Single concern. No behaviour change for any channel configured the documented way — `groups` was already the only section anything honoured.

Stand: Echo Act IV Pro