### PR TITLE
docs(proactive-loop): chain the PR gate so its refusal cannot be skipped

### DIFF
--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -101,8 +101,8 @@ caps this file and refuses date stamps in it).
    owned and ownerless as two separately labelled groups; one undifferentiated list means change nothing.
    Not running with no trees → `Monitor` `bash src/watch-tasks-stream.sh` persistent. A missing sentinel
    is UNKNOWN, not dead; never hand-roll a process check.
-9.5. **PR thread gate**, before posting to a PR thread:
-   `python3 skills/proactive-loop/scripts/pr-monologue-check.py <PR url|number --repo owner/name> --me <your-login>`
+9.5. **PR thread gate**, chained so a refusal cannot be skipped:
+   `python3 skills/proactive-loop/scripts/pr-monologue-check.py <PR url|number --repo owner/name> --me <your-login> && gh pr comment <number> --repo <owner/name> --body-file <f>`
    (0 safe · 1 refuse, run and span named · 2 cannot answer). On refuse, re-solicit through a stand.
 10. **Discord.** Check the channels in `reference_discord_channels.md`; forward actionable public items to
     the dev channel. #bot2bot tags: `claim:` `blocked:` `done:` `ping:` `nack:` `opinion-requested:`.

--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -81,8 +81,10 @@ caps this file and refuses date stamps in it).
    (no whole-list interface; a removal needs a reason); audit notes with `--audit-notes "$PWD"` and
    retire merged items. Compute: `idle-held.py … | idle-surface-hash.py --state …` → `post <hash>` or
    `quiet <hash>`. On `post`: send ONE FYI line to the owner's primary channel, THEN re-run the same
-   pipe with `--commit` on `idle-surface-hash.py`. Never commit before the send; never build the list
-   from recall.
+   pipe with `--write` on `idle-held.py` AND `--commit` on `idle-surface-hash.py` — each flag belongs
+   to its own side, and `--commit` alone leaves added holds, removal reasons and notes unpersisted, so
+   the next pass re-posts the stale hold. Never commit before the send; never build the list from
+   recall.
    `quiet` + owner active in the last ~30 min → still drop a one-line activity signal.
 6.7. **Failure closure.** Every reported failure ends with the mechanism that prevents its recurrence,
    linked, or the sentence "no mechanism exists, because X". A filed lesson is not a third option.

--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -80,8 +80,9 @@ caps this file and refuses date stamps in it).
    `python3 skills/proactive-loop/scripts/idle-held.py --state "$WORKSPACE/state/idle-streak.json" --remove <id> --reason "<why>" --add <id>:<gate> --note <owner/repo#n>`
    (no whole-list interface; a removal needs a reason); audit notes with `--audit-notes "$PWD"` and
    retire merged items. Compute: `idle-held.py … | idle-surface-hash.py --state …` → `post <hash>` or
-   `quiet <hash>`. On `post`: send ONE FYI line to the owner's primary channel, THEN re-run with
-   `--write` and `--commit`. Never commit before the send; never build the list from recall.
+   `quiet <hash>`. On `post`: send ONE FYI line to the owner's primary channel, THEN re-run the same
+   pipe with `--commit` on `idle-surface-hash.py`. Never commit before the send; never build the list
+   from recall.
    `quiet` + owner active in the last ~30 min → still drop a one-line activity signal.
 6.7. **Failure closure.** Every reported failure ends with the mechanism that prevents its recurrence,
    linked, or the sentence "no mechanism exists, because X". A filed lesson is not a third option.

--- a/tests/proactive-loop-idle-surface-composition.test.py
+++ b/tests/proactive-loop-idle-surface-composition.test.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""The documented step-6.5 sequence, end to end across both CLIs.
+
+The component suites exercise `idle-held.py` and `idle-surface-hash.py` apart;
+neither can catch a documented pipe that drops one side's persistence.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+HELD = REPO / "skills" / "proactive-loop" / "scripts" / "idle-held.py"
+HASH = REPO / "skills" / "proactive-loop" / "scripts" / "idle-surface-hash.py"
+
+fails: list[str] = []
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    print(f"  {'ok  ' if cond else 'FAIL'}  {name}" + ("" if cond else f"   {detail}"))
+    if not cond:
+        fails.append(name)
+
+
+def seed(state: Path) -> None:
+    state.write_text(json.dumps({"held_item_ids": [["old", "owner"]]}))
+
+
+def run(state: Path, held_extra: list[str], hash_extra: list[str]):
+    a = subprocess.run([sys.executable, str(HELD), "--state", str(state),
+                        "--remove", "old", "--reason", "superseded",
+                        "--add", "new:ci", "--note", "owner/repo#42", *held_extra],
+                       capture_output=True, text=True)
+    b = subprocess.run([sys.executable, str(HASH), "--state", str(state), *hash_extra],
+                       input=a.stdout, capture_output=True, text=True)
+    return a, b, json.loads(state.read_text())
+
+
+print("proactive-loop idle surface: the documented composition")
+
+with tempfile.TemporaryDirectory() as d:
+    st = Path(d) / "idle.json"
+    seed(st)
+    a, b, doc = run(st, ["--write"], ["--commit"])
+    check("documented pipe: both CLIs exit 0", a.returncode == 0 and b.returncode == 0,
+          f"{a.returncode}/{b.returncode} {a.stderr[:120]}{b.stderr[:120]}")
+    check("documented pipe: the held EDIT persists",
+          doc.get("held_item_ids") == [["new", "ci"]], json.dumps(doc.get("held_item_ids")))
+    check("documented pipe: the note persists alongside it",
+          (doc.get("held_item_notes") or {}).get("new") == "owner/repo#42",
+          json.dumps(doc.get("held_item_notes")))
+
+    # The next unchanged pass must be quiet: an FYI that repeats itself trains the
+    # owner to ignore the surface that exists to interrupt them.
+    a2 = subprocess.run([sys.executable, str(HELD), "--state", str(st)],
+                        capture_output=True, text=True)
+    b2 = subprocess.run([sys.executable, str(HASH), "--state", str(st)],
+                        input=a2.stdout, capture_output=True, text=True)
+    check("documented pipe: an unchanged next pass is quiet",
+          b2.stdout.startswith("quiet"),
+          f"held rc={a2.returncode} out={b2.stdout.strip()[:90]} err={b2.stderr[:90]}")
+
+with tempfile.TemporaryDirectory() as d:
+    st = Path(d) / "idle.json"
+    seed(st)
+    _, _, only_commit = run(st, [], ["--commit"])
+    check("CONTROL: --commit alone loses the edit, which is why both flags are documented",
+          only_commit.get("held_item_ids") == [["old", "owner"]],
+          json.dumps(only_commit.get("held_item_ids")))
+
+print(f"\n{'FAILED: ' + ', '.join(fails) if fails else 'all passed'}")
+sys.exit(1 if fails else 0)


### PR DESCRIPTION
## The gap

Step 3.45 writes its gate as a chain:

```
gh-duplicate-check.py … && gh issue create …
```

so a refusal stops the action. Step 9.5 is the same kind of gate — refuse a post into a thread that is only me — but was written as a bare command with the consequence in prose:

```
pr-monologue-check.py <number> --me <login>
(0 safe · 1 refuse … ). On refuse, re-solicit through a stand.
```

Nothing enforces that. Run the check and the post in one block and the refusal is *printed after the comment is already up*.

## It happened

On #3873 the gate returned refuse — `Posting again talks into silence. Re-solicit a human/stand, or leave it.` — and my comment posted anyway, because both commands were in one block and I read the output afterwards. The check was correct: three consecutive events on that thread were mine. The prose form gave a correct verdict no later than the action it was meant to prevent.

## Change

Two lines. 9.5 now reads as `check && post`, matching 3.45.

It also names `--repo` in the invocation. The documented form omitted it, and the default resolves to this repo — so a run against a PR anywhere else silently measures the same-numbered thread here, which is usually empty and therefore always "safe". That default is fixed separately in #4114; naming the flag here is the part that belongs to the skill.

`tests/proactive-loop-skill-budget.test.py`: `Ran 5 tests … OK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
