### PR TITLE
fix(proactive-loop): count body mentions, and surface the newest one

### DIFF
--- a/skills/proactive-loop/scripts/warn-already-triaged.py
+++ b/skills/proactive-loop/scripts/warn-already-triaged.py
@@ -120,22 +120,23 @@ def report(name, text, files):
             print(f"             +{len(hits) - SHOW_CANDIDATES} further candidate(s) NOT shown — "
                   f"narrow the claim to see them")
         return "parked"
-    body = []
+    hits_by_file = {}
     for tok in toks:
         for f in files:
-            ls = [i for i, line in enumerate(lines_of(f), 1)
-                  if tok.lower() in line.lower()]
-            if ls:
-                body.append((tok, display(f), ls[0], ls[-1], len(ls)))
-    if body:
-        # Parking files are append-only, so the NEWEST mention holds the current
-        # verdict; count every matching line, never one per file.
-        tok, fn, first, last, n = body[0]
-        total = sum(b[4] for b in body)
-        extra = ("" if len(body) == 1 else
-                 f", +{total - n} in {len(body) - 1} other token/file pair(s)")
+            for i, line in enumerate(lines_of(f), 1):
+                if tok.lower() in line.lower():
+                    hits_by_file.setdefault(display(f), {}).setdefault(i, tok)
+    if hits_by_file:
+        # Parking files are append-only, so the NEWEST line of the file holding
+        # the MOST mentions is the verdict; token order is not relevance.
+        total = sum(len(v) for v in hits_by_file.values())
+        fn, at = max(hits_by_file.items(), key=lambda kv: len(kv[1]))
+        ls = sorted(at)
+        first, last, n = ls[0], ls[-1], len(ls)
+        extra = ("" if len(hits_by_file) == 1 else
+                 f", +{total - n} in {len(hits_by_file) - 1} other file(s)")
         print(f"  NO HEADING {label:25} — but {n} body mention(s) in {fn}{extra}; "
-              f"NEWEST '{tok}' -> {fn}:{last}, oldest :{first}. "
+              f"NEWEST '{at[last]}' -> {fn}:{last}, oldest :{first}. "
               f"READ the newest first")
         return "parked"
     print(f"  NONE FOUND {label:25} — no heading, no body mention; genuinely "

--- a/skills/proactive-loop/scripts/warn-already-triaged.py
+++ b/skills/proactive-loop/scripts/warn-already-triaged.py
@@ -123,15 +123,20 @@ def report(name, text, files):
     body = []
     for tok in toks:
         for f in files:
-            for i, line in enumerate(lines_of(f), 1):
-                if tok.lower() in line.lower():
-                    body.append((tok, display(f), i)); break
+            ls = [i for i, line in enumerate(lines_of(f), 1)
+                  if tok.lower() in line.lower()]
+            if ls:
+                body.append((tok, display(f), ls[0], ls[-1], len(ls)))
     if body:
-        # "No heading" is NOT "nothing written" — material is often parked in a
-        # BODY under a neighbouring heading.
-        tok, fn, i = body[0]
-        print(f"  NO HEADING {label:25} — but {len(body)} body mention(s), first "
-              f"'{tok}' -> {fn}:{i}. READ before investigating")
+        # Parking files are append-only, so the NEWEST mention holds the current
+        # verdict; count every matching line, never one per file.
+        tok, fn, first, last, n = body[0]
+        total = sum(b[4] for b in body)
+        extra = ("" if len(body) == 1 else
+                 f", +{total - n} in {len(body) - 1} other token/file pair(s)")
+        print(f"  NO HEADING {label:25} — but {n} body mention(s) in {fn}{extra}; "
+              f"NEWEST '{tok}' -> {fn}:{last}, oldest :{first}. "
+              f"READ the newest first")
         return "parked"
     print(f"  NONE FOUND {label:25} — no heading, no body mention; genuinely "
           f"untriaged, OR every token missed (try one from the warn text)")

--- a/tests/warn-already-triaged-body-mention-count.test.py
+++ b/tests/warn-already-triaged-body-mention-count.test.py
@@ -77,7 +77,48 @@ class BodyMentionCount(unittest.TestCase):
         self.assertEqual(verdict, "parked")
         self.assertIn("CANDIDATES", out)
         self.assertNotIn("NO HEADING", out)
+class MultiTokenAxis(unittest.TestCase):
+    """Every test above uses ONE token; these pin the multi-token axis (sonichi, #4098).
 
+    A claim normally yields several tokens, so a line matching two of them was
+    counted twice, and the surfaced pair was chosen by token order rather than by
+    which file actually holds the record.
+    """
+
+    def test_a_line_matching_two_tokens_counts_once(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = pathlib.Path(d) / "build_log.md"
+            p.write_text("".join(f"- alpha-probe and beta-probe both here {i}\n"
+                                 for i in range(5)))
+            verdict, out = _run([p], claim="the `alpha-probe` and `beta-probe` paths")
+        self.assertEqual(verdict, "parked")
+        self.assertIn("5 body mention(s)", out)
+        self.assertNotIn("10 body mention(s)", out)
+        self.assertNotIn("+5", out)
+
+    def test_the_file_holding_the_record_is_surfaced_not_the_first_token(self):
+        """A 1-line aside must not outrank a 12-line standing instruction."""
+        with tempfile.TemporaryDirectory() as d:
+            aside = pathlib.Path(d) / "notes.md"
+            aside.write_text("aside: alpha-probe mentioned once in passing\n")
+            log = pathlib.Path(d) / "build_log.md"
+            log.write_text("".join(f"- beta-probe re-fired; DO NOT re-investigate {i}\n"
+                                   for i in range(12)))
+            verdict, out = _run([aside, log],
+                                claim="the `alpha-probe` and `beta-probe` paths")
+        self.assertEqual(verdict, "parked")
+        self.assertIn("12 body mention(s) in build_log.md", out)
+        self.assertIn("build_log.md:12", out)
+        self.assertNotIn("notes.md:1, oldest", out)
+
+    def test_the_newest_lines_own_token_is_the_one_named(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = pathlib.Path(d) / "build_log.md"
+            p.write_text("alpha-probe first\nfiller\nbeta-probe newest\n")
+            verdict, out = _run([p], claim="the `alpha-probe` and `beta-probe` paths")
+        self.assertEqual(verdict, "parked")
+        self.assertIn("NEWEST 'beta-probe'", out)
+        self.assertIn("build_log.md:3", out)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/warn-already-triaged-body-mention-count.test.py
+++ b/tests/warn-already-triaged-body-mention-count.test.py
@@ -1,0 +1,83 @@
+"""A body-mention count must count mentions, and surface the NEWEST one.
+
+`report()`'s no-heading branch used `break` after the first matching line in each
+file, so `len(body)` counted (token, file) pairs rather than mentions: a file
+holding twelve mentions of the subject reported "1 body mention(s)". It also
+printed `body[0]`'s first line. Parking files are append-only, so that is the
+OLDEST entry — the earliest guess — while the newest one carries the verdict and
+any standing instruction.
+
+Sibling guard: `warn-already-triaged-truncation.test.py` pins the same
+header-disagrees-with-body failure on the CANDIDATES (heading) branch.
+"""
+import contextlib
+import importlib.util
+import io
+import pathlib
+import tempfile
+import unittest
+
+_SRC = (pathlib.Path(__file__).resolve().parents[1]
+        / "skills" / "proactive-loop" / "scripts" / "warn-already-triaged.py")
+_spec = importlib.util.spec_from_file_location("wat", _SRC)
+wat = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(wat)
+
+TOK = "snowflake-decode"
+
+
+def _run(files, claim=f"the `{TOK}` path"):
+    wat._LINES.clear()
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        verdict = wat.report(None, claim, files)
+    return verdict, buf.getvalue()
+
+
+class BodyMentionCount(unittest.TestCase):
+    def test_counts_every_matching_line_not_one_per_file(self):
+        """12 mentions in one file must not report as 1."""
+        with tempfile.TemporaryDirectory() as d:
+            p = pathlib.Path(d) / "build_log.md"
+            p.write_text("".join(f"- pass note {i}: {TOK} re-fired\n"
+                                 for i in range(12)))
+            verdict, out = _run([p])
+        self.assertEqual(verdict, "parked")
+        self.assertIn("12 body mention(s)", out)
+        self.assertNotIn("1 body mention(s)", out)
+
+    def test_surfaces_the_newest_line_not_the_oldest(self):
+        """The reported line must be the LAST match, with the first kept for context."""
+        with tempfile.TemporaryDirectory() as d:
+            p = pathlib.Path(d) / "build_log.md"
+            # token on lines 1 and 5; nothing on the lines between.
+            p.write_text(f"oldest: {TOK} looked transient\nfiller\nfiller\nfiller\n"
+                         f"newest: {TOK} — do not re-investigate\n")
+            verdict, out = _run([p])
+        self.assertEqual(verdict, "parked")
+        self.assertIn("NEWEST", out)
+        self.assertIn("build_log.md:5", out)
+        self.assertIn("oldest :1", out)
+
+    def test_single_mention_still_reads_as_one(self):
+        """Positive control: the honest count of one mention is still 1."""
+        with tempfile.TemporaryDirectory() as d:
+            p = pathlib.Path(d) / "notes.md"
+            p.write_text(f"- only note: {TOK} happened once\n")
+            verdict, out = _run([p])
+        self.assertEqual(verdict, "parked")
+        self.assertIn("1 body mention(s)", out)
+
+    def test_heading_branch_still_wins_over_body(self):
+        """Negative control: a heading match must NOT fall through to this branch."""
+        with tempfile.TemporaryDirectory() as d:
+            p = pathlib.Path(d) / "notes.md"
+            p.write_text(f"## {TOK} triage\n\nbody mentions {TOK} again\n")
+            verdict, out = _run([p])
+        self.assertEqual(verdict, "parked")
+        self.assertIn("CANDIDATES", out)
+        self.assertNotIn("NO HEADING", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Addresses defects 1 and 2 of #4097 — **deliberately not `Closes`**: @yixuan-ag2 added a THIRD defect to that issue on 2026-09-10 (`warn-already-triaged.py` never reads `current-track-archive.md`; 76 entries unreachable by the step-3.4 gate on one measured host). This PR does not fix it, so merging must not auto-close the issue.

## The defect

`warn-already-triaged.py` is the step-3.4 gate a proactive pass runs before investigating a warn or telling the owner how the system behaves. On a recurring warn it answered with a count that was wrong by 12×, and pointed at the least informative entry in the record.

Two consequences of one `break`:

1. **`len(body)` was not a mention count.** It counted `(token, file)` pairs that matched at least once — one per file per token — and printed that as `"N body mention(s)"`. That string is a claim about how much has been written on a subject, which is exactly the quantity a reader uses to decide whether the record is substantial. "1 body mention" reads as *mentioned once in passing*.
2. **`body[0]`'s first line is the OLDEST mention.** These parking files are append-only. For a recurring subject the newest entry carries the current verdict and any standing instruction; the oldest carries the first guess.

## Before / after, on the live file that triggered this

`<workspace>/build_log.md`, 12 lines containing `core-request-rejections` (`grep -c` = 12), same claim string into both versions:

```
BEFORE (origin/main)  verdict=parked
  NO HEADING this claim — but 1 body mention(s), first 'core-request-rejections'
                         -> build_log.md:112991. READ before investigating

AFTER  (this branch)  verdict=parked
  NO HEADING this claim — but 12 body mention(s) in build_log.md; NEWEST
                         'core-request-rejections' -> build_log.md:127721,
                         oldest :112991. READ the newest first
```

The line `origin/main` surfaced (`:112991`, five days old) says the warn *"cleared on its own"*. The newest mention, which it never showed, says:

> `core-request-rejections` re-fired (4 in 15m). The record said do not re-investigate — check the cron …

## Why it mattered here

This was found by walking into it. A pass re-derived the full mechanism of an unrelated warn — proxy source, ledger decode attempts, a duplicate-issue search — before discovering the conclusion was already on a PR thread, in a comment the same account had written 36 hours earlier. The gate *ran*, returned `parked`, and its output argued for investigating anyway.

## Tests

`tests/warn-already-triaged-body-mention-count.test.py`, 4 cases: the 12-vs-1 count, newest-line selection, and two controls — a single mention must still read as `1`, and a heading match must still take the `CANDIDATES` branch rather than falling through.

```
Ran 4 tests — OK
```

**Mutation-checked** (`git stash` the source, keep the tests, `__pycache__` cleared):

```
FAIL: test_counts_every_matching_line_not_one_per_file
  AssertionError: '12 body mention(s)' not found in "… but 1 body mention(s), first …"
FAIL: test_surfaces_the_newest_line_not_the_oldest
  AssertionError: 'NEWEST' not found in "… but 1 body mention(s), first … build_log.md:1 …"
Ran 4 tests — FAILED (failures=2)
```

Both controls pass in that state too, which is what makes them controls rather than a second copy of the assertion.

Sibling suites green at this head: `warn-already-triaged-truncation.test.py`, `proactive-loop-warn-already-triaged.test.py`.

## Note on the neighbouring branch

The `CANDIDATES` branch ten lines above already holds this rule, in a comment — *"Hits are ordered by token then file — not by relevance, so a silent truncation hides an arbitrary subset. Anything withheld is counted out loud"* — and it does count its remainder (`+N further candidate(s) NOT shown`). `tests/warn-already-triaged-truncation.test.py` pins it. The body branch truncated silently and printed the truncated figure as the total; this brings it under the same rule.

## Not this PR

#3864 and #4016 are both `tokens()` extraction gaps (snake_case / UPPER_SNAKE identifiers never get searched). This defect is downstream of extraction — the token matched 12 lines fine. They are also near-duplicates of each other, and one `ENT` fix would close both.

