### PR TITLE
fix(current-track): the pin vocabulary must not match a denial or the ordinary verb

### DIFF
--- a/src/current_track.py
+++ b/src/current_track.py
@@ -50,8 +50,10 @@ DEFAULT_KEEP = 32 * 1024
 
 #: Entries other tools read as LIVE STATE, kept at any age: an aged-out hold
 #: reads as "not held" to every consumer that greps this file.
+#: `HOLD` is case-SENSITIVE: the lowercase verb and a denial of a hold are not state.
+#: A config-value hold keeps its own alternative — that spelling is lowercase by nature.
 PIN_DEFAULT = re.compile(
-    r"\bHOLD\b|\bhands off\b|\bdo not (?:merge|touch|act|proceed)\b"
+    r"(?-i:\bHOLD\b)|\b\w+=hold\b|\bhands off\b|\bdo not (?:merge|touch|act|proceed)\b"
     r"|\bin force until\b|\bawait(?:ing)? (?:the )?owner\b|⛔",
     re.I,
 )

--- a/tests/current-track-rotate.test.py
+++ b/tests/current-track-rotate.test.py
@@ -621,5 +621,70 @@ class RotateAndAppend(unittest.TestCase):
         r = Cli(app, stdin="## 2026-09-06T02:30Z — no trailing newline")(self.p); self.assertEqual(r.returncode, 0)
         self.assertTrue(self.p.read_text().endswith("no trailing newline\n"))
 
+
+
+class PinVocabularyDiscriminates(unittest.TestCase):
+    """PIN_DEFAULT must pin a live hold and NOT pin prose that merely says the word.
+
+    The pin is what keeps rotation from archiving an owner hold, so a false positive is
+    not cosmetic: on a real host 4 of 4 sections matched and rotation could free 0 B,
+    while the entries actually holding the budget were a negation and a note *about*
+    this bug. Measured on two hosts: every match was the ordinary lowercase verb.
+    """
+
+    # Each case is (text, should_pin, why) — one table so a new spelling is one row.
+    CASES = [
+        # --- must NOT pin: the word appears, the meaning is absent -------------------
+        ("No live owner hold in this section.", False, "negation"),
+        ("Prior block's facts still hold: CLEAN is not the review bar.", False, "ordinary verb"),
+        ("`gh api --paginate` all still hold — see the block below.", False, "ordinary verb"),
+        ("the bottleneck the recap pointed at, now with a real number. I hold 6.", False,
+         "ordinary verb"),
+        ("3 of 4 sections pinned by the GENUINE authority.json hold; see #4031.", False,
+         "a note ABOUT a hold is not a hold"),
+        # --- must pin: a real, live marker ------------------------------------------
+        ("## HOLD: hands off #3166, in force until 2026-09-08", True, "all-caps status token"),
+        ("state/authority.json github_formal_review=hold (set after an unauthorised APPROVE)",
+         True, "config VALUE — lowercase by construction"),
+        ("do not merge until the owner rules", True, "imperative"),
+        ("hands off this branch", True, "imperative"),
+        ("⛔ blocked pending the owner", True, "explicit marker"),
+        ("awaiting the owner", True, "explicit wait"),
+    ]
+
+    def test_each_spelling_is_classified_by_meaning_not_by_the_bare_word(self):
+        for text, want, why in self.CASES:
+            with self.subTest(why=why, text=text[:48]):
+                got = bool(ct.PIN_DEFAULT.search(text))
+                self.assertEqual(got, want,
+                                 f"{'should' if want else 'should NOT'} pin ({why}): {text!r}")
+
+    def test_a_negation_entry_is_actually_archived_end_to_end(self):
+        """The regex table above is a unit; this is the behaviour it exists to produce."""
+        pre, _ = fixture(0)
+        denial = ("## 2026-01-01T00:00Z — status\nNo live owner hold in this section.\n\n")
+        E = lambda n, c: f"## 2026-09-{n:02d}T00:00Z — entry {n}\n" + (c * 900) + "\n\n"
+        filler = "".join(E(i, "x") for i in range(2, 29))
+        r = ct.plan(pre + denial + filler, 8 * 1024)
+        self.assertNotIn("No live owner hold", r.head,
+                         "an entry that says there is NO hold was pinned as if there were one")
+        self.assertIn("No live owner hold", r.archived, "it must be archived, never dropped")
+
+    def test_a_config_value_hold_survives_every_budget(self):
+        """The genuine marker on this host is a lowercase config value, not a status token.
+        A case-sensitive-only narrowing would archive it the moment it is not newest."""
+        pre, _ = fixture(0)
+        hold = ("## 2026-01-01T00:00Z — authority\n"
+                "state/authority.json github_formal_review=hold — unruled\n\n")
+        E = lambda n, c: f"## 2026-09-{n:02d}T00:00Z — entry {n}\n" + (c * 900) + "\n\n"
+        filler = "".join(E(i, "y") for i in range(2, 29))
+        corpus = pre + hold + filler
+        for keep in (1024, 4 * 1024, 8 * 1024, 32 * 1024):
+            with self.subTest(keep=keep):
+                r = ct.plan(corpus, keep)
+                self.assertIn("github_formal_review=hold", r.head,
+                              f"live config-value hold archived at keep={keep}")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #4031.

## What changed, and why

`PIN_DEFAULT` matched `\bHOLD\b` under `re.I`, so **any entry containing the lowercase word pinned itself** and rotation could never archive it. A pin is what keeps an owner hold from ageing out of `current-track.md`, so the alternative was deliberately broad — but the ordinary English verb is far commoner in this file than the status token.

Two things make the false positives worse than noise, and both are live on my host:

- **A denial pins.** `"No live owner hold in this section"` says there is *no* hold, and pinned the section as if there were one.
- **A note about the bug pins the section it is written in.** 13,382 B of my anchor is held by an entry that describes *this issue*. A vocabulary-matching pin cannot tell a hold from a discussion of holds.

Net effect: 4 of 4 sections matched, rotation freed **0 B**, and the file sat over a budget it is read against on every proactive-loop pass.

## The fix, and why it is not just case-sensitivity

@john-the-dev proposed `(?-i:\bHOLD\b)` on the issue, verified on his host. That narrowing is right and I kept it — it is what kills `facts still hold`. **On its own it pins zero entries here**, because my genuine marker is a *config value*, not a status token:

```
state/authority.json  github_formal_review=hold     <- lowercase by construction, and load-bearing
```

His markers are `[awaiting the owner]` / `[do not merge]`; mine is a quoted config field. A case-only narrowing therefore archives a live hold the moment it stops being the newest entry — the same class of harm he flagged for `--no-pin`, one layer in. So the fix keeps his narrowing **and** gives the config-value spelling its own alternative:

```python
r"(?-i:\bHOLD\b)|\b\w+=hold\b|\bhands off\b|\bdo not (?:merge|touch|act|proceed)\b"
r"|\bin force until\b|\bawait(?:ing)? (?:the )?owner\b|⛔"
```

Every other alternative is byte-identical, so this is inert on hosts whose markers are imperatives.

## Before/after evidence — my real anchor file, not a fixture

```
$ python3 scripts/current-track-rotate.py --dry-run <anchor>      # parent commit
current-track-rotate: ROTATED BUT STILL OVER BUDGET — would archive 0 B; the head is
33678 B against a 32768 B budget because 4 pinned entries hold 33631 B

$ python3 scripts/current-track-rotate.py --dry-run <anchor>      # this branch
current-track-rotate: would move 1257 B to <anchor>-archive.md, keep 32421 B
```

Applied for real on a copy, the safety properties that matter:

```
genuine  github_formal_review=hold   in head: 1   in archive: 0
released "No live owner hold"        in archive: 1
conservation  33678 -> head 32421 + archive 1257 = 33678   (delta +0)
```

## Second host, from the reviewer (added after @john-the-dev's approval at `0deda7636`)

He ran the three patterns against his own live anchor rather than a fixture, which is the part my host could not supply:

```
                  entries pinned    bytes pinned
OLD                    11/11             40,281     <- 100% of the file
case-only narrowing     5/11             10,960
this PR                 5/11             10,960     <- identical on every entry
```

Two things this settles that my evidence could not. **The added `\b\w+=hold\b` is inert there by construction, not by luck** — `=hold` does not occur anywhere in his file, and the two patterns agree on all 11 entries. And the impact is far larger than my host showed: the shipped vocabulary pins his *entire* anchor, so rotation has nothing to release and can only move what recency allows; this frees **29,321 B** for rotation there.

He also ran the falsifying check a narrowing deserves — a narrowing's risk is a false negative, so the question is what stops being pinned. Of the six entries that lose their pin, all six are the ordinary verb or a note referring to a hold, and his one live `## HOLD (in force until ...)` marker still pins. **Zero genuine holds dropped.** Two of those six are `"PQ 5 (ag2-space hold)"` and `"because of the Stand-authority hold"` — the "a note ABOUT a hold is not a hold" row of the test table, found in the wild on a host that is not mine.

Note his `review-checks.sh --diff` returned **PARTIAL**, not PASS: prose-cap skipped because his tree is not this PR's revision, leaving 2 in-scope files unscanned. CI is the authority for that check, and it is green here.

## Tests run

`tests/current-track-rotate.test.py`: **41 -> 44**, `rc=0`.

The new `PinVocabularyDiscriminates` case is a table of eleven spellings — five that must not pin (denial, three ordinary-verb forms measured from two hosts' real anchors, and a note about a hold) and six that must (all-caps token, config value, both imperatives, `⛔`, and an explicit wait) — plus two behavioural tests: a denial entry is actually archived, and a config-value hold survives at every budget from 1 KiB to 32 KiB.

**Red control, at the parent commit with only the tests applied:**

```
Ran 44 tests ... FAILED (failures=6)
AssertionError: True != False : should NOT pin (negation): 'No live owner hold in this section.'
AssertionError: True != False : should NOT pin (ordinary verb): "Prior block's facts still hold: ..."
AssertionError: True != False : should NOT pin (a note ABOUT a hold is not a hold): '3 of 4 sections pinned ...'
```

With the fix: `Ran 44 tests ... OK`. The 41 pre-existing tests are untouched and still pass — their fixtures use the all-caps `HOLD:` token, which is exactly the spelling the narrowing preserves.

`scripts/review-checks.sh --diff`: **PASS** (hardcoded-paths + root-artifacts + prose-cap). It failed my first attempt on the 2-line comment cap; the narrative moved here, which is what it asks for.

## What this does NOT fix

A vocabulary pin still cannot distinguish a hold from a description of one — this PR only stops the two spellings that are provably not state. The durable form is an explicit marker (a literal `⛔`, or a front-matter field) that no prose can accidentally spell. I did not add one here because it changes how entries are authored, which is a separate decision.

— sutando-qingyun-air

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWadxs6dcfXYn9LSK511m2

