### PR TITLE
fix(proactive-loop): the monologue gate names the repo it measured

### DIFF
--- a/skills/proactive-loop/scripts/pr-monologue-check.py
+++ b/skills/proactive-loop/scripts/pr-monologue-check.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 from datetime import datetime, timezone
 
+DEFAULT_REPO = "sonichi/sutando"
 DEFAULT_THRESHOLD = 3
 
 
@@ -82,12 +83,17 @@ def fetch(repo: str, number: int):
 def main(argv=None) -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("number", type=int)
-    ap.add_argument("--repo", default="sonichi/sutando")
+    ap.add_argument("--repo", default=None)
     ap.add_argument("--me", required=True)
     ap.add_argument("--threshold", type=int, default=DEFAULT_THRESHOLD)
     ap.add_argument("--count-bots", action="store_true",
                     help="treat bot comments as engagement (default: ignore them)")
     args = ap.parse_args(argv)
+    # A silently-defaulted repo makes this gate unable to refuse: on a PR in any
+    # other repo it reads the same-numbered thread here, which is usually empty.
+    if args.repo is None:
+        args.repo = DEFAULT_REPO
+        print(f"assuming --repo {DEFAULT_REPO} (not given)", file=sys.stderr)
 
     if args.threshold < 1:
         print("threshold must be >= 1", file=sys.stderr)
@@ -101,16 +107,17 @@ def main(argv=None) -> int:
     events = merge_events(comments, reviews, keep_bots=args.count_bots)
     run, span = trailing_run(events, args.me)
     if not events:
-        print(f"#{args.number}: no comment/review activity yet — safe to post")
+        print(f"{args.repo}#{args.number}: no comment/review activity yet — safe to post")
         return 0
     if run >= args.threshold:
         print(
-            f"REFUSE #{args.number}: your last {run} events on this thread are ALL yours, "
+            f"REFUSE {args.repo}#{args.number}: your last {run} events on this thread are ALL yours, "
             f"spanning {span:.1f}d, with no reply from anyone else.\n"
             f"  Posting again talks into silence. Re-solicit a human/stand, or leave it."
         )
         return 1
-    print(f"#{args.number}: trailing run of yours = {run} (threshold {args.threshold}) — safe to post")
+    print(f"{args.repo}#{args.number}: trailing run of yours = {run} "
+          f"(threshold {args.threshold}) — safe to post")
     return 0
 
 

--- a/tests/proactive-loop-pr-monologue-check.test.py
+++ b/tests/proactive-loop-pr-monologue-check.test.py
@@ -108,6 +108,33 @@ class TestMain(unittest.TestCase):
     def test_empty_thread_is_safe(self):
         self.assertEqual(self._with_fetch([], [], ["1", "--me", ME]), 0)
 
+    def test_every_verdict_names_the_repo_it_measured(self):
+        """A bare `#1` cannot be told apart from the same number in another repo,
+        so a cross-repo run reads an unrelated (usually empty) thread and can only
+        ever say "safe" — a gate that cannot refuse."""
+        import io
+        from contextlib import redirect_stdout
+        for argv, want in (
+                (["1", "--me", ME], g.DEFAULT_REPO),
+                (["1", "--me", ME, "--repo", "other/repo"], "other/repo"),
+        ):
+            for events in ([], [c(T(1), ME)]):
+                buf = io.StringIO()
+                with redirect_stdout(buf):
+                    self._with_fetch(events, [], argv)
+                self.assertIn(f"{want}#1", buf.getvalue())
+
+    def test_the_repo_reaches_fetch(self):
+        seen = []
+        real = g.fetch
+        g.fetch = lambda repo, number: (seen.append(repo), ([], []))[1]
+        try:
+            g.main(["1", "--me", ME])
+            g.main(["1", "--me", ME, "--repo", "other/repo"])
+        finally:
+            g.fetch = real
+        self.assertEqual(seen, [g.DEFAULT_REPO, "other/repo"])
+
     def test_a_fetch_failure_is_cannot_answer_not_a_green_light(self):
         real = g.fetch
 

--- a/tests/proactive-loop-pr-monologue-check.test.py
+++ b/tests/proactive-loop-pr-monologue-check.test.py
@@ -118,7 +118,9 @@ class TestMain(unittest.TestCase):
                 (["1", "--me", ME], g.DEFAULT_REPO),
                 (["1", "--me", ME, "--repo", "other/repo"], "other/repo"),
         ):
-            for events in ([], [c(T(1), ME)]):
+            # All three verdict branches, including REFUSE — the branch the tool
+            # exists for, and the one a wrong repo silently makes unreachable.
+            for events in ([], [c(T(1), ME)], [c(T(1), ME), c(T(2), ME), c(T(3), ME)]):
                 buf = io.StringIO()
                 with redirect_stdout(buf):
                     self._with_fetch(events, [], argv)


### PR DESCRIPTION
## The bug

`--repo` defaulted to `sonichi/sutando` silently, and all three verdict lines printed a bare `#<number>`. Run the gate against a PR in any other repo and it measures the same-numbered thread *here* — then reports the result in output you cannot tell apart from a real one.

That is worse than a wrong number. This is a **refusal** gate, and the thread it falls back to is usually empty or long-closed, so it returns "safe to post" every time. Outside the default repo it was structurally incapable of refusing.

Found by running it live. `ag2-space/ag2space-backend#1060` had one trailing comment of mine; the gate said zero:

```
$ pr-monologue-check.py 1060 --me john-the-dev
#1060: trailing run of yours = 0 (threshold 3) — safe to post

$ pr-monologue-check.py 1060 --me john-the-dev --repo ag2-space/ag2space-backend
#1060: trailing run of yours = 1 (threshold 3) — safe to post
```

Same command, same printed subject, different answer. The first read `sonichi/sutando#1060` — a PR closed since May with `comments=0`.

Step 9.5 of the proactive-loop skill invokes it as `pr-monologue-check.py <number> --me <login>`, with no repo, which is how I hit it.

## The fix

Verdicts print `<owner/name>#<number>`; a defaulted repo announces itself on stderr. No change to threshold, counting, or exit codes.

```
$ pr-monologue-check.py 1060 --me john-the-dev
assuming --repo sonichi/sutando (not given)        # stderr
sonichi/sutando#1060: trailing run of yours = 0 (threshold 3) — safe to post

$ pr-monologue-check.py 1060 --me john-the-dev --repo ag2-space/ag2space-backend
ag2-space/ag2space-backend#1060: trailing run of yours = 1 (threshold 3) — safe to post
```

I kept the default rather than making `--repo` required: the skill's documented invocation omits it, and the common case really is this repo. What was missing was the gate saying so.

## Tests

Two cases, on the branch. `test_every_verdict_names_the_repo_it_measured` covers both the empty-thread and populated-thread verdicts under both a defaulted and an explicit repo; `test_the_repo_reaches_fetch` pins that the resolved value is what `fetch` receives.

**Mutation-proven** — reverting only the script, keeping the tests, with `__pycache__` cleared:

```
$ python3 tests/proactive-loop-pr-monologue-check.test.py     # script at origin/main
Ran 27 tests in 0.002s
FAILED (errors=2)

$ python3 tests/proactive-loop-pr-monologue-check.test.py     # this branch
Ran 27 tests in 0.002s
OK                                                            # exit 0
```

The pre-existing 25 pass in both directions, so the two new ones are what the fix buys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Evidence correction (after @yixuan-ag2's review)

They could not reproduce the `#1060` case — both forms returned `trailing run 0` for them, while for me the two forms still differ. Both readings are correct: an intervening reply resets a trailing run, so **the demonstration above is verdict-based and therefore time-dependent**. Their sentence for it is the right one: *"a same-answer probe on one number cannot discriminate here."*

Here is the same defect shown by **subject** rather than by verdict, which cannot decay:

```
sonichi/sutando#1060              MERGED  2026-05-23  chore(schedule-crons): fallback /proactive-loop …
ag2-space/ag2space-backend#1060   OPEN    2026-09-10  feat(synapse): make the pairing-code mint interval …
```

Two unrelated pull requests. Before this change both are reported as `#1060`, and the bare invocation always reads the first.

## Blast radius, corrected

I wrote that the bare form "reads the same-numbered thread here (usually empty) and can only ever return safe". That over-claims, and @yixuan-ag2 bounded it correctly:

- number exists in **both** repos (sutando runs past 4100, the backend ~1060, so any number ≤ ~1060) → a plausible **wrong answer**, silently. This is the dangerous class and the one `#1060` falls in.
- number exists in **only one** → `rc=2` and a 404. A loud refusal, not a wrong answer.

So the fix matters for low numbers and is cosmetic for high ones. Still worth it — the verdict line naming `sonichi/sutando#1060` is visibly wrong to anyone who meant the backend — but the correct claim is narrower than the one I opened with.
