### PR TITLE
fix(tool-suites-check): a workspace with no vault repo is not an untracked file

### DIFF
--- a/skills/proactive-loop/scripts/tool-suites-check.py
+++ b/skills/proactive-loop/scripts/tool-suites-check.py
@@ -149,20 +149,28 @@ def _warn_if_uncarried(decl: Path) -> None:
 
     Advisory only — a backup concern must never fail a test run.
     """
-    ws = decl.parent.parent
+    # hosts/<host>/X is two deep, state/X one: parent.parent lands inside the
+    # workspace for the carried path and would probe the wrong tree.
+    ws = decl.parent.parent.parent if decl.parent.parent.name == "hosts" else decl.parent.parent
     try:
         r = subprocess.run(["git", "-C", str(ws), "ls-files", "--error-unmatch",
                             str(decl.relative_to(ws))],
                            capture_output=True, text=True, timeout=10)
     except Exception:
         return                      # no git, no repo, or a path outside it: not our business
+    # git exits 128 for "not a git repository" WITHOUT raising, so the guard above
+    # never saw it: a workspace with no vault repo reported every file untracked.
+    if r.returncode == 128 or "not a git repository" in r.stderr:
+        return
     if r.returncode != 0:
+        move = ("" if decl.parent.parent.name == "hosts" else
+                f"Move it to hosts/<host>/{EXTRAS}, which the vault already carries with no "
+                f"config edit. Do NOT add a state/ path to vault.sync.include: the vault emits "
+                f"carve-outs after includes so a `state/` exclude re-ignores it, and `include` "
+                f"REPLACES the carrier set rather than extending it (see sync-workspace.sh:36-45).")
         print(f"[tool-suites-check] WARNING: {decl} is NOT tracked in the workspace vault. "
-              f"If it is lost, the suites it registers stop running SILENTLY (absent = no extras). "
-              f"Move it to hosts/<host>/{EXTRAS}, which the vault already carries with no config "
-              f"edit. Do NOT add a state/ path to vault.sync.include: the vault emits carve-outs "
-              f"after includes so a `state/` exclude re-ignores it, and `include` REPLACES the "
-              f"carrier set rather than extending it (see sync-workspace.sh:36-45).",
+              f"If it is lost, the suites it registers stop running SILENTLY (absent = no "
+              f"extras). {move}".rstrip(),
               file=sys.stderr)
 
 

--- a/tests/proactive-loop-tool-suites-check.test.py
+++ b/tests/proactive-loop-tool-suites-check.test.py
@@ -391,9 +391,8 @@ with tempfile.TemporaryDirectory() as td:
 
 print("\ncase: no vault repo at all is SILENT, not a permanent untracked warning")
 with tempfile.TemporaryDirectory() as td:
-    # No `git init`: git exits 128 "not a git repository" WITHOUT raising, so the
-    # probe cannot distinguish it from a tracked-but-absent file. Warning here is
-    # unactionable and fires on every pass forever.
+    # No `git init`: git exits 128 WITHOUT raising, so the probe cannot tell
+    # "no repo" from "untracked" and warns on every pass forever.
     ws = Path(td) / "ws"
     (ws / "state").mkdir(parents=True)
     f = ws / "state" / tsc.EXTRAS

--- a/tests/proactive-loop-tool-suites-check.test.py
+++ b/tests/proactive-loop-tool-suites-check.test.py
@@ -371,6 +371,9 @@ print("\ncase: the uncarried warning names a remedy that can actually work")
 with tempfile.TemporaryDirectory() as td:
     ws = Path(td) / "ws"
     (ws / "state").mkdir(parents=True)
+    # A REAL repo: an untracked file exits 1 here. Without one git exits 128,
+    # which is "I cannot tell", not "untracked" — see the no-repo case below.
+    subprocess.run(["git", "init", "-q", str(ws)], check=True)
     f = ws / "state" / tsc.EXTRAS
     f.write_text(json.dumps({"suites": []}))
     buf = io.StringIO()
@@ -385,6 +388,36 @@ with tempfile.TemporaryDirectory() as td:
           "Add its path to vault.sync.include." in msg, False)
     check("it names the carve-out ordering", "after includes" in msg, True)
     check("it warns that include REPLACES the carrier set", "REPLACES" in msg, True)
+
+print("\ncase: no vault repo at all is SILENT, not a permanent untracked warning")
+with tempfile.TemporaryDirectory() as td:
+    # No `git init`: git exits 128 "not a git repository" WITHOUT raising, so the
+    # probe cannot distinguish it from a tracked-but-absent file. Warning here is
+    # unactionable and fires on every pass forever.
+    ws = Path(td) / "ws"
+    (ws / "state").mkdir(parents=True)
+    f = ws / "state" / tsc.EXTRAS
+    f.write_text(json.dumps({"suites": []}))
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        tsc.extra_suites(f, Path(td))
+    check("no repo => no warning", "NOT tracked" in buf.getvalue(), False)
+
+print("\ncase: the carried hosts/<host>/ path is probed against the WORKSPACE")
+with tempfile.TemporaryDirectory() as td:
+    # hosts/<host>/X is two levels deep; parent.parent is <workspace>/hosts, so the
+    # probe ran against the wrong tree and the remedy told it to move where it is.
+    ws = Path(td) / "ws"
+    (ws / "hosts" / "H").mkdir(parents=True)
+    subprocess.run(["git", "init", "-q", str(ws)], check=True)
+    f = ws / "hosts" / "H" / tsc.EXTRAS
+    f.write_text(json.dumps({"suites": []}))
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        tsc.extra_suites(f, Path(td))
+    msg = buf.getvalue()
+    check("an untracked carried file still warns", "NOT tracked" in msg, True)
+    check("it does NOT tell it to move where it already is", "hosts/<host>/" in msg, False)
 
 print("\ncase: a state DIRECTORY still resolves (the pre-move call shape)")
 with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## The bug

`_warn_if_uncarried` asks `git ls-files --error-unmatch` whether the extras declaration is carried, and treats **any** non-zero exit as "not tracked". But git exits **128** for *"not a git repository"* without raising — so the `except Exception: return` guard above it, whose own comment already says *"no git, no repo, or a path outside it: not our business"*, never sees that case.

On a workspace that is not a repo, the probe cannot tell *"the vault exists and this file is missing from it"* from *"there is no vault"*. It reports the first.

Measured on a live host, running exactly what the function runs:

```
decl exists: True
the exact git call: rc=128
stderr: fatal: not a git repository (or any of the parent directories): .git
```

The result is a warning on **every pass, forever**, naming a data-loss risk that cannot occur, ending in advice to move a file to the path it is already at:

```
WARNING: .../hosts/<host>/tool-suites-extra.json is NOT tracked in the workspace vault.
... Move it to hosts/<host>/tool-suites-extra.json, which the vault already carries ...
```

A permanent unactionable warning is worse than none: it is the one you learn to scroll past, on a check whose whole purpose is telling you a silent failure has happened.

## Second defect, same probe

`ws = decl.parent.parent` resolves the workspace for the legacy `state/<file>` (one level) but lands on `<workspace>/hosts` for the carried `hosts/<host>/<file>` (two). So the canonical location is probed against the wrong tree, and the "move it to `hosts/<host>/`" remedy is self-referential exactly when the file is already correct. The remedy text is now omitted when the declaration is already carried.

## Change

- 128 / `not a git repository` → return, matching the guard's existing intent.
- Derive the workspace by depth rather than assuming one level.
- Emit the move-it remedy only when it names somewhere else.

Nothing else moves: a real repo with a genuinely untracked file still warns, with the same text.

## Tests

One existing case changed and two added. The existing "remedy names something that works" case built its workspace **without** `git init` — it was passing on the 128 path, so it asserted the bug. It now runs `git init`, where an untracked file exits 1, which is the case it meant to test.

**Mutation-proven** — script reverted to `origin/main`, tests kept, `__pycache__` cleared:

```
FAIL no repo => no warning: got True want False
FAIL it does NOT tell it to move where it already is: got True want False
FAIL — 2 check(s)
```

and on this branch:

```
PASS — tool-suites-check tests     # exit 0
```

The third new check ("an untracked carried file still warns") passes both ways on purpose — it is the control that the fix silences only the unmeasurable case.

## Note for whoever merges

`#3961` also touches `skills/proactive-loop/scripts/tool-suites-check.py`, in a different function (the missing-`workspace/scripts` early return). Separate concern, but the two will want a rebase depending on merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
