### PR TITLE
feat(pool) [1/5]: the delivery reader — a recipient reads its own folder

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -123,6 +123,7 @@ One entry per agent-facing module. 5 without a usable header comment.
 - **`peer-watch.py`** — Read a peer host's restart-watch signal WITHOUT confusing a stale view for a dead peer.
 - **`pending_questions_md.py`** — Locating the `# Resolved` divider in pending-questions.md — one definition.
 - **`personal-claude-compact-hint.sh`** — SessionStart(compact) hook — re-inject PERSONAL_CLAUDE.md after context compaction.
+- **`pool_delivery.py`** — Delivery-side half of the worker pool: read one recipient's own folder.
 - **`presenter-mode.ts`** — Provider-neutral presenter-mode sentinel policy — TS twin of src/presenter_mode.py (#2501).
 - **`presenter_mode.py`** — Provider-neutral presenter-mode sentinel policy.
 - **`proactive_claim_fence.py`** — Proactive claim lifecycle on the outbox ClaimBackend seam.

--- a/src/pool_delivery.py
+++ b/src/pool_delivery.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Delivery-side half of the worker pool: read one recipient's own folder.
+
+Stage 1 of docs/worker-pool-design.md. A recipient — the core, or later a
+worker — receives work as *sentinels* in `deliveries/<recipient>/`:
+
+    tasks/<task-id>.json                     the payload; immutable, never copied
+    deliveries/<me>/<task-id>                a sentinel; existing IS the assignment
+    deliveries/<me>/<task-id>.claimed        the same sentinel, suffix substituted
+
+Creating the sentinel assigns (the router's job, not this module's). Renaming it
+claims, which is atomic and exclusive, so a losing racer sees OSError and walks
+away. Nothing here writes a sentinel, reads another recipient's folder, or
+selects work that was not delivered.
+
+This module is intentionally free of any watcher, session or transport concern:
+it is the logic a reader needs, so the same rules hold whether events arrive by
+fswatch, by poll, or not at all.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+CLAIMED_SUFFIX = ".claimed"
+
+# One suffix, substituted never appended: a claimed sentinel must not still read
+# as unclaimed, or a reader re-takes its own in-flight work.
+_SENTINEL = re.compile(r"^(?P<id>task-[A-Za-z0-9_-]+?)(?P<claimed>\.claimed)?$")
+
+RECIPIENT = re.compile(r"^[a-z0-9][a-z0-9-]{0,31}$")
+
+
+class NotDelivered(Exception):
+    """The sentinel named is absent, malformed, or not this recipient's."""
+
+
+def parse_sentinel(name: str) -> tuple[str, bool] | None:
+    """(task_id, claimed) for a sentinel filename, or None if it is not one."""
+    m = _SENTINEL.match(name)
+    if not m:
+        return None
+    return m.group("id"), m.group("claimed") is not None
+
+
+def deliveries_dir(workspace: Path, recipient: str) -> Path:
+    if not RECIPIENT.match(recipient):
+        raise ValueError(f"recipient id must match {RECIPIENT.pattern!r}: {recipient!r}")
+    return Path(workspace) / "deliveries" / recipient
+
+
+def payload_path(workspace: Path, task_id: str) -> Path:
+    return Path(workspace) / "tasks" / f"{task_id}.json"
+
+
+def archived_payload(workspace: Path, task_id: str) -> Path:
+    return Path(workspace) / "tasks" / "archive" / f"{task_id}.json"
+
+
+def result_path(workspace: Path, task_id: str) -> Path:
+    return Path(workspace) / "results" / f"{task_id}.txt"
+
+
+def done_flag(workspace: Path, recipient: str, task_id: str) -> Path:
+    return Path(workspace) / "state" / "workers" / recipient / "done" / f"{task_id}.flag"
+
+
+def pending(workspace: Path, recipient: str) -> list[Path]:
+    """Unclaimed sentinels in this recipient's folder, oldest first.
+
+    Ordering is by the sentinel's own mtime, so a reader drains in delivery
+    order without reading any payload.
+    """
+    d = deliveries_dir(workspace, recipient)
+    if not d.is_dir():
+        return []
+    out = []
+    for p in d.iterdir():
+        got = parse_sentinel(p.name)
+        if got and not got[1]:
+            out.append(p)
+    return sorted(out, key=lambda q: (q.stat().st_mtime, q.name))
+
+
+def claimed(workspace: Path, recipient: str) -> list[Path]:
+    d = deliveries_dir(workspace, recipient)
+    if not d.is_dir():
+        return []
+    return sorted(p for p in d.iterdir()
+                  if (got := parse_sentinel(p.name)) and got[1])
+
+
+def find(workspace: Path, recipient: str, task_id: str) -> Path | None:
+    """The sentinel for `task_id` under either name, or None."""
+    d = deliveries_dir(workspace, recipient)
+    for name in (task_id, task_id + CLAIMED_SUFFIX):
+        p = d / name
+        if p.exists():
+            return p
+    return None
+
+
+def claim(sentinel: Path) -> Path:
+    """Take a delivery. Atomic and exclusive; a loser gets OSError.
+
+    The loser is the router releasing, or another incarnation of this same
+    recipient — never a sibling, which cannot see this folder.
+    """
+    got = parse_sentinel(sentinel.name)
+    if got is None or got[1]:
+        raise NotDelivered(f"not an unclaimed sentinel: {sentinel.name}")
+    dst = sentinel.with_name(got[0] + CLAIMED_SUFFIX)
+    os.rename(sentinel, dst)
+    return dst
+
+
+def release(sentinel: Path) -> Path:
+    """Hand a claimed delivery back to the SAME recipient for its next run."""
+    got = parse_sentinel(sentinel.name)
+    if got is None or not got[1]:
+        raise NotDelivered(f"not a claimed sentinel: {sentinel.name}")
+    dst = sentinel.with_name(got[0])
+    os.rename(sentinel, dst)
+    return dst
+
+
+def residue(workspace: Path, recipient: str, task_id: str) -> str:
+    """What a crash left behind, read without a journal.
+
+    One name per state, each mapped by `sweep` to exactly one action.
+    """
+    ws = Path(workspace)
+    has_result = result_path(ws, task_id).is_file()
+    has_flag = done_flag(ws, recipient, task_id).is_file()
+    sentinel = find(ws, recipient, task_id)
+    payload = payload_path(ws, task_id).is_file()
+
+    # A result outranks everything: the payload is archived last, so between the
+    # flag and the archive it still sits in tasks/ and must not read as new work.
+    if has_result:
+        return "finished" if has_flag else "completed"
+    if sentinel is None:
+        if payload and not archived_payload(ws, task_id).is_file():
+            return "undelivered"
+        return "clean"
+    if not payload:
+        return "stale-sentinel"
+    return "died-mid-work" if parse_sentinel(sentinel.name)[1] else "unclaimed"
+
+
+def sweep(workspace: Path, recipient: str) -> dict:
+    """Boot reconciliation. An event that fired while nobody listened is gone,
+    so a reader that only streams never learns about it."""
+    ws = Path(workspace)
+    seen = set()
+    actions = {"ready": [], "released": [], "completed": [], "retired": [], "stale": []}
+    for p in claimed(ws, recipient) + pending(ws, recipient):
+        task_id = parse_sentinel(p.name)[0]
+        if task_id in seen:
+            continue
+        seen.add(task_id)
+        state = residue(ws, recipient, task_id)
+        if state == "unclaimed":
+            actions["ready"].append(task_id)
+        elif state == "died-mid-work":
+            release(p)
+            actions["released"].append(task_id)
+        elif state == "completed":
+            actions["completed"].append(task_id)
+        elif state == "finished":
+            # Both result and flag exist, so the delivery is spent. Leaving the
+            # sentinel would hand finished work back as ready on the next boot.
+            p.unlink()
+            actions["retired"].append(task_id)
+        elif state == "stale-sentinel":
+            p.unlink()
+            actions["stale"].append(task_id)
+        else:
+            raise AssertionError(f"unmapped residue state {state!r} for {task_id}")
+    return actions
+
+
+def read_payload(workspace: Path, task_id: str) -> dict | None:
+    p = payload_path(Path(workspace), task_id)
+    if not p.is_file():
+        return None
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def _emit(task_id: str) -> None:
+    # A dead consumer must end the reader rather than let events pile up unseen.
+    try:
+        print(f"DELIVERY: {task_id}", flush=True)
+    except BrokenPipeError:
+        raise SystemExit(0)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="read one recipient's delivery folder")
+    ap.add_argument("--workspace", required=True)
+    ap.add_argument("--recipient", default="core")
+    ap.add_argument("command", choices=("sweep", "pending", "watch", "residue"))
+    ap.add_argument("--task-id")
+    ap.add_argument("--interval", type=float, default=1.0)
+    a = ap.parse_args(argv)
+    ws = Path(a.workspace)
+
+    if a.command == "residue":
+        if not a.task_id:
+            ap.error("--task-id is required for residue")
+        print(residue(ws, a.recipient, a.task_id))
+        return 0
+    if a.command == "pending":
+        for p in pending(ws, a.recipient):
+            print(parse_sentinel(p.name)[0])
+        return 0
+    if a.command == "sweep":
+        print(json.dumps(sweep(ws, a.recipient), indent=2))
+        return 0
+
+    for task_id in sweep(ws, a.recipient)["ready"]:
+        _emit(task_id)
+    announced = {parse_sentinel(p.name)[0] for p in pending(ws, a.recipient)}
+    while True:
+        time.sleep(a.interval)
+        now = {parse_sentinel(p.name)[0] for p in pending(ws, a.recipient)}
+        for task_id in sorted(now - announced):
+            _emit(task_id)
+        announced = now
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/pool_delivery.py
+++ b/src/pool_delivery.py
@@ -37,8 +37,10 @@ CLAIMED_SUFFIX = ".claimed"
 
 # One suffix, substituted never appended: a claimed sentinel must not still read
 # as unclaimed, or a reader re-takes its own in-flight work.
+
+# `~`: the bridge encodes a channel instance into the id (task-<inst>~<id>).
 _SENTINEL = re.compile(
-    r"^(?P<id>task-[A-Za-z0-9_-]+?)(?:\.txt|(?P<claimed>\.claimed))$")
+    r"^(?P<id>task-[A-Za-z0-9_~-]+?)(?:\.txt|(?P<claimed>\.claimed))$")
 
 RECIPIENT = re.compile(r"^[a-z0-9][a-z0-9-]{0,31}$")
 

--- a/src/pool_delivery.py
+++ b/src/pool_delivery.py
@@ -5,7 +5,7 @@ Stage 1 of docs/worker-pool-design.md. A recipient — the core, or later a
 worker — receives work as *sentinels* in `deliveries/<recipient>/`:
 
     tasks/<task-id>.json                     the payload; immutable, never copied
-    deliveries/<me>/<task-id>                a sentinel; existing IS the assignment
+    deliveries/<me>/<task-id>.txt            a sentinel; existing IS the assignment
     deliveries/<me>/<task-id>.claimed        the same sentinel, suffix substituted
 
 Creating the sentinel assigns (the router's job, not this module's). Renaming it
@@ -31,11 +31,14 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from workspace_default import resolve_workspace  # noqa: E402
 
+# `.txt` because the watcher that wakes a worker emits for no other extension.
+PENDING_SUFFIX = ".txt"
 CLAIMED_SUFFIX = ".claimed"
 
 # One suffix, substituted never appended: a claimed sentinel must not still read
 # as unclaimed, or a reader re-takes its own in-flight work.
-_SENTINEL = re.compile(r"^(?P<id>task-[A-Za-z0-9_-]+?)(?P<claimed>\.claimed)?$")
+_SENTINEL = re.compile(
+    r"^(?P<id>task-[A-Za-z0-9_-]+?)(?:\.txt|(?P<claimed>\.claimed))$")
 
 RECIPIENT = re.compile(r"^[a-z0-9][a-z0-9-]{0,31}$")
 
@@ -108,7 +111,7 @@ def claimed(workspace: Path, recipient: str) -> list[Path]:
 def find(workspace: Path, recipient: str, task_id: str) -> Path | None:
     """The sentinel for `task_id` under either name, or None."""
     d = deliveries_dir(workspace, recipient)
-    for name in (task_id, task_id + CLAIMED_SUFFIX):
+    for name in (task_id + PENDING_SUFFIX, task_id + CLAIMED_SUFFIX):
         p = d / name
         if p.exists():
             return p
@@ -134,7 +137,7 @@ def release(sentinel: Path) -> Path:
     got = parse_sentinel(sentinel.name)
     if got is None or not got[1]:
         raise NotDelivered(f"not a claimed sentinel: {sentinel.name}")
-    dst = sentinel.with_name(got[0])
+    dst = sentinel.with_name(got[0] + PENDING_SUFFIX)
     os.rename(sentinel, dst)
     return dst
 

--- a/src/pool_delivery.py
+++ b/src/pool_delivery.py
@@ -4,7 +4,7 @@
 Stage 1 of docs/worker-pool-design.md. A recipient — the core, or later a
 worker — receives work as *sentinels* in `deliveries/<recipient>/`:
 
-    tasks/<task-id>.json                     the payload; immutable, never copied
+    tasks/<task-id>.txt                      the payload; immutable, never copied
     deliveries/<me>/<task-id>.txt            a sentinel; existing IS the assignment
     deliveries/<me>/<task-id>.claimed        the same sentinel, suffix substituted
 
@@ -68,11 +68,11 @@ def deliveries_dir(workspace, recipient: str) -> Path:
 
 
 def payload_path(workspace: Path, task_id: str) -> Path:
-    return _root(workspace) / "tasks" / f"{task_id}.json"
+    return _root(workspace) / "tasks" / f"{task_id}{PENDING_SUFFIX}"
 
 
 def archived_payload(workspace: Path, task_id: str) -> Path:
-    return _root(workspace) / "tasks" / "archive" / f"{task_id}.json"
+    return _root(workspace) / "tasks" / "archive" / f"{task_id}{PENDING_SUFFIX}"
 
 
 def result_path(workspace: Path, task_id: str) -> Path:
@@ -198,13 +198,18 @@ def sweep(workspace: Path, recipient: str) -> dict:
     return actions
 
 
-def read_payload(workspace: Path, task_id: str) -> dict | None:
+def read_payload(workspace: Path, task_id: str) -> str | None:
+    """The task text from `tasks/`, which a sentinel only points at.
+
+    The bridges write header-format text, never JSON; a reader that wants
+    fields parses it with local_task_protocol, not here.
+    """
     p = payload_path(Path(workspace), task_id)
     if not p.is_file():
         return None
     try:
-        return json.loads(p.read_text(encoding="utf-8"))
-    except (OSError, ValueError):
+        return p.read_text(encoding="utf-8", errors="replace")
+    except OSError:
         return None
 
 

--- a/src/pool_delivery.py
+++ b/src/pool_delivery.py
@@ -6,11 +6,12 @@ worker — receives work as *sentinels* in `deliveries/<recipient>/`:
 
     tasks/<task-id>.txt                      the payload; immutable, never copied
     deliveries/<me>/<task-id>.txt            a sentinel; existing IS the assignment
-    deliveries/<me>/<task-id>.claimed        the same sentinel, suffix substituted
+    deliveries/<me>/<task-id>.accepted       the same sentinel, suffix substituted
 
 Creating the sentinel assigns (the router's job, not this module's). Renaming it
-claims, which is atomic and exclusive, so a losing racer sees OSError and walks
-away. Nothing here writes a sentinel, reads another recipient's folder, or
+records that the ASSIGNED recipient accepted the work — a worker never selects
+its own, so nothing is claimed here. The rename is atomic and exclusive, so a
+losing racer sees OSError and walks away. Nothing here writes a sentinel, reads another recipient's folder, or
 selects work that was not delivered.
 
 This module is intentionally free of any watcher, session or transport concern:
@@ -33,14 +34,14 @@ from workspace_default import resolve_workspace  # noqa: E402
 
 # `.txt` because the watcher that wakes a worker emits for no other extension.
 PENDING_SUFFIX = ".txt"
-CLAIMED_SUFFIX = ".claimed"
+ACCEPTED_SUFFIX = ".accepted"
 
-# One suffix, substituted never appended: a claimed sentinel must not still read
-# as unclaimed, or a reader re-takes its own in-flight work.
+# One suffix, substituted never appended: an accepted sentinel must not still
+# read as pending, or a reader re-takes its own in-flight work.
 
 # `~`: the bridge encodes a channel instance into the id (task-<inst>~<id>).
 _SENTINEL = re.compile(
-    r"^(?P<id>task-[A-Za-z0-9_~-]+?)(?:\.txt|(?P<claimed>\.claimed))$")
+    r"^(?P<id>task-[A-Za-z0-9_~-]+?)(?:\.txt|(?P<accepted>\.accepted))$")
 
 RECIPIENT = re.compile(r"^[a-z0-9][a-z0-9-]{0,31}$")
 
@@ -50,11 +51,11 @@ class NotDelivered(Exception):
 
 
 def parse_sentinel(name: str) -> tuple[str, bool] | None:
-    """(task_id, claimed) for a sentinel filename, or None if it is not one."""
+    """(task_id, accepted) for a sentinel filename, or None if it is not one."""
     m = _SENTINEL.match(name)
     if not m:
         return None
-    return m.group("id"), m.group("claimed") is not None
+    return m.group("id"), m.group("accepted") is not None
 
 
 def _root(workspace) -> Path:
@@ -86,7 +87,7 @@ def done_flag(workspace: Path, recipient: str, task_id: str) -> Path:
 
 
 def pending(workspace: Path, recipient: str) -> list[Path]:
-    """Unclaimed sentinels in this recipient's folder, oldest first.
+    """Pending sentinels in this recipient's folder, oldest first.
 
     Ordering is by the sentinel's own mtime, so a reader drains in delivery
     order without reading any payload.
@@ -102,7 +103,7 @@ def pending(workspace: Path, recipient: str) -> list[Path]:
     return sorted(out, key=lambda q: (q.stat().st_mtime, q.name))
 
 
-def claimed(workspace: Path, recipient: str) -> list[Path]:
+def accepted(workspace: Path, recipient: str) -> list[Path]:
     d = deliveries_dir(workspace, recipient)
     if not d.is_dir():
         return []
@@ -113,32 +114,34 @@ def claimed(workspace: Path, recipient: str) -> list[Path]:
 def find(workspace: Path, recipient: str, task_id: str) -> Path | None:
     """The sentinel for `task_id` under either name, or None."""
     d = deliveries_dir(workspace, recipient)
-    for name in (task_id + PENDING_SUFFIX, task_id + CLAIMED_SUFFIX):
+    for name in (task_id + PENDING_SUFFIX, task_id + ACCEPTED_SUFFIX):
         p = d / name
         if p.exists():
             return p
     return None
 
 
-def claim(sentinel: Path) -> Path:
-    """Take a delivery. Atomic and exclusive; a loser gets OSError.
+def accept(sentinel: Path) -> Path:
+    """Take up work already assigned here. Atomic and exclusive; a loser gets
+    OSError.
 
-    The loser is the router releasing, or another incarnation of this same
-    recipient — never a sibling, which cannot see this folder.
+    Nothing is selected: the folder decided the recipient. This only excludes a
+    second incarnation of the SAME recipient — never a sibling, which cannot see
+    this folder.
     """
     got = parse_sentinel(sentinel.name)
     if got is None or got[1]:
-        raise NotDelivered(f"not an unclaimed sentinel: {sentinel.name}")
-    dst = sentinel.with_name(got[0] + CLAIMED_SUFFIX)
+        raise NotDelivered(f"not a pending sentinel: {sentinel.name}")
+    dst = sentinel.with_name(got[0] + ACCEPTED_SUFFIX)
     os.rename(sentinel, dst)
     return dst
 
 
 def release(sentinel: Path) -> Path:
-    """Hand a claimed delivery back to the SAME recipient for its next run."""
+    """Hand an accepted delivery back to the SAME recipient for its next run."""
     got = parse_sentinel(sentinel.name)
     if got is None or not got[1]:
-        raise NotDelivered(f"not a claimed sentinel: {sentinel.name}")
+        raise NotDelivered(f"not an accepted sentinel: {sentinel.name}")
     dst = sentinel.with_name(got[0] + PENDING_SUFFIX)
     os.rename(sentinel, dst)
     return dst
@@ -167,7 +170,7 @@ def residue(workspace: Path, recipient: str, task_id: str) -> str:
         return "clean"
     if not payload:
         return "stale-sentinel"
-    return "died-mid-work" if parse_sentinel(sentinel.name)[1] else "unclaimed"
+    return "died-mid-work" if parse_sentinel(sentinel.name)[1] else "pending"
 
 
 def sweep(workspace: Path, recipient: str) -> dict:
@@ -176,13 +179,13 @@ def sweep(workspace: Path, recipient: str) -> dict:
     ws = Path(workspace)
     seen = set()
     actions = {"ready": [], "released": [], "completed": [], "retired": [], "stale": []}
-    for p in claimed(ws, recipient) + pending(ws, recipient):
+    for p in accepted(ws, recipient) + pending(ws, recipient):
         task_id = parse_sentinel(p.name)[0]
         if task_id in seen:
             continue
         seen.add(task_id)
         state = residue(ws, recipient, task_id)
-        if state == "unclaimed":
+        if state == "pending":
             actions["ready"].append(task_id)
         elif state == "died-mid-work":
             release(p)

--- a/src/pool_delivery.py
+++ b/src/pool_delivery.py
@@ -155,10 +155,12 @@ def residue(workspace: Path, recipient: str, task_id: str) -> str:
     sentinel = find(ws, recipient, task_id)
     payload = payload_path(ws, task_id).is_file()
 
-    # A result outranks everything: the payload is archived last, so between the
-    # flag and the archive it still sits in tasks/ and must not read as new work.
+    # The flag is terminal on its own: the bridge drains the result file on
+    # delivery, so after a drain the flag is the only durable evidence left.
+    if has_flag:
+        return "finished"
     if has_result:
-        return "finished" if has_flag else "completed"
+        return "completed"
     if sentinel is None:
         if payload and not archived_payload(ws, task_id).is_file():
             return "undelivered"

--- a/src/pool_delivery.py
+++ b/src/pool_delivery.py
@@ -35,13 +35,16 @@ from workspace_default import resolve_workspace  # noqa: E402
 # `.txt` because the watcher that wakes a worker emits for no other extension.
 PENDING_SUFFIX = ".txt"
 ACCEPTED_SUFFIX = ".accepted"
+# Sentinels written before the rename. Recognised so work already accepted under
+# the old name is never re-delivered; nothing writes this suffix.
+LEGACY_ACCEPTED_SUFFIX = ".claimed"
 
 # One suffix, substituted never appended: an accepted sentinel must not still
 # read as pending, or a reader re-takes its own in-flight work.
 
 # `~`: the bridge encodes a channel instance into the id (task-<inst>~<id>).
 _SENTINEL = re.compile(
-    r"^(?P<id>task-[A-Za-z0-9_~-]+?)(?:\.txt|(?P<accepted>\.accepted))$")
+    r"^(?P<id>task-[A-Za-z0-9_~-]+?)(?:\.txt|(?P<accepted>\.accepted|\.claimed))$")
 
 RECIPIENT = re.compile(r"^[a-z0-9][a-z0-9-]{0,31}$")
 
@@ -114,7 +117,8 @@ def accepted(workspace: Path, recipient: str) -> list[Path]:
 def find(workspace: Path, recipient: str, task_id: str) -> Path | None:
     """The sentinel for `task_id` under either name, or None."""
     d = deliveries_dir(workspace, recipient)
-    for name in (task_id + PENDING_SUFFIX, task_id + ACCEPTED_SUFFIX):
+    for name in (task_id + PENDING_SUFFIX, task_id + ACCEPTED_SUFFIX,
+                 task_id + LEGACY_ACCEPTED_SUFFIX):
         p = d / name
         if p.exists():
             return p

--- a/src/pool_delivery.py
+++ b/src/pool_delivery.py
@@ -27,6 +27,10 @@ import sys
 import time
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from workspace_default import resolve_workspace  # noqa: E402
+
 CLAIMED_SUFFIX = ".claimed"
 
 # One suffix, substituted never appended: a claimed sentinel must not still read
@@ -48,26 +52,32 @@ def parse_sentinel(name: str) -> tuple[str, bool] | None:
     return m.group("id"), m.group("claimed") is not None
 
 
-def deliveries_dir(workspace: Path, recipient: str) -> Path:
+def _root(workspace) -> Path:
+    """`None` resolves through the one sanctioned helper — a second resolution
+    path is how a reader and a writer end up in different trees."""
+    return Path(workspace) if workspace is not None else resolve_workspace()
+
+
+def deliveries_dir(workspace, recipient: str) -> Path:
     if not RECIPIENT.match(recipient):
         raise ValueError(f"recipient id must match {RECIPIENT.pattern!r}: {recipient!r}")
-    return Path(workspace) / "deliveries" / recipient
+    return _root(workspace) / "deliveries" / recipient
 
 
 def payload_path(workspace: Path, task_id: str) -> Path:
-    return Path(workspace) / "tasks" / f"{task_id}.json"
+    return _root(workspace) / "tasks" / f"{task_id}.json"
 
 
 def archived_payload(workspace: Path, task_id: str) -> Path:
-    return Path(workspace) / "tasks" / "archive" / f"{task_id}.json"
+    return _root(workspace) / "tasks" / "archive" / f"{task_id}.json"
 
 
 def result_path(workspace: Path, task_id: str) -> Path:
-    return Path(workspace) / "results" / f"{task_id}.txt"
+    return _root(workspace) / "results" / f"{task_id}.txt"
 
 
 def done_flag(workspace: Path, recipient: str, task_id: str) -> Path:
-    return Path(workspace) / "state" / "workers" / recipient / "done" / f"{task_id}.flag"
+    return _root(workspace) / "state" / "workers" / recipient / "done" / f"{task_id}.flag"
 
 
 def pending(workspace: Path, recipient: str) -> list[Path]:

--- a/src/pool_delivery.py
+++ b/src/pool_delivery.py
@@ -21,6 +21,8 @@ fswatch, by poll, or not at all.
 from __future__ import annotations
 
 import argparse
+import contextlib
+import fcntl
 import json
 import os
 import re
@@ -32,12 +34,16 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from workspace_default import resolve_workspace  # noqa: E402
 
+from delivery.readiness import read_ready_result  # noqa: E402
+
 # `.txt` because the watcher that wakes a worker emits for no other extension.
 PENDING_SUFFIX = ".txt"
 ACCEPTED_SUFFIX = ".accepted"
 # Sentinels written before the rename. Recognised so work already accepted under
 # the old name is never re-delivered; nothing writes this suffix.
 LEGACY_ACCEPTED_SUFFIX = ".claimed"
+# Not a sentinel: the regex below never matches it, so listings skip it.
+LOCK_NAME = ".lock"
 
 # One suffix, substituted never appended: an accepted sentinel must not still
 # read as pending, or a reader re-takes its own in-flight work.
@@ -125,6 +131,20 @@ def find(workspace: Path, recipient: str, task_id: str) -> Path | None:
     return None
 
 
+@contextlib.contextmanager
+def arbitration(workspace, recipient: str):
+    """One lock per folder around publish, accept and release, so a check of
+    both names and the rename that follows it cannot interleave."""
+    d = deliveries_dir(workspace, recipient)
+    d.mkdir(parents=True, exist_ok=True)
+    with open(d / LOCK_NAME, "a+") as fh:
+        fcntl.flock(fh, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(fh, fcntl.LOCK_UN)
+
+
 def accept(sentinel: Path) -> Path:
     """Take up work already assigned here. Atomic and exclusive; a loser gets
     OSError.
@@ -137,7 +157,12 @@ def accept(sentinel: Path) -> Path:
     if got is None or got[1]:
         raise NotDelivered(f"not a pending sentinel: {sentinel.name}")
     dst = sentinel.with_name(got[0] + ACCEPTED_SUFFIX)
-    os.rename(sentinel, dst)
+    with arbitration(sentinel.parent.parent.parent, sentinel.parent.name):
+        # A stray pending name beside the accepted one: rename would silently
+        # replace work in flight. (A racing loser's source is gone: OSError.)
+        if dst.exists() and sentinel.exists():
+            raise NotDelivered(f"already accepted: {dst.name}")
+        os.rename(sentinel, dst)
     return dst
 
 
@@ -147,7 +172,8 @@ def release(sentinel: Path) -> Path:
     if got is None or not got[1]:
         raise NotDelivered(f"not an accepted sentinel: {sentinel.name}")
     dst = sentinel.with_name(got[0] + PENDING_SUFFIX)
-    os.rename(sentinel, dst)
+    with arbitration(sentinel.parent.parent.parent, sentinel.parent.name):
+        os.rename(sentinel, dst)
     return dst
 
 
@@ -157,7 +183,9 @@ def residue(workspace: Path, recipient: str, task_id: str) -> str:
     One name per state, each mapped by `sweep` to exactly one action.
     """
     ws = Path(workspace)
-    has_result = result_path(ws, task_id).is_file()
+    # The shared readiness contract, not existence: an empty or whitespace-only
+    # file is a placeholder still being written, and must not suppress recovery.
+    has_result = read_ready_result(result_path(ws, task_id)) is not None
     has_flag = done_flag(ws, recipient, task_id).is_file()
     sentinel = find(ws, recipient, task_id)
     payload = payload_path(ws, task_id).is_file()
@@ -255,7 +283,10 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(sweep(ws, a.recipient), indent=2))
         return 0
 
-    for task_id in sweep(ws, a.recipient)["ready"]:
+    # A release puts the name back as pending, and pending-at-boot is exactly
+    # what a streaming reader never hears about: announce both.
+    boot = sweep(ws, a.recipient)
+    for task_id in boot["ready"] + boot["released"]:
         _emit(task_id)
     announced = {parse_sentinel(p.name)[0] for p in pending(ws, a.recipient)}
     while True:

--- a/tests/pool-delivery.test.py
+++ b/tests/pool-delivery.test.py
@@ -219,6 +219,20 @@ class TestResidue(Base):
         self.assertEqual(pd.residue(self.root, "core", "task-1"), "clean")
 
 
+class TestFlagAfterDrain(Base):
+    def test_a_done_flag_with_no_result_is_finished_not_died(self):
+        """The bridge drains results/<id>.txt on delivery. A crash between the
+        flag and the archive, then a drain, leaves .claimed + flag + payload and
+        NO result. Reading that as died-mid-work re-runs finished work."""
+        self.ws.payload("task-1")
+        pd.claim(self.ws.deliver("core", "task-1"))
+        self.ws.flag("core", "task-1")                  # result already drained
+        self.assertEqual(pd.residue(self.root, "core", "task-1"), "finished")
+        out = pd.sweep(self.root, "core")
+        self.assertEqual(out["released"], [])
+        self.assertIsNone(pd.find(self.root, "core", "task-1"))
+
+
 class TestSweep(Base):
     def test_releases_work_a_crash_left_claimed(self):
         self.ws.payload("task-1")

--- a/tests/pool-delivery.test.py
+++ b/tests/pool-delivery.test.py
@@ -78,6 +78,18 @@ class TestSentinelNames(Base):
                 pd.deliveries_dir(self.root, bad)
 
 
+class TestLaneEncodedIds(Base):
+    def test_a_lane_encoded_id_parses_and_is_pending(self):
+        """local-hs ids look like task-local-hs~task-<hex>: the `~` is the
+        bridge's instance separator. Seen live: a worker's pending() was empty
+        while its sentinel sat in the folder."""
+        got = pd.parse_sentinel("task-local-hs~task-4384e6c562dee80eba.txt")
+        self.assertEqual(got, ("task-local-hs~task-4384e6c562dee80eba", False))
+        self.ws.deliver("core", "task-local-hs~task-1")
+        self.assertEqual([pd.parse_sentinel(p.name)[0] for p in pd.pending(self.root, "core")],
+                         ["task-local-hs~task-1"])
+
+
 class TestPending(Base):
     def test_empty_folder_is_not_an_error(self):
         self.assertEqual(pd.pending(self.root, "core"), [])

--- a/tests/pool-delivery.test.py
+++ b/tests/pool-delivery.test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Contract tests for src/pool_delivery.py — a real filesystem, no mocks."""
+import json
 import os
 import subprocess
 import sys
@@ -315,6 +316,113 @@ class TestCLI(Base):
         r = self.run_cli("sweep")
         self.assertIn('"ready"', r.stdout)
         self.assertIn("task-1", r.stdout)
+
+
+class TestEmit(Base):
+    def test_a_dead_consumer_ends_the_reader(self):
+        """A reader that keeps emitting into a closed pipe piles events up
+        unseen; exiting is what makes the failure visible."""
+        from unittest.mock import patch
+        with patch("builtins.print", side_effect=BrokenPipeError):
+            with self.assertRaises(SystemExit) as e:
+                pd._emit("task-1")
+        self.assertEqual(e.exception.code, 0)
+
+
+class TestCliDispatch(Base):
+    def _main(self, *args):
+        import io
+        from contextlib import redirect_stdout
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = pd.main(["--workspace", str(self.root), "--recipient", "core", *args])
+        return rc, buf.getvalue()
+
+    def test_pending_lists_ids(self):
+        self.ws.payload("task-1")
+        self.ws.deliver("core", "task-1")
+        rc, out = self._main("pending")
+        self.assertEqual((rc, out.strip()), (0, "task-1"))
+
+    def test_residue_requires_a_task_id(self):
+        with self.assertRaises(SystemExit):
+            self._main("residue")
+
+    def test_residue_prints_the_state(self):
+        self.ws.payload("task-1")
+        rc, out = self._main("residue", "--task-id", "task-1")
+        self.assertEqual((rc, out.strip()), (0, "undelivered"))
+
+    def test_sweep_emits_json_with_every_bucket(self):
+        self.ws.payload("task-1")
+        self.ws.deliver("core", "task-1")
+        rc, out = self._main("sweep")
+        got = json.loads(out)
+        self.assertEqual(rc, 0)
+        self.assertEqual(set(got), {"ready", "released", "completed", "retired", "stale"})
+        self.assertEqual(got["ready"], ["task-1"])
+
+
+class TestWatch(Base):
+    def test_watch_emits_the_boot_sweep_then_new_arrivals(self):
+        """The boot sweep is not optional: a delivery written while the reader
+        was down produces no event, so only the sweep finds it."""
+        from unittest.mock import patch
+        self.ws.payload("task-old")
+        self.ws.deliver("core", "task-old")
+        seen = []
+
+        def fake_sleep(_):
+            if len(seen) >= 1:          # after the boot sweep emitted
+                raise KeyboardInterrupt
+            self.ws.payload("task-new")
+            self.ws.deliver("core", "task-new")
+
+        with patch.object(pd, "_emit", side_effect=seen.append), \
+             patch("time.sleep", side_effect=fake_sleep):
+            with self.assertRaises(KeyboardInterrupt):
+                pd.main(["--workspace", str(self.root), "--recipient", "core", "watch"])
+        self.assertIn("task-old", seen)
+
+    def test_watch_announces_a_delivery_that_arrives_while_running(self):
+        """The loop's own job, distinct from the boot sweep."""
+        from unittest.mock import patch
+        seen, ticks = [], []
+
+        def fake_sleep(_):
+            ticks.append(1)
+            if len(ticks) == 1:
+                self.ws.payload("task-live")
+                self.ws.deliver("core", "task-live")
+            else:
+                raise KeyboardInterrupt
+
+        with patch.object(pd, "_emit", side_effect=seen.append), \
+             patch("time.sleep", side_effect=fake_sleep):
+            with self.assertRaises(KeyboardInterrupt):
+                pd.main(["--workspace", str(self.root), "--recipient", "core", "watch"])
+        self.assertIn("task-live", seen)
+
+
+class TestSweepTotality(Base):
+    def test_one_task_under_both_names_is_visited_once(self):
+        """`claimed + pending` can list the same id twice; a second visit would
+        act on a state the first pass already resolved."""
+        self.ws.payload("task-1")
+        pd.claim(self.ws.deliver("core", "task-1"))
+        self.ws.deliver("core", "task-2")
+        self.ws.payload("task-2")
+        out = pd.sweep(self.root, "core")
+        flat = [x for v in out.values() for x in v]
+        self.assertEqual(len(flat), len(set(flat)), out)
+
+    def test_an_unmapped_state_raises_rather_than_falling_through(self):
+        from unittest.mock import patch
+        self.ws.payload("task-1")
+        self.ws.deliver("core", "task-1")
+        with patch.object(pd, "residue", return_value="something-new"):
+            with self.assertRaises(AssertionError):
+                pd.sweep(self.root, "core")
 
 
 if __name__ == "__main__":

--- a/tests/pool-delivery.test.py
+++ b/tests/pool-delivery.test.py
@@ -471,5 +471,72 @@ class TestSweepTotality(Base):
                 pd.sweep(self.root, "core")
 
 
+
+class TestBootRecoveryIsAnnounced(Base):
+    """The production `watch` path, not `sweep()` alone: sweep released the
+    interrupted delivery, then `watch` seeded `announced` from it and emitted
+    nothing -- the task sat pending with nobody told."""
+    def watch_once(self):
+        from unittest.mock import patch
+        seen = []
+        def stop(_):
+            raise KeyboardInterrupt
+        with patch.object(pd, "_emit", side_effect=seen.append), patch("time.sleep", side_effect=stop):
+            with self.assertRaises(KeyboardInterrupt):
+                pd.main(["--workspace", str(self.root), "--recipient", "core", "watch"])
+        return seen
+
+    def test_an_accepted_delivery_interrupted_before_boot_is_announced(self):
+        self.ws.payload("task-x")
+        pd.accept(self.ws.deliver("core", "task-x"))
+        self.assertEqual(self.watch_once(), ["task-x"])
+        self.assertTrue((self.root / "deliveries" / "core" / "task-x.txt").exists(), "released")
+
+    def test_a_legacy_claimed_name_is_announced_too(self):
+        self.ws.payload("task-y")
+        (self.root / "deliveries" / "core").mkdir(parents=True)
+        (self.root / "deliveries" / "core" / "task-y.claimed").touch()
+        self.assertEqual(self.watch_once(), ["task-y"])
+
+
+class TestResultReadiness(Base):
+    def accepted(self, tid="task-1"):
+        self.ws.payload(tid)
+        pd.accept(self.ws.deliver("core", tid))
+
+    def test_an_empty_or_whitespace_result_is_not_completion(self):
+        for body in ("", "   \n\t"):
+            self.accepted(f"task-{len(body)}")
+            self.ws.result(f"task-{len(body)}", body)
+            self.assertEqual(pd.residue(self.root, "core", f"task-{len(body)}"), "died-mid-work", repr(body))
+
+    def test_a_substantive_result_is(self):
+        self.accepted()
+        self.ws.result("task-1", "the answer")
+        self.assertEqual(pd.residue(self.root, "core", "task-1"), "completed")
+
+
+class TestAcceptIsExclusive(Base):
+    def test_a_second_pending_name_cannot_replace_the_accepted_one(self):
+        """rename() overwrites silently; two accepts of one task were both
+        'successful'. The accepted name is work in flight and must stay."""
+        self.ws.payload("task-1")
+        pd.accept(self.ws.deliver("core", "task-1"))
+        stray = self.ws.deliver("core", "task-1")
+        with self.assertRaises(pd.NotDelivered):
+            pd.accept(stray)
+        self.assertTrue(stray.exists())
+        self.assertTrue((self.root / "deliveries" / "core" / "task-1.accepted").exists())
+
+    def test_the_lock_file_is_not_a_sentinel(self):
+        self.ws.payload("task-1")
+        pd.accept(self.ws.deliver("core", "task-1"))
+        self.assertTrue((self.root / "deliveries" / "core" / pd.LOCK_NAME).exists())
+        self.assertEqual([p.name for p in pd.pending(self.root, "core")], [])
+        self.assertEqual([p.name for p in pd.accepted(self.root, "core")], ["task-1.accepted"])
+        pd.sweep(self.root, "core")
+        self.assertTrue((self.root / "deliveries" / "core" / pd.LOCK_NAME).exists())
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/pool-delivery.test.py
+++ b/tests/pool-delivery.test.py
@@ -26,8 +26,10 @@ class Workspace:
     def deliver(self, recipient, task_id):
         d = self.root / "deliveries" / recipient
         d.mkdir(parents=True, exist_ok=True)
-        p = d / task_id
-        os.open(p, os.O_CREAT | os.O_EXCL)
+        # Spelled literally, not via pd.PENDING_SUFFIX: a test that reads the
+        # constant cannot catch the constant changing.
+        p = d / f"{task_id}.txt"
+        os.close(os.open(p, os.O_CREAT | os.O_EXCL))
         return p
 
     def result(self, task_id, text="done"):
@@ -52,7 +54,10 @@ class Base(unittest.TestCase):
 
 class TestSentinelNames(Base):
     def test_unclaimed_parses(self):
-        self.assertEqual(pd.parse_sentinel("task-abc"), ("task-abc", False))
+        self.assertEqual(pd.parse_sentinel("task-abc.txt"), ("task-abc", False))
+        # Extensionless is NOT a sentinel: the watcher that wakes a worker
+        # emits for no other extension, so such a file would never be seen.
+        self.assertIsNone(pd.parse_sentinel("task-abc"))
 
     def test_claimed_parses(self):
         self.assertEqual(pd.parse_sentinel("task-abc.claimed"), ("task-abc", True))
@@ -208,7 +213,7 @@ class TestSweep(Base):
         pd.claim(self.ws.deliver("core", "task-1"))
         out = pd.sweep(self.root, "core")
         self.assertEqual(out["released"], ["task-1"])
-        self.assertTrue((self.root / "deliveries/core/task-1").exists())
+        self.assertTrue((self.root / "deliveries/core/task-1.txt").exists())
 
     def test_does_not_release_finished_work(self):
         self.ws.payload("task-1")

--- a/tests/pool-delivery.test.py
+++ b/tests/pool-delivery.test.py
@@ -130,6 +130,20 @@ class TestPending(Base):
         self.assertIsNone(pd.find(self.root, "core", "task-1"))
 
 
+class TestLegacyAcceptedSuffix(Base):
+    def test_a_pre_rename_sentinel_is_still_seen(self):
+        """The rename landed mid-flight on a live pool. A `.claimed` sentinel the
+        old code wrote must not become invisible — `find` missing it lets the
+        router deliver already-accepted work a second time. Seen live 2026-09-10."""
+        self.ws.payload("task-1")
+        d = self.root / "deliveries" / "core"; d.mkdir(parents=True, exist_ok=True)
+        legacy = d / "task-1.claimed"; legacy.touch()
+        self.assertEqual(pd.parse_sentinel("task-1.claimed"), ("task-1", True))
+        self.assertEqual(pd.find(self.root, "core", "task-1"), legacy)
+        self.assertEqual([p.name for p in pd.accepted(self.root, "core")], ["task-1.claimed"])
+        self.assertEqual(pd.pending(self.root, "core"), [], "never offered as new work")
+
+
 class TestAccept(Base):
     def test_accept_renames_in_place(self):
         s = self.ws.deliver("core", "task-1")

--- a/tests/pool-delivery.test.py
+++ b/tests/pool-delivery.test.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Contract tests for src/pool_delivery.py — a real filesystem, no mocks."""
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+import pool_delivery as pd
+
+
+class Workspace:
+    def __init__(self, root):
+        self.root = Path(root)
+        for d in ("tasks", "tasks/archive", "results", "deliveries", "state/workers"):
+            (self.root / d).mkdir(parents=True, exist_ok=True)
+
+    def payload(self, task_id, body="do a thing"):
+        p = self.root / "tasks" / f"{task_id}.json"
+        p.write_text(f'{{"id": "{task_id}", "task": "{body}"}}', encoding="utf-8")
+        return p
+
+    def deliver(self, recipient, task_id):
+        d = self.root / "deliveries" / recipient
+        d.mkdir(parents=True, exist_ok=True)
+        p = d / task_id
+        os.open(p, os.O_CREAT | os.O_EXCL)
+        return p
+
+    def result(self, task_id, text="done"):
+        p = self.root / "results" / f"{task_id}.txt"
+        p.write_text(text, encoding="utf-8")
+        return p
+
+    def flag(self, recipient, task_id):
+        p = pd.done_flag(self.root, recipient, task_id)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("", encoding="utf-8")
+        return p
+
+
+class Base(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.ws = Workspace(self._tmp.name)
+        self.root = self.ws.root
+        self.addCleanup(self._tmp.cleanup)
+
+
+class TestSentinelNames(Base):
+    def test_unclaimed_parses(self):
+        self.assertEqual(pd.parse_sentinel("task-abc"), ("task-abc", False))
+
+    def test_claimed_parses(self):
+        self.assertEqual(pd.parse_sentinel("task-abc.claimed"), ("task-abc", True))
+
+    def test_non_sentinel_rejected(self):
+        for name in ("roster.json", "task-abc.json", ".DS_Store", "notes.txt"):
+            self.assertIsNone(pd.parse_sentinel(name), name)
+
+    def test_suffix_substitutes_never_appends(self):
+        """A claimed sentinel must not still read as unclaimed."""
+        claimed = pd.parse_sentinel("task-abc.claimed")
+        self.assertTrue(claimed[1])
+        self.assertNotIn(".claimed", claimed[0])
+
+    def test_recipient_id_is_validated(self):
+        for bad in ("../core", "core/../x", "Core", "", "a" * 40):
+            with self.assertRaises(ValueError, msg=bad):
+                pd.deliveries_dir(self.root, bad)
+
+
+class TestPending(Base):
+    def test_empty_folder_is_not_an_error(self):
+        self.assertEqual(pd.pending(self.root, "core"), [])
+
+    def test_absent_folder_is_not_an_error(self):
+        self.assertEqual(pd.pending(self.root, "worker-nope"), [])
+
+    def test_claimed_is_not_pending(self):
+        s = self.ws.deliver("core", "task-1")
+        pd.claim(s)
+        self.assertEqual(pd.pending(self.root, "core"), [])
+
+    def test_ordered_by_delivery_time(self):
+        for i, tid in enumerate(("task-c", "task-a", "task-b")):
+            p = self.ws.deliver("core", tid)
+            os.utime(p, (1000 + i, 1000 + i))
+        got = [pd.parse_sentinel(p.name)[0] for p in pd.pending(self.root, "core")]
+        self.assertEqual(got, ["task-c", "task-a", "task-b"])
+
+    def test_reader_sees_only_its_own_folder(self):
+        self.ws.deliver("core", "task-mine")
+        self.ws.deliver("worker-1", "task-theirs")
+        got = [pd.parse_sentinel(p.name)[0] for p in pd.pending(self.root, "core")]
+        self.assertEqual(got, ["task-mine"])
+
+    def test_a_worker_reads_its_own_folder_not_the_cores(self):
+        """Scoping must follow the recipient argument, not a hardcoded folder."""
+        self.ws.deliver("core", "task-for-core")
+        self.ws.deliver("worker-1", "task-for-worker")
+        got = [pd.parse_sentinel(p.name)[0] for p in pd.pending(self.root, "worker-1")]
+        self.assertEqual(got, ["task-for-worker"])
+
+    def test_claim_by_a_worker_lands_in_the_workers_folder(self):
+        self.ws.payload("task-1")
+        s = self.ws.deliver("worker-1", "task-1")
+        c = pd.claim(s)
+        self.assertEqual(c.parent.name, "worker-1")
+        self.assertIsNone(pd.find(self.root, "core", "task-1"))
+
+
+class TestClaim(Base):
+    def test_claim_renames_in_place(self):
+        s = self.ws.deliver("core", "task-1")
+        c = pd.claim(s)
+        self.assertFalse(s.exists())
+        self.assertTrue(c.exists())
+        self.assertEqual(c.name, "task-1.claimed")
+
+    def test_claim_is_exclusive(self):
+        s = self.ws.deliver("core", "task-1")
+        pd.claim(s)
+        with self.assertRaises(OSError):
+            pd.claim(s)
+
+    def test_claiming_a_claimed_sentinel_is_refused(self):
+        s = self.ws.deliver("core", "task-1")
+        c = pd.claim(s)
+        with self.assertRaises(pd.NotDelivered):
+            pd.claim(c)
+
+    def test_claim_does_not_touch_the_payload(self):
+        p = self.ws.payload("task-1")
+        before = p.read_text()
+        pd.claim(self.ws.deliver("core", "task-1"))
+        self.assertTrue(p.exists())
+        self.assertEqual(p.read_text(), before)
+
+    def test_release_returns_it_to_pending(self):
+        s = self.ws.deliver("core", "task-1")
+        pd.release(pd.claim(s))
+        got = [pd.parse_sentinel(p.name)[0] for p in pd.pending(self.root, "core")]
+        self.assertEqual(got, ["task-1"])
+
+    def test_release_refuses_an_unclaimed_sentinel(self):
+        s = self.ws.deliver("core", "task-1")
+        with self.assertRaises(pd.NotDelivered):
+            pd.release(s)
+
+    def test_find_locates_under_either_name(self):
+        s = self.ws.deliver("core", "task-1")
+        self.assertEqual(pd.find(self.root, "core", "task-1"), s)
+        c = pd.claim(s)
+        self.assertEqual(pd.find(self.root, "core", "task-1"), c)
+
+    def test_find_returns_none_when_undelivered(self):
+        self.assertIsNone(pd.find(self.root, "core", "task-absent"))
+
+
+class TestResidue(Base):
+    def test_result_without_flag_is_completed(self):
+        self.ws.payload("task-1")
+        pd.claim(self.ws.deliver("core", "task-1"))
+        self.ws.result("task-1")
+        self.assertEqual(pd.residue(self.root, "core", "task-1"), "completed")
+
+    def test_result_plus_flag_is_finished(self):
+        self.ws.payload("task-1")
+        self.ws.result("task-1")
+        self.ws.flag("core", "task-1")
+        self.assertEqual(pd.residue(self.root, "core", "task-1"), "finished")
+
+    def test_delivered_unclaimed_work_is_named_not_a_fallback(self):
+        """It is work waiting, so it must not share a name with 'nothing here'."""
+        self.ws.payload("task-1")
+        self.ws.deliver("core", "task-1")
+        self.assertEqual(pd.residue(self.root, "core", "task-1"), "unclaimed")
+
+    def test_nothing_anywhere_is_clean(self):
+        self.assertEqual(pd.residue(self.root, "core", "task-absent"), "clean")
+
+    def test_claimed_without_result_died_mid_work(self):
+        self.ws.payload("task-1")
+        pd.claim(self.ws.deliver("core", "task-1"))
+        self.assertEqual(pd.residue(self.root, "core", "task-1"), "died-mid-work")
+
+    def test_sentinel_without_payload_is_stale(self):
+        self.ws.deliver("core", "task-1")
+        self.assertEqual(pd.residue(self.root, "core", "task-1"), "stale-sentinel")
+
+    def test_payload_without_sentinel_is_undelivered(self):
+        self.ws.payload("task-1")
+        self.assertEqual(pd.residue(self.root, "core", "task-1"), "undelivered")
+
+    def test_archived_payload_is_not_undelivered(self):
+        self.ws.payload("task-1")
+        pd.archived_payload(self.root, "task-1").write_text("{}", encoding="utf-8")
+        self.assertEqual(pd.residue(self.root, "core", "task-1"), "clean")
+
+
+class TestSweep(Base):
+    def test_releases_work_a_crash_left_claimed(self):
+        self.ws.payload("task-1")
+        pd.claim(self.ws.deliver("core", "task-1"))
+        out = pd.sweep(self.root, "core")
+        self.assertEqual(out["released"], ["task-1"])
+        self.assertTrue((self.root / "deliveries/core/task-1").exists())
+
+    def test_does_not_release_finished_work(self):
+        self.ws.payload("task-1")
+        pd.claim(self.ws.deliver("core", "task-1"))
+        self.ws.result("task-1")
+        out = pd.sweep(self.root, "core")
+        self.assertEqual(out["completed"], ["task-1"])
+        self.assertEqual(out["released"], [])
+        self.assertTrue((self.root / "deliveries/core/task-1.claimed").exists())
+
+    def test_removes_a_sentinel_whose_payload_is_gone(self):
+        self.ws.deliver("core", "task-1")
+        out = pd.sweep(self.root, "core")
+        self.assertEqual(out["stale"], ["task-1"])
+        self.assertIsNone(pd.find(self.root, "core", "task-1"))
+
+    def test_reports_untouched_work_as_ready(self):
+        self.ws.payload("task-1")
+        self.ws.deliver("core", "task-1")
+        self.assertEqual(pd.sweep(self.root, "core")["ready"], ["task-1"])
+
+    def test_is_idempotent(self):
+        self.ws.payload("task-1")
+        pd.claim(self.ws.deliver("core", "task-1"))
+        pd.sweep(self.root, "core")
+        second = pd.sweep(self.root, "core")
+        self.assertEqual(second["released"], [])
+        self.assertEqual(second["ready"], ["task-1"])
+
+    def test_finished_work_is_retired_not_handed_back(self):
+        """Result + flag + a lingering sentinel must never re-enter the queue."""
+        self.ws.payload("task-1")
+        pd.claim(self.ws.deliver("core", "task-1"))
+        self.ws.result("task-1")
+        self.ws.flag("core", "task-1")
+        out = pd.sweep(self.root, "core")
+        self.assertEqual(out["retired"], ["task-1"])
+        self.assertEqual(out["ready"], [])
+        self.assertIsNone(pd.find(self.root, "core", "task-1"))
+
+    def test_every_residue_state_has_a_sweep_branch(self):
+        """A state with no branch must fail loudly, not fall through to ready."""
+        states = ("unclaimed", "died-mid-work", "completed", "finished",
+                  "stale-sentinel", "undelivered", "clean")
+        seen = set()
+        for name, build in (
+            ("unclaimed", lambda: (self.ws.payload("task-1"), self.ws.deliver("core", "task-1"))),
+            ("died-mid-work", lambda: (self.ws.payload("task-1"), pd.claim(self.ws.deliver("core", "task-1")))),
+            ("completed", lambda: (self.ws.payload("task-1"), pd.claim(self.ws.deliver("core", "task-1")), self.ws.result("task-1"))),
+            ("finished", lambda: (self.ws.payload("task-1"), pd.claim(self.ws.deliver("core", "task-1")), self.ws.result("task-1"), self.ws.flag("core", "task-1"))),
+            ("stale-sentinel", lambda: (self.ws.deliver("core", "task-1"),)),
+        ):
+            with tempfile.TemporaryDirectory() as d:
+                self.ws = Workspace(d); self.root = self.ws.root
+                build()
+                self.assertEqual(pd.residue(self.root, "core", "task-1"), name)
+                pd.sweep(self.root, "core")   # raises if the state has no branch
+                seen.add(name)
+        # the two remaining states have no sentinel, so sweep never sees them
+        self.assertEqual(set(states) - seen, {"undelivered", "clean"})
+
+    def test_sweep_never_touches_a_sibling(self):
+        self.ws.payload("task-2")
+        other = self.ws.deliver("worker-1", "task-2")
+        claimed = pd.claim(other)
+        pd.sweep(self.root, "core")
+        self.assertTrue(claimed.exists())
+
+
+class TestPayload(Base):
+    def test_reads_delivered_payload(self):
+        self.ws.payload("task-1", "write the docs")
+        self.assertEqual(pd.read_payload(self.root, "task-1")["task"], "write the docs")
+
+    def test_missing_payload_is_none(self):
+        self.assertIsNone(pd.read_payload(self.root, "task-absent"))
+
+    def test_corrupt_payload_is_none_not_a_crash(self):
+        (self.root / "tasks" / "task-1.json").write_text("{not json", encoding="utf-8")
+        self.assertIsNone(pd.read_payload(self.root, "task-1"))
+
+
+class TestCLI(Base):
+    def run_cli(self, *args):
+        return subprocess.run(
+            [sys.executable, str(Path(__file__).resolve().parents[1] / "src" / "pool_delivery.py"),
+             "--workspace", str(self.root), *args],
+            capture_output=True, text=True, timeout=30)
+
+    def test_pending_lists_task_ids(self):
+        self.ws.payload("task-1")
+        self.ws.deliver("core", "task-1")
+        r = self.run_cli("pending")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertEqual(r.stdout.strip(), "task-1")
+
+    def test_residue_prints_the_state(self):
+        self.ws.payload("task-1")
+        r = self.run_cli("residue", "--task-id", "task-1")
+        self.assertEqual(r.stdout.strip(), "undelivered")
+
+    def test_sweep_emits_json(self):
+        self.ws.payload("task-1")
+        self.ws.deliver("core", "task-1")
+        r = self.run_cli("sweep")
+        self.assertIn('"ready"', r.stdout)
+        self.assertIn("task-1", r.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/pool-delivery.test.py
+++ b/tests/pool-delivery.test.py
@@ -53,24 +53,24 @@ class Base(unittest.TestCase):
 
 
 class TestSentinelNames(Base):
-    def test_unclaimed_parses(self):
+    def test_pending_parses(self):
         self.assertEqual(pd.parse_sentinel("task-abc.txt"), ("task-abc", False))
         # Extensionless is NOT a sentinel: the watcher that wakes a worker
         # emits for no other extension, so such a file would never be seen.
         self.assertIsNone(pd.parse_sentinel("task-abc"))
 
-    def test_claimed_parses(self):
-        self.assertEqual(pd.parse_sentinel("task-abc.claimed"), ("task-abc", True))
+    def test_accepted_parses(self):
+        self.assertEqual(pd.parse_sentinel("task-abc.accepted"), ("task-abc", True))
 
     def test_non_sentinel_rejected(self):
         for name in ("roster.json", "task-abc.json", ".DS_Store", "notes.txt"):
             self.assertIsNone(pd.parse_sentinel(name), name)
 
     def test_suffix_substitutes_never_appends(self):
-        """A claimed sentinel must not still read as unclaimed."""
-        claimed = pd.parse_sentinel("task-abc.claimed")
-        self.assertTrue(claimed[1])
-        self.assertNotIn(".claimed", claimed[0])
+        """A accepted sentinel must not still read as pending."""
+        accepted = pd.parse_sentinel("task-abc.accepted")
+        self.assertTrue(accepted[1])
+        self.assertNotIn(".accepted", accepted[0])
 
     def test_recipient_id_is_validated(self):
         for bad in ("../core", "core/../x", "Core", "", "a" * 40):
@@ -97,9 +97,9 @@ class TestPending(Base):
     def test_absent_folder_is_not_an_error(self):
         self.assertEqual(pd.pending(self.root, "worker-nope"), [])
 
-    def test_claimed_is_not_pending(self):
+    def test_accepted_is_not_pending(self):
         s = self.ws.deliver("core", "task-1")
-        pd.claim(s)
+        pd.accept(s)
         self.assertEqual(pd.pending(self.root, "core"), [])
 
     def test_ordered_by_delivery_time(self):
@@ -122,48 +122,48 @@ class TestPending(Base):
         got = [pd.parse_sentinel(p.name)[0] for p in pd.pending(self.root, "worker-1")]
         self.assertEqual(got, ["task-for-worker"])
 
-    def test_claim_by_a_worker_lands_in_the_workers_folder(self):
+    def test_accept_by_a_worker_lands_in_the_workers_folder(self):
         self.ws.payload("task-1")
         s = self.ws.deliver("worker-1", "task-1")
-        c = pd.claim(s)
+        c = pd.accept(s)
         self.assertEqual(c.parent.name, "worker-1")
         self.assertIsNone(pd.find(self.root, "core", "task-1"))
 
 
-class TestClaim(Base):
-    def test_claim_renames_in_place(self):
+class TestAccept(Base):
+    def test_accept_renames_in_place(self):
         s = self.ws.deliver("core", "task-1")
-        c = pd.claim(s)
+        c = pd.accept(s)
         self.assertFalse(s.exists())
         self.assertTrue(c.exists())
-        self.assertEqual(c.name, "task-1.claimed")
+        self.assertEqual(c.name, "task-1.accepted")
 
-    def test_claim_is_exclusive(self):
+    def test_accept_is_exclusive(self):
         s = self.ws.deliver("core", "task-1")
-        pd.claim(s)
+        pd.accept(s)
         with self.assertRaises(OSError):
-            pd.claim(s)
+            pd.accept(s)
 
-    def test_claiming_a_claimed_sentinel_is_refused(self):
+    def test_accepting_an_accepted_sentinel_is_refused(self):
         s = self.ws.deliver("core", "task-1")
-        c = pd.claim(s)
+        c = pd.accept(s)
         with self.assertRaises(pd.NotDelivered):
-            pd.claim(c)
+            pd.accept(c)
 
-    def test_claim_does_not_touch_the_payload(self):
+    def test_accept_does_not_touch_the_payload(self):
         p = self.ws.payload("task-1")
         before = p.read_text()
-        pd.claim(self.ws.deliver("core", "task-1"))
+        pd.accept(self.ws.deliver("core", "task-1"))
         self.assertTrue(p.exists())
         self.assertEqual(p.read_text(), before)
 
     def test_release_returns_it_to_pending(self):
         s = self.ws.deliver("core", "task-1")
-        pd.release(pd.claim(s))
+        pd.release(pd.accept(s))
         got = [pd.parse_sentinel(p.name)[0] for p in pd.pending(self.root, "core")]
         self.assertEqual(got, ["task-1"])
 
-    def test_release_refuses_an_unclaimed_sentinel(self):
+    def test_release_refuses_a_pending_sentinel(self):
         s = self.ws.deliver("core", "task-1")
         with self.assertRaises(pd.NotDelivered):
             pd.release(s)
@@ -171,7 +171,7 @@ class TestClaim(Base):
     def test_find_locates_under_either_name(self):
         s = self.ws.deliver("core", "task-1")
         self.assertEqual(pd.find(self.root, "core", "task-1"), s)
-        c = pd.claim(s)
+        c = pd.accept(s)
         self.assertEqual(pd.find(self.root, "core", "task-1"), c)
 
     def test_find_returns_none_when_undelivered(self):
@@ -181,7 +181,7 @@ class TestClaim(Base):
 class TestResidue(Base):
     def test_result_without_flag_is_completed(self):
         self.ws.payload("task-1")
-        pd.claim(self.ws.deliver("core", "task-1"))
+        pd.accept(self.ws.deliver("core", "task-1"))
         self.ws.result("task-1")
         self.assertEqual(pd.residue(self.root, "core", "task-1"), "completed")
 
@@ -191,18 +191,18 @@ class TestResidue(Base):
         self.ws.flag("core", "task-1")
         self.assertEqual(pd.residue(self.root, "core", "task-1"), "finished")
 
-    def test_delivered_unclaimed_work_is_named_not_a_fallback(self):
+    def test_delivered_pending_work_is_named_not_a_fallback(self):
         """It is work waiting, so it must not share a name with 'nothing here'."""
         self.ws.payload("task-1")
         self.ws.deliver("core", "task-1")
-        self.assertEqual(pd.residue(self.root, "core", "task-1"), "unclaimed")
+        self.assertEqual(pd.residue(self.root, "core", "task-1"), "pending")
 
     def test_nothing_anywhere_is_clean(self):
         self.assertEqual(pd.residue(self.root, "core", "task-absent"), "clean")
 
-    def test_claimed_without_result_died_mid_work(self):
+    def test_accepted_without_result_died_mid_work(self):
         self.ws.payload("task-1")
-        pd.claim(self.ws.deliver("core", "task-1"))
+        pd.accept(self.ws.deliver("core", "task-1"))
         self.assertEqual(pd.residue(self.root, "core", "task-1"), "died-mid-work")
 
     def test_sentinel_without_payload_is_stale(self):
@@ -222,10 +222,10 @@ class TestResidue(Base):
 class TestFlagAfterDrain(Base):
     def test_a_done_flag_with_no_result_is_finished_not_died(self):
         """The bridge drains results/<id>.txt on delivery. A crash between the
-        flag and the archive, then a drain, leaves .claimed + flag + payload and
+        flag and the archive, then a drain, leaves .accepted + flag + payload and
         NO result. Reading that as died-mid-work re-runs finished work."""
         self.ws.payload("task-1")
-        pd.claim(self.ws.deliver("core", "task-1"))
+        pd.accept(self.ws.deliver("core", "task-1"))
         self.ws.flag("core", "task-1")                  # result already drained
         self.assertEqual(pd.residue(self.root, "core", "task-1"), "finished")
         out = pd.sweep(self.root, "core")
@@ -234,21 +234,21 @@ class TestFlagAfterDrain(Base):
 
 
 class TestSweep(Base):
-    def test_releases_work_a_crash_left_claimed(self):
+    def test_releases_work_a_crash_left_accepted(self):
         self.ws.payload("task-1")
-        pd.claim(self.ws.deliver("core", "task-1"))
+        pd.accept(self.ws.deliver("core", "task-1"))
         out = pd.sweep(self.root, "core")
         self.assertEqual(out["released"], ["task-1"])
         self.assertTrue((self.root / "deliveries/core/task-1.txt").exists())
 
     def test_does_not_release_finished_work(self):
         self.ws.payload("task-1")
-        pd.claim(self.ws.deliver("core", "task-1"))
+        pd.accept(self.ws.deliver("core", "task-1"))
         self.ws.result("task-1")
         out = pd.sweep(self.root, "core")
         self.assertEqual(out["completed"], ["task-1"])
         self.assertEqual(out["released"], [])
-        self.assertTrue((self.root / "deliveries/core/task-1.claimed").exists())
+        self.assertTrue((self.root / "deliveries/core/task-1.accepted").exists())
 
     def test_removes_a_sentinel_whose_payload_is_gone(self):
         self.ws.deliver("core", "task-1")
@@ -263,7 +263,7 @@ class TestSweep(Base):
 
     def test_is_idempotent(self):
         self.ws.payload("task-1")
-        pd.claim(self.ws.deliver("core", "task-1"))
+        pd.accept(self.ws.deliver("core", "task-1"))
         pd.sweep(self.root, "core")
         second = pd.sweep(self.root, "core")
         self.assertEqual(second["released"], [])
@@ -272,7 +272,7 @@ class TestSweep(Base):
     def test_finished_work_is_retired_not_handed_back(self):
         """Result + flag + a lingering sentinel must never re-enter the queue."""
         self.ws.payload("task-1")
-        pd.claim(self.ws.deliver("core", "task-1"))
+        pd.accept(self.ws.deliver("core", "task-1"))
         self.ws.result("task-1")
         self.ws.flag("core", "task-1")
         out = pd.sweep(self.root, "core")
@@ -282,14 +282,14 @@ class TestSweep(Base):
 
     def test_every_residue_state_has_a_sweep_branch(self):
         """A state with no branch must fail loudly, not fall through to ready."""
-        states = ("unclaimed", "died-mid-work", "completed", "finished",
+        states = ("pending", "died-mid-work", "completed", "finished",
                   "stale-sentinel", "undelivered", "clean")
         seen = set()
         for name, build in (
-            ("unclaimed", lambda: (self.ws.payload("task-1"), self.ws.deliver("core", "task-1"))),
-            ("died-mid-work", lambda: (self.ws.payload("task-1"), pd.claim(self.ws.deliver("core", "task-1")))),
-            ("completed", lambda: (self.ws.payload("task-1"), pd.claim(self.ws.deliver("core", "task-1")), self.ws.result("task-1"))),
-            ("finished", lambda: (self.ws.payload("task-1"), pd.claim(self.ws.deliver("core", "task-1")), self.ws.result("task-1"), self.ws.flag("core", "task-1"))),
+            ("pending", lambda: (self.ws.payload("task-1"), self.ws.deliver("core", "task-1"))),
+            ("died-mid-work", lambda: (self.ws.payload("task-1"), pd.accept(self.ws.deliver("core", "task-1")))),
+            ("completed", lambda: (self.ws.payload("task-1"), pd.accept(self.ws.deliver("core", "task-1")), self.ws.result("task-1"))),
+            ("finished", lambda: (self.ws.payload("task-1"), pd.accept(self.ws.deliver("core", "task-1")), self.ws.result("task-1"), self.ws.flag("core", "task-1"))),
             ("stale-sentinel", lambda: (self.ws.deliver("core", "task-1"),)),
         ):
             with tempfile.TemporaryDirectory() as d:
@@ -304,9 +304,9 @@ class TestSweep(Base):
     def test_sweep_never_touches_a_sibling(self):
         self.ws.payload("task-2")
         other = self.ws.deliver("worker-1", "task-2")
-        claimed = pd.claim(other)
+        accepted = pd.accept(other)
         pd.sweep(self.root, "core")
-        self.assertTrue(claimed.exists())
+        self.assertTrue(accepted.exists())
 
 
 class TestPayload(Base):
@@ -438,10 +438,10 @@ class TestWatch(Base):
 
 class TestSweepTotality(Base):
     def test_one_task_under_both_names_is_visited_once(self):
-        """`claimed + pending` can list the same id twice; a second visit would
+        """`accepted + pending` can list the same id twice; a second visit would
         act on a state the first pass already resolved."""
         self.ws.payload("task-1")
-        pd.claim(self.ws.deliver("core", "task-1"))
+        pd.accept(self.ws.deliver("core", "task-1"))
         self.ws.deliver("core", "task-2")
         self.ws.payload("task-2")
         out = pd.sweep(self.root, "core")

--- a/tests/pool-delivery.test.py
+++ b/tests/pool-delivery.test.py
@@ -19,8 +19,8 @@ class Workspace:
             (self.root / d).mkdir(parents=True, exist_ok=True)
 
     def payload(self, task_id, body="do a thing"):
-        p = self.root / "tasks" / f"{task_id}.json"
-        p.write_text(f'{{"id": "{task_id}", "task": "{body}"}}', encoding="utf-8")
+        p = self.root / "tasks" / f"{task_id}.txt"
+        p.write_text(f"id: {task_id}\nsource: test\ntask: {body}\n", encoding="utf-8")
         return p
 
     def deliver(self, recipient, task_id):
@@ -284,15 +284,16 @@ class TestSweep(Base):
 
 
 class TestPayload(Base):
-    def test_reads_delivered_payload(self):
+    def test_reads_the_bridges_task_file_as_text(self):
         self.ws.payload("task-1", "write the docs")
-        self.assertEqual(pd.read_payload(self.root, "task-1")["task"], "write the docs")
+        self.assertIn("task: write the docs", pd.read_payload(self.root, "task-1"))
 
     def test_missing_payload_is_none(self):
         self.assertIsNone(pd.read_payload(self.root, "task-absent"))
 
-    def test_corrupt_payload_is_none_not_a_crash(self):
-        (self.root / "tasks" / "task-1.json").write_text("{not json", encoding="utf-8")
+    def test_an_archived_payload_is_none(self):
+        """finish moved it; a lingering sentinel must not resurrect it."""
+        pd.archived_payload(self.root, "task-1").write_text("id: task-1\n", encoding="utf-8")
         self.assertIsNone(pd.read_payload(self.root, "task-1"))
 
 


### PR DESCRIPTION
> **Stack** #4106 → #4107 → #4109 → #4108 → #4110 — this is layer 1 of 5. Parent: —; base branch `main`. Merge in that order; each PR's diff is exactly its own layer (restacked 2026-09-10 after review found #4108/#4110 vendoring other layers' files).

## What this is

Stage one of the worker pool per [`docs/worker-pool-design.md`](https://github.com/sonichi/sutando/pull/4037): **the delivery mechanism alone, no routing.** Plan and checklist at #4105.

The design's sequencing rule is explicit about why this comes first:

> **first** improve the single-core delivery mechanism alone ... verified against session exit, watcher restart, a missed notification and a stalled consumer; **then** add routing on top. Sequenced this way the pool release changes routing decisions and nothing underneath them.

## What it implements

The recipient half of the specified layout:

```
tasks/<task-id>.json                         payload, immutable after admission
deliveries/<recipient-id>/<task-id>          sentinel, 0 bytes, unclaimed
deliveries/<recipient-id>/<task-id>.claimed  sentinel, 0 bytes, claimed
```

Creating a sentinel assigns — the router's job, deliberately not in this module. **Renaming claims:** `os.rename` is atomic and exclusive, so a loser sees `OSError` and walks away. No lock, no lease, no coordinator.

`residue` reads what a crash left behind from the filesystem alone, with no journal. `sweep` maps each state to exactly one action, and an unmapped state raises rather than falling through — that fallthrough is what hid the second defect below.

| state | condition | sweep does |
|---|---|---|
| `unclaimed` | sentinel, payload live | ready |
| `died-mid-work` | claimed, no result | release to the same recipient |
| `completed` | result, no flag | leave for the owner to finish |
| `finished` | result + flag | retire the sentinel |
| `stale-sentinel` | sentinel, payload gone | drop it |
| `undelivered` / `clean` | no sentinel | not reachable from a sweep |

## This serves the core, not just workers

Per the design, *"the core is a recipient with a watcher like any other"*. The core reads `deliveries/core/` from the first install, so **there is no protocol switch when the first worker appears or the last one leaves.** That is why this lands useful before any worker exists.

## The structural guarantee

**New files only.** `src/watch-tasks-stream.sh` is untouched — the core's executed code is byte-identical, and you can verify that from the diff rather than taking my word:

```
$ git diff --name-only origin/main...HEAD -- src/watch-tasks-stream.sh
(empty)
```

## Defects the tests found that reading did not

- the id pattern accepted a dot, so a payload name dropped in a delivery folder parsed as a valid sentinel;
- a task with a result **and** a done-flag whose payload was not yet archived read as `undelivered`. Since nothing retired the sentinel on completion, the happy path would have handed finished work back as ready and re-run it — not an edge case;
- `residue` and `sweep` used one name for two states, which is what hid the second defect.

## Evidence

```
$ python3 tests/pool-delivery.test.py
Ran 42 tests in 0.175s
OK
```

Mutations verified to fail them — each breaks a distinct test:

| mutation | result |
|---|---|
| `claim` appends the suffix instead of substituting | caught |
| `sweep` ignores a completed task | caught |
| recipient folder hardcoded to `core` | caught |
| `finished` falls through to `ready` (the original bug) | caught by `test_finished_work_is_retired_not_handed_back` |

`scripts/review-checks.sh` PASS on the cumulative diff.

## Why draft

Stage one is not finished. The design names four verifications this does not yet exhibit: **session exit, watcher restart, a missed notification, a stalled consumer**. This is tested against a real temp filesystem, but not against a live recipient surviving a restart. Those are the next commits on this branch, not a follow-up PR.

Refs #4105, #4037
