### PR TITLE
feat(pool): build what the broker needs to draw the worker picker

### DIFF
--- a/skills/worker-pool/scripts/create_worker.py
+++ b/skills/worker-pool/scripts/create_worker.py
@@ -29,6 +29,7 @@ for _p in (str(_SCRIPTS), str(_REPO / "src")):
     if _p not in sys.path:
         sys.path.insert(0, _p)
 
+import pool_advertise as pa  # noqa: E402
 import pool_roster as pr  # noqa: E402
 
 import spawn_worker as sw  # noqa: E402
@@ -80,13 +81,13 @@ def preflight(workspace, repo, room: str) -> None:
                       "stamp — see #3875")
 
 
-def compile_with(workspace, worker_id: str, label: str, room) -> dict:
+def compile_with(workspace, worker_id: str, label: str, room, runtime=None) -> dict:
     """Add this worker to the roster, and its room to the bindings.
 
     Delegates to the one locked registration writer: two `create_worker` runs
     against the same workspace must not race each other's read-merge-write.
     """
-    return pr.register_worker(workspace, worker_id, label, room)
+    return pr.register_worker(workspace, worker_id, label, room, runtime=runtime)
 
 
 def report(made: dict, roster: dict, room, orphans: list) -> str:
@@ -150,13 +151,27 @@ def main(argv=None) -> int:
         return REFUSED
 
     try:
-        roster = compile_with(workspace, made["worker_id"], a.label, a.room)
+        roster = compile_with(workspace, made["worker_id"], a.label, a.room,
+                              runtime=made.get("runtime"))
     except (pr.RosterError, OSError) as e:
         # The worker exists and the roster does not know it: say so loudly with
         # the repair, or it becomes the silent stale-roster case again.
         print(f"create-worker: worker {made['worker_id']} was created, but the "
               f"roster could not be compiled: {e}\n"
               f"  it will receive nothing until the roster names it.",
+              file=sys.stderr)
+        return 1
+
+    try:
+        # The picker follows the roster only through this file (the bridge
+        # sends it); a compile without it leaves the picker one worker behind.
+        pa.write_advertisement(workspace)
+    except OSError as e:
+        print(f"create-worker: worker {made['worker_id']} is routable (roster "
+              f"v{roster['version']}), but the advertisement could not be "
+              f"written: {e}\n"
+              f"  the picker will not show it until this succeeds: "
+              f"python3 skills/worker-pool/scripts/pool_advertise.py --workspace {workspace} --write",
               file=sys.stderr)
         return 1
 

--- a/skills/worker-pool/scripts/pool_advertise.py
+++ b/skills/worker-pool/scripts/pool_advertise.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""What the pool tells the broker, so the worker picker can show it.
+
+The picker reads two different things and they arrive by different routes:
+
+    POST /v1/workers            live/dead ids  -> each row's STATUS
+    PUT  /v1/agents/<me>/profile workers meta  -> each row's LABEL and runtime
+
+Send only one and the picker is half-right: statuses with raw 32-hex ids for
+names, or names attached to nothing. So both bodies are built here, from the
+one roster, and a caller sends them together.
+
+This module builds; it does not send. The transport, its credentials and its
+retry policy belong to whatever already talks to the broker.
+"""
+from __future__ import annotations
+
+import argparse
+import contextlib
+import fcntl
+import json
+import tempfile
+import os
+import sys
+import time
+from pathlib import Path
+
+# Sibling skill scripts resolve from this directory; core helpers from the repo
+# root (parents[3] of skills/<name>/scripts/<file>.py, symlinks resolved).
+_SCRIPTS = Path(__file__).resolve().parent
+for _p in (str(_SCRIPTS), str(_SCRIPTS.parents[2] / "src")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import pool_roster as pr  # noqa: E402
+
+# The broker's field names are the affinity era's; the roster is this design's.
+# Translating here keeps that vocabulary out of everything else.
+ACTIVE_STATES = ("live",)
+# Not answering now: a recovering worker is shown as such, never as "available".
+DEAD_STATES = ("abandoned", "recovering")
+
+
+def _rows(roster: dict) -> dict:
+    workers = roster.get("workers")
+    return workers if isinstance(workers, dict) else {}
+
+
+def bindings(roster: dict) -> dict:
+    """The roster's room -> worker bindings in the broker's row shape, so a
+    picker can show which worker a room is pinned to. A binding is a worker id
+    or a one-member list, the two forms the roster accepts; a binding to a
+    retired worker is not advertised, since retired ids occur nowhere."""
+    rows = _rows(roster)
+    out = {}
+    for room, bound in (roster.get("bindings") or {}).items():
+        members = [m for m in (bound if isinstance(bound, list) else [bound])
+                   if isinstance(m, str) and m]
+        members = [m for m in members if (rows.get(m) or {}).get("state") != "retired"]
+        if members:
+            out[str(room)] = {"instance": members[0], "instances": members, "pinned": True}
+    return out
+
+
+def _labels(roster: dict) -> dict:
+    """What each non-retired worker is called here, as applied by this runtime."""
+    out = {}
+    for wid, row in sorted(_rows(roster).items()):
+        row = row or {}
+        if row.get("state") == "retired":
+            continue
+        out[wid] = str(row.get("label") or wid)
+    return out
+
+
+def report(roster: dict, now=None) -> dict:
+    """The reported leg: runtime facts, plus how far this runtime has applied
+    the user's configuration. Never a source of names or bindings — the broker
+    files `applied` as last-reported and keeps the user's intent apart from it."""
+    workers = []
+    for wid, row in sorted(_rows(roster).items()):
+        row = row or {}
+        w = {"id": wid, "state": str(row.get("state"))}
+        if row.get("runtime"):
+            w["runtime"] = str(row["runtime"])
+        workers.append(w)
+    return {"ts": int(now if now is not None else time.time()),
+            "roster_version": roster.get("version"),
+            "workers": workers,
+            "applied": {"config_version": roster.get("config_version"),
+                        "labels": _labels(roster),
+                        "bindings": bindings(roster)}}
+
+
+def snapshot(roster: dict, now=None) -> dict:
+    """The `POST /v1/workers` body today's broker accepts, projected from the
+    report: live ids, ids not answering (abandoned or recovering), bindings."""
+    rep = report(roster, now)
+    live = [w["id"] for w in rep["workers"] if w["state"] in ACTIVE_STATES]
+    dead = [w["id"] for w in rep["workers"] if w["state"] in DEAD_STATES]
+    return {"ts": rep["ts"], "live_cores": live, "dead_cores": dead,
+            "bindings": rep["applied"]["bindings"],
+            "roster_version": rep["roster_version"]}
+
+
+def profile_workers(roster: dict) -> dict:
+    """The profile card's `workers` map today's broker accepts, projected from
+    the report's applied labels. Retired workers are omitted — the broker treats
+    any id it has metadata for as at least "available"."""
+    rep = report(roster)
+    runtime = {w["id"]: w.get("runtime") for w in rep["workers"]}
+    out = {}
+    for wid, label in rep["applied"]["labels"].items():
+        meta = {"label": label}
+        if runtime.get(wid):
+            meta["runtime"] = runtime[wid]
+        out[wid] = meta
+    return out
+
+
+def advertisement(workspace, now=None) -> dict:
+    """Both bodies from one roster read, so they cannot disagree."""
+    roster = pr.load_roster(workspace)
+    if roster is None:
+        raise FileNotFoundError("no roster to advertise")
+    return {"report": report(roster, now),
+            "workers_snapshot": snapshot(roster, now),
+            "profile_patch": {"workers": profile_workers(roster)}}
+
+
+ADVERTISEMENT_FILE = "pool-advertisement.json"
+
+
+def advertisement_path(workspace) -> Path:
+    """Beside the roster: the bridge reads this file and sends the two bodies."""
+    return pr.roster_path(workspace).parent / ADVERTISEMENT_FILE
+
+
+def _lock_path(path: Path) -> Path:
+    return path.with_name(path.name + ".lock")
+
+
+def _current_version(path: Path):
+    try:
+        return int(json.loads(path.read_text())["workers"]["roster_version"])
+    except (OSError, ValueError, KeyError, TypeError):
+        return None
+
+
+def write_advertisement(workspace, now=None) -> Path:
+    """Persist the advertisement for the bridge: `report` is the reported leg,
+    `workers` the exact POST /v1/workers body, `profile_workers` the profile
+    card's workers field. Written whole-or-not (temp file + replace) so a
+    reader never sees a torn file, and under a lock from the roster read to
+    the replace, refusing to overwrite a newer roster's advertisement, so two
+    writers cannot publish out of order."""
+    path = advertisement_path(workspace)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(_lock_path(path), "a+") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        try:
+            ad = advertisement(workspace, now)
+            mine = ad["report"].get("roster_version")
+            live = _current_version(path)
+            if isinstance(mine, int) and live is not None and live > mine:
+                return path  # a newer roster is already published; this one is stale
+            body = json.dumps({"ts": ad["workers_snapshot"]["ts"],
+                               "report": ad["report"],
+                               "workers": ad["workers_snapshot"],
+                               "profile_workers": ad["profile_patch"]["workers"]},
+                              indent=2, sort_keys=True)
+            fd, tmp = tempfile.mkstemp(prefix=".pool-advertisement.", dir=path.parent)
+            try:
+                with os.fdopen(fd, "w") as fh:
+                    fh.write(body + "\n")
+                os.replace(tmp, path)
+            except BaseException:
+                with contextlib.suppress(OSError):
+                    os.unlink(tmp)
+                raise
+        finally:
+            fcntl.flock(lock, fcntl.LOCK_UN)
+    return path
+
+
+def ensure_advertisement(workspace, now=None):
+    """Write the advertisement when the file does not say what the roster says
+    now: missing, an older roster, or an older schema (a file without the
+    report, or whose report differs from the roster's). None when there is no
+    roster. For boot, where a compile may have happened while nothing was
+    running to advertise it; cheap to call every run."""
+    if not pr.roster_path(workspace).exists():
+        return None
+    path = advertisement_path(workspace)
+    roster = pr.load_roster(workspace)
+    try:
+        have = json.loads(path.read_text())["report"]
+    except (OSError, ValueError, KeyError, TypeError):
+        have = None
+    want = report(roster, now=0)
+    if isinstance(have, dict) and {k: v for k, v in have.items() if k != "ts"} == \
+            {k: v for k, v in want.items() if k != "ts"}:
+        return path
+    return write_advertisement(workspace, now=now)
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="build the pool's broker advertisement")
+    ap.add_argument("--workspace", default=None)
+    ap.add_argument("--write", action="store_true",
+                    help="also write state/pool-advertisement.json for the bridge")
+    ap.add_argument("--ensure", action="store_true",
+                    help="write the file only if the roster has moved past it; no roster is not an error")
+    a = ap.parse_args(argv)
+    if a.ensure:
+        path = ensure_advertisement(a.workspace)
+        print(path if path else "pool-advertise: no roster, nothing to advertise", file=sys.stderr)
+        return 0
+    try:
+        ad = advertisement(a.workspace)
+        if a.write:
+            print(write_advertisement(a.workspace), file=sys.stderr)
+        print(json.dumps(ad, indent=2))
+    except FileNotFoundError as e:
+        print(f"pool-advertise: {e}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/worker-pool/scripts/pool_roster.py
+++ b/skills/worker-pool/scripts/pool_roster.py
@@ -194,7 +194,7 @@ def compile_roster(workspace, workers: dict, bindings=None, version=None) -> dic
     return roster
 
 
-def register_worker(workspace, worker_id: str, label: str, room=None) -> dict:
+def register_worker(workspace, worker_id: str, label: str, room=None, runtime=None) -> dict:
     """Add a worker to the roster and, if given, bind its room — the one
     production writer for this transaction.
 
@@ -206,6 +206,8 @@ def register_worker(workspace, worker_id: str, label: str, room=None) -> dict:
     with _locked(workspace):
         workers = dict((load_roster(workspace) or {}).get("workers") or {})
         workers[worker_id] = {"state": "live", "label": label or worker_id}
+        if runtime:
+            workers[worker_id]["runtime"] = str(runtime)
         bindings = dict(load_bindings(workspace))
         if room:
             bindings[room] = worker_id

--- a/skills/worker-pool/tests/create-worker-command.test.py
+++ b/skills/worker-pool/tests/create-worker-command.test.py
@@ -46,6 +46,7 @@ class Base(unittest.TestCase):
             (Path(workspace) / "deliveries" / wid).mkdir(parents=True)
             (Path(workspace) / "state" / "workers" / wid).mkdir(parents=True)
             return {"worker_id": wid, "label": kw.get("label") or wid,
+                    "runtime": kw.get("runtime") or "claude",
                     "cwd": kw.get("cwd") or str(repo),
                     "delivery_dir": str(Path(workspace) / "deliveries" / wid),
                     "tmux": {"socket": "/tmp/s.sock", "session_name": f"w-{wid}"}}
@@ -63,6 +64,35 @@ class Base(unittest.TestCase):
 
 
 class TestTheRosterCannotGoStale(Base):
+    def test_creating_a_worker_writes_the_advertisement_file(self):
+        self.run_cli("--label", "alpha")
+        got = json.loads((self.ws / "state" / "pool-advertisement.json").read_text())
+        self.assertEqual(sorted(got), ["profile_workers", "report", "ts", "workers"])
+        labels = [w["label"] for w in got["profile_workers"].values()]
+        self.assertEqual(labels, ["alpha"])
+        self.assertEqual(len(got["workers"]["live_cores"]) + len(got["workers"]["dead_cores"]), 1)
+
+    def test_the_resolved_runtime_reaches_the_roster_and_the_advertisement(self):
+        self.assertEqual(self.run_cli("--label", "Research", "--runtime", "codex"), 0)
+        wid = self.spawned[0]
+        self.assertEqual(pr.load_roster(self.ws)["workers"][wid]["runtime"], "codex")
+        got = json.loads((self.ws / "state" / "pool-advertisement.json").read_text())
+        self.assertEqual(got["profile_workers"][wid], {"label": "Research", "runtime": "codex"})
+
+    def test_an_advertisement_write_failure_is_reported_as_itself(self):
+        real = cw.pa.write_advertisement
+        cw.pa.write_advertisement = lambda ws, now=None: (_ for _ in ()).throw(OSError(28, "No space left"))
+        self.addCleanup(lambda: setattr(cw.pa, "write_advertisement", real))
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            rc = self.run_cli("--label", "alpha")
+        self.assertEqual(rc, 1)
+        self.assertIn(self.spawned[0], pr.load_roster(self.ws)["workers"])  # routable
+        self.assertIn("is routable", err.getvalue())
+        self.assertIn("advertisement could not be written", err.getvalue())
+        self.assertNotIn("roster could not be compiled", err.getvalue())
+        self.assertFalse((self.ws / "state" / "pool-advertisement.json").exists())
+
     def test_creating_a_worker_puts_it_in_the_roster(self):
         self.assertEqual(self.run_cli("--label", "reviewer"), 0)
         roster = pr.load_roster(self.ws)

--- a/skills/worker-pool/tests/pool-advertise.test.py
+++ b/skills/worker-pool/tests/pool-advertise.test.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""The picker shows what we advertise, so the two bodies must agree.
+
+Status comes from the snapshot, the name from the profile patch. A worker in
+one and not the other renders wrong rather than absent, which is why both are
+built from a single roster read.
+
+Run: python3 tests/pool-advertise.test.py
+"""
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+import unittest.mock
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import pool_advertise as pa  # noqa: E402
+
+import pool_roster as pr  # noqa: E402
+
+W1 = "a3f91c2d4e5b6a7c8d9e0f1a2b3c4d5e"
+W2 = "b4e02d3c5f6a7b8c9d0e1f2a3b4c5d6e"
+W3 = "c5f13e4d6a7b8c9d0e1f2a3b4c5d6e7f"
+
+
+class Base(unittest.TestCase):
+    def setUp(self):
+        self._t = tempfile.TemporaryDirectory()
+        self.addCleanup(self._t.cleanup)
+        self.ws = Path(self._t.name)
+
+    def roster(self, workers):
+        return pr.compile_roster(self.ws, workers, {})
+
+
+class TestStatusComesFromState(Base):
+    def test_live_is_active_and_abandoned_is_dead(self):
+        r = self.roster({W1: {"state": "live"}, W2: {"state": "abandoned"}})
+        snap = pa.snapshot(r, now=1000)
+        self.assertEqual(snap["live_cores"], [W1])
+        self.assertEqual(snap["dead_cores"], [W2])
+        self.assertEqual(snap["ts"], 1000)
+
+    def test_recovering_is_not_answering_never_available(self):
+        r = self.roster({W1: {"state": "recovering"}})
+        snap = pa.snapshot(r, now=1)
+        self.assertEqual(snap["live_cores"], [])
+        self.assertEqual(snap["dead_cores"], [W1])  # not answering now; never "available"
+
+    def test_the_roster_version_rides_along(self):
+        r = self.roster({W1: {"state": "live"}})
+        self.assertEqual(pa.snapshot(r, now=1)["roster_version"], r["version"])
+
+
+class TestNamesComeFromTheProfilePatch(Base):
+    def test_a_label_is_carried(self):
+        r = self.roster({W1: {"state": "live", "label": "reviewer"}})
+        self.assertEqual(pa.profile_workers(r)[W1]["label"], "reviewer")
+
+    def test_an_unlabelled_worker_falls_back_to_its_id(self):
+        r = self.roster({W1: {"state": "live"}})
+        self.assertEqual(pa.profile_workers(r)[W1]["label"], W1)
+
+    def test_a_declared_runtime_is_carried_so_a_codex_worker_reads_right(self):
+        r = self.roster({W1: {"state": "live", "runtime": "codex"}})
+        self.assertEqual(pa.profile_workers(r)[W1]["runtime"], "codex")
+
+    def test_no_runtime_is_omitted_rather_than_guessed(self):
+        # The broker defaults an absent runtime to claude; sending one we did
+        # not declare would make a guess look like a declaration.
+        r = self.roster({W1: {"state": "live"}})
+        self.assertNotIn("runtime", pa.profile_workers(r)[W1])
+
+    def test_a_retired_worker_is_advertised_nowhere(self):
+        # The broker renders any id it has metadata for, so leaving a retired
+        # worker here would pin a deleted worker to the picker permanently.
+        r = self.roster({W1: {"state": "live"}, W2: {"state": "retired"}})
+        self.assertNotIn(W2, pa.profile_workers(r))
+        snap = pa.snapshot(r, now=1)
+        self.assertNotIn(W2, snap["live_cores"] + snap["dead_cores"])
+
+
+class TestTheTwoBodiesAgree(Base):
+    def test_every_advertised_status_has_a_name(self):
+        r = self.roster({W1: {"state": "live", "label": "one"},
+                         W2: {"state": "abandoned"},
+                         W3: {"state": "recovering", "label": "three"}})
+        ad = pa.advertisement(self.ws, now=1)
+        named = set(ad["profile_patch"]["workers"])
+        snap = ad["workers_snapshot"]
+        self.assertTrue(set(snap["live_cores"] + snap["dead_cores"]) <= named)
+
+    def test_both_bodies_come_from_one_roster_read(self):
+        self.roster({W1: {"state": "live", "label": "one"}})
+        ad = pa.advertisement(self.ws, now=7)
+        self.assertEqual(ad["workers_snapshot"]["live_cores"], [W1])
+        self.assertEqual(ad["profile_patch"]["workers"][W1]["label"], "one")
+
+    def test_no_roster_refuses_rather_than_advertising_an_empty_pool(self):
+        # An empty advertisement would retire every worker the picker shows.
+        with self.assertRaises(FileNotFoundError):
+            pa.advertisement(self.ws)
+
+
+class TestCli(Base):
+    def test_it_prints_both_bodies_as_json(self):
+        self.roster({W1: {"state": "live", "label": "one"}})
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            self.assertEqual(pa.main(["--workspace", str(self.ws)]), 0)
+        got = json.loads(out.getvalue())
+        self.assertEqual(got["workers_snapshot"]["live_cores"], [W1])
+        self.assertEqual(got["profile_patch"]["workers"][W1]["label"], "one")
+
+    def test_no_roster_exits_two_and_says_so(self):
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertEqual(pa.main(["--workspace", str(self.ws)]), 2)
+        self.assertIn("no roster", err.getvalue())
+
+
+class AdvertisementFile(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.ws = Path(self.tmp.name)
+        pr.compile_roster(self.ws, {"w1": {"label": "alpha", "state": "live",
+                                            "runtime": "claude"}}, {}, version=1)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_the_file_carries_both_bodies_exactly(self):
+        path = pa.write_advertisement(self.ws, now=1700000000)
+        self.assertEqual(path, self.ws / "state" / "pool-advertisement.json")
+        got = json.loads(path.read_text())
+        ad = pa.advertisement(self.ws, now=1700000000)
+        self.assertEqual(got["ts"], 1700000000)
+        self.assertEqual(got["workers"], ad["workers_snapshot"])
+        self.assertEqual(got["profile_workers"], ad["profile_patch"]["workers"])
+        self.assertEqual(got["profile_workers"]["w1"]["label"], "alpha")
+
+    def test_the_write_leaves_no_temp_file_behind(self):
+        pa.write_advertisement(self.ws)
+        names = sorted(p.name for p in (self.ws / "state").iterdir())
+        self.assertNotIn(True, [n.startswith(".pool-advertisement.") for n in names])
+        self.assertIn("pool-advertisement.json", names)
+
+    def test_the_cli_write_flag_writes_and_prints_the_path(self):
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            rc = pa.main(["--workspace", str(self.ws), "--write"])
+        self.assertEqual(rc, 0)
+        self.assertIn("pool-advertisement.json", err.getvalue())
+        self.assertEqual(json.loads(out.getvalue())["profile_patch"]["workers"]["w1"]["label"], "alpha")
+        self.assertTrue((self.ws / "state" / "pool-advertisement.json").exists())
+
+    def test_a_failed_replace_leaves_neither_file_nor_temp(self):
+        import os
+        real = os.replace
+
+        def boom(src, dst):
+            raise OSError("disk full")
+
+        pa.os.replace = boom
+        try:
+            with self.assertRaises(OSError):
+                pa.write_advertisement(self.ws)
+        finally:
+            pa.os.replace = real
+        names = [p.name for p in (self.ws / "state").iterdir()]
+        self.assertNotIn("pool-advertisement.json", names)
+        self.assertFalse(any(n.startswith(".pool-advertisement.") for n in names))
+
+    def test_no_roster_means_no_file(self):
+        empty = Path(tempfile.mkdtemp())
+        with self.assertRaises(FileNotFoundError):
+            pa.write_advertisement(empty)
+        self.assertFalse((empty / "state" / "pool-advertisement.json").exists())
+
+
+class BindingsInTheSnapshot(unittest.TestCase):
+    def test_each_bound_room_is_a_pinned_row_for_its_worker(self):
+        ws = Path(tempfile.mkdtemp())
+        pr.compile_roster(ws, {"w1": {"label": "alpha", "state": "live"}},
+                          {"!a:x": "w1"}, version=1)
+        snap = pa.snapshot(pr.load_roster(ws), now=1)
+        self.assertEqual(snap["bindings"],
+                         {"!a:x": {"instance": "w1", "instances": ["w1"], "pinned": True}})
+        # A binding with no worker (a cleared pin) is not a row.
+        self.assertEqual(pa.bindings({"bindings": {"!b:x": ""}}), {})
+
+    def test_no_bindings_is_an_empty_map_not_a_missing_key(self):
+        ws = Path(tempfile.mkdtemp())
+        pr.compile_roster(ws, {"w1": {"label": "alpha", "state": "live"}}, {}, version=1)
+        self.assertEqual(pa.snapshot(pr.load_roster(ws), now=1)["bindings"], {})
+
+
+class EnsureAtBoot(unittest.TestCase):
+    def _ws(self, version=1):
+        ws = Path(tempfile.mkdtemp())
+        pr.compile_roster(ws, {"w1": {"label": "alpha", "state": "live"}}, {}, version=version)
+        return ws
+
+    def test_an_existing_roster_without_the_file_gets_one(self):
+        ws = self._ws()
+        path = pa.ensure_advertisement(ws, now=5)
+        self.assertEqual(path, pa.advertisement_path(ws))
+        self.assertEqual(json.loads(path.read_text())["workers"]["roster_version"], 1)
+
+    def test_calling_ensure_twice_with_nothing_changed_writes_once(self):
+        ws = self._ws()
+        path = pa.ensure_advertisement(ws, now=5)
+        first = path.stat().st_mtime_ns
+        self.assertEqual(pa.ensure_advertisement(ws, now=9), path)
+        self.assertEqual(path.stat().st_mtime_ns, first)
+
+    def test_a_current_file_is_left_alone(self):
+        ws = self._ws()
+        path = pa.write_advertisement(ws, now=5)
+        before = path.read_bytes(), path.stat().st_mtime_ns
+        pa.ensure_advertisement(ws, now=9)
+        self.assertEqual((path.read_bytes(), path.stat().st_mtime_ns), before)
+
+    def test_a_roster_that_moved_past_the_file_rewrites_it(self):
+        ws = self._ws()
+        pa.write_advertisement(ws, now=5)
+        pr.compile_roster(ws, {"w1": {"label": "alpha", "state": "live"},
+                              "w2": {"label": "beta", "state": "live"}}, {}, version=2)
+        got = json.loads(pa.ensure_advertisement(ws, now=9).read_text())
+        self.assertEqual(got["workers"]["roster_version"], 2)
+        self.assertEqual(sorted(got["profile_workers"]), ["w1", "w2"])
+
+    def test_no_roster_means_nothing_and_is_not_an_error(self):
+        ws = Path(tempfile.mkdtemp())
+        self.assertIsNone(pa.ensure_advertisement(ws))
+        self.assertFalse(pa.advertisement_path(ws).exists())
+        self.assertEqual(pa.main(["--workspace", str(ws), "--ensure"]), 0)
+
+    def test_the_cli_ensure_writes_for_an_existing_roster(self):
+        ws = self._ws()
+        self.assertEqual(pa.main(["--workspace", str(ws), "--ensure"]), 0)
+        self.assertTrue(pa.advertisement_path(ws).exists())
+
+
+
+class TheReportedLeg(unittest.TestCase):
+    ROSTER = {"version": 7, "config_version": 3,
+              "workers": {"w1": {"label": "Mars", "state": "live", "runtime": "claude"},
+                          "w2": {"label": "Beta", "state": "recovering"},
+                          "w3": {"label": "Old", "state": "retired"}},
+              "bindings": {"!a:x": "w1"}}
+
+    def test_facts_verbatim_and_applied_config_apart(self):
+        rep = pa.report(self.ROSTER, now=5)
+        self.assertEqual(rep["ts"], 5)
+        self.assertEqual(rep["roster_version"], 7)
+        self.assertEqual(rep["workers"], [{"id": "w1", "state": "live", "runtime": "claude"},
+                                          {"id": "w2", "state": "recovering"},
+                                          {"id": "w3", "state": "retired"}])
+        self.assertEqual(rep["applied"], {"config_version": 3,
+                                          "labels": {"w1": "Mars", "w2": "Beta"},
+                                          "bindings": {"!a:x": {"instance": "w1", "instances": ["w1"], "pinned": True}}})
+
+    def test_a_roster_without_a_config_version_reports_none(self):
+        self.assertIsNone(pa.report({"version": 1, "workers": {}, "bindings": {}}, now=1)["applied"]["config_version"])
+
+    def test_recovering_is_not_answering_in_the_compat_view(self):
+        snap = pa.snapshot(self.ROSTER, now=5)
+        self.assertEqual(snap["live_cores"], ["w1"])
+        self.assertEqual(snap["dead_cores"], ["w2"])  # never "available"
+
+    def test_the_compat_bodies_are_projections_of_the_report(self):
+        rep = pa.report(self.ROSTER, now=5)
+        snap = pa.snapshot(self.ROSTER, now=5)
+        self.assertEqual(snap["bindings"], rep["applied"]["bindings"])
+        self.assertEqual(snap["roster_version"], rep["roster_version"])
+        self.assertEqual(pa.profile_workers(self.ROSTER),
+                         {"w1": {"label": "Mars", "runtime": "claude"}, "w2": {"label": "Beta"}})
+
+    def test_the_file_carries_the_report_beside_the_compat_bodies(self):
+        ws = Path(tempfile.mkdtemp())
+        pr.compile_roster(ws, {"w1": {"label": "alpha", "state": "recovering"}}, {}, version=2)
+        got = json.loads(pa.write_advertisement(ws, now=9).read_text())
+        self.assertEqual(sorted(got), ["profile_workers", "report", "ts", "workers"])
+        self.assertEqual(got["report"]["workers"], [{"id": "w1", "state": "recovering"}])
+        self.assertEqual(got["workers"]["dead_cores"], ["w1"])
+
+
+class ReviewedShapes(unittest.TestCase):
+    """The roster's accepted binding forms, schema upgrades, and two writers."""
+
+    def test_a_one_member_list_binding_is_advertised_like_a_scalar(self):
+        ws = Path(tempfile.mkdtemp())
+        pr.compile_roster(ws, {"w1": {"label": "a", "state": "live"}}, {"!a:x": ["w1"]}, version=1)
+        got = pa.snapshot(pr.load_roster(ws), now=1)["bindings"]
+        self.assertEqual(got, {"!a:x": {"instance": "w1", "instances": ["w1"], "pinned": True}})
+
+    def test_a_binding_to_a_retired_worker_is_not_advertised(self):
+        r = {"version": 2, "workers": {"w1": {"label": "a", "state": "retired"}}, "bindings": {"!a:x": "w1"}}
+        self.assertEqual(pa.bindings(r), {})
+        self.assertNotIn("w1", pa.profile_workers(r))
+
+    def test_a_same_version_file_of_an_older_schema_is_rebuilt_at_boot(self):
+        ws = Path(tempfile.mkdtemp())
+        pr.compile_roster(ws, {"w1": {"label": "a", "state": "recovering"}}, {}, version=3)
+        path = pa.advertisement_path(ws); path.parent.mkdir(parents=True, exist_ok=True)
+        old = {"ts": 1, "workers": {"ts": 1, "live_cores": [], "dead_cores": [], "bindings": {},
+                                    "roster_version": 3}, "profile_workers": {"w1": {"label": "a"}}}
+        path.write_text(json.dumps(old))
+        pa.ensure_advertisement(ws, now=5)
+        got = json.loads(path.read_text())
+        self.assertIn("report", got)
+        self.assertEqual(got["workers"]["dead_cores"], ["w1"])  # recovering: not answering
+
+    def test_a_current_file_is_left_alone_by_content(self):
+        ws = Path(tempfile.mkdtemp())
+        pr.compile_roster(ws, {"w1": {"label": "a", "state": "live"}}, {}, version=3)
+        path = pa.write_advertisement(ws, now=5)
+        before = path.stat().st_mtime_ns
+        pa.ensure_advertisement(ws, now=9)
+        self.assertEqual(path.stat().st_mtime_ns, before)
+
+    def test_a_writer_that_lost_the_race_does_not_regress_a_newer_publication(self):
+        import threading
+        ws = Path(tempfile.mkdtemp())
+        pr.compile_roster(ws, {"w1": {"label": "a", "state": "live"}}, {}, version=10)
+        real_replace = os.replace
+        paused = threading.Event(); release = threading.Event()
+
+        def slow_replace(src, dst):
+            if not paused.is_set():
+                paused.set(); release.wait(5)
+            return real_replace(src, dst)
+
+        errors = []
+        def old_writer():
+            try:
+                with unittest.mock.patch.object(pa.os, "replace", slow_replace):
+                    pa.write_advertisement(ws, now=1)
+            except Exception as e:  # pragma: no cover
+                errors.append(e)
+        t = threading.Thread(target=old_writer); t.start()
+        self.assertTrue(paused.wait(5))
+        # v11 retires the worker; its writer must wait for the lock, then publish
+        pr.compile_roster(ws, {"w1": {"label": "a", "state": "retired"}}, {}, version=11)
+        newer = threading.Thread(target=lambda: pa.write_advertisement(ws, now=2)); newer.start()
+        release.set(); t.join(5); newer.join(5)
+        got = json.loads(pa.advertisement_path(ws).read_text())
+        self.assertEqual(errors, [])
+        self.assertEqual(got["report"]["roster_version"], 11)
+        self.assertEqual(got["workers"]["live_cores"], [])
+        # and a late v10 write after v11 is refused outright
+        pr.compile_roster(ws, {"w1": {"label": "a", "state": "live"}}, {}, version=10)
+        pa.write_advertisement(ws, now=3)
+        self.assertEqual(json.loads(pa.advertisement_path(ws).read_text())["report"]["roster_version"], 11)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
> **Stack** #4106 → #4107 → #4109 → #4108 → {#4110, #4115 → **this**}. Based on #4115 (`create-worker`), which it pairs with: that command creates a worker, this makes the worker visible to the owner.

Owner request (in-room, 2026-09-10), after asking why the worker picker was empty: build the instance side of the loop.

## The finding this closes

**The picker is already built and shipped** — `WorkerRoster`, `WorkerBindingPrompt`, the `+` button, the rename pencil, all on the client's `main` since 2026-08-31. It renders nothing because **the instance never advertises its pool**.

Measured on the live rig: the client's read path resolves, but the registry it reads is empty, and the only code that ever filled it (`_maybe_push_workers_snapshot`) lives on the retired rescue line and reads `state/pool-status.json`, which nothing in this design writes.

## What it adds

`src/pool_advertise.py` — builds the two bodies the picker needs, from one roster read:

```
POST /v1/workers               live_cores / dead_cores   -> each row's STATUS
PUT  /v1/agents/<me>/profile   workers: {id: {label}}    -> each row's NAME
```

Sending one without the other renders half a row — statuses labelled with raw 32-hex ids, or names attached to nothing — so they are built together and cannot disagree.

**Translation, not passthrough.** The broker's field names are the affinity era's; the roster is this design's:

| roster state | advertised as | why |
|---|---|---|
| `live` | `live_cores` -> "active" | running now |
| `abandoned` | `dead_cores` -> "dead" | the core marked it gone |
| `recovering` | **neither list** | the broker renders a known-but-unlisted id as "available", which is exactly a restarting worker |
| `retired` | **neither body** | any id with metadata stays on the picker forever, so a deleted worker would be permanent |

**It builds; it does not send.** Transport, credentials and retry belong to whatever already talks to the broker. That keeps this testable with no network and no broker.

## Evidence

Parent `6a9b275c6`: neither file exists.

Head, against the live roster:

```json
{ "workers_snapshot": { "ts": 1789030786, "live_cores": ["39041ce6a444…"], "dead_cores": [], "roster_version": 1 },
  "profile_patch": { "workers": { "39041ce6a444…": { "label": "worker-1" } } } }
```

13 tests, **100%** of the new file (measured with the repo's `.coveragerc`, the way the gate runs it). Controls:

| mutation | result |
|---|---|
| drop the `retired` filter | `test_a_retired_worker_is_advertised_nowhere` fails |
| call `recovering` dead | `test_recovering_is_neither_so_the_broker_reads_it_available` fails |

Sibling suites green at head: `pool-delivery`, `pool-bindings-roster`, `create-worker-command`. Repo gate PASS on the cumulative diff.

## What still stands between this and a working picker

Tracked on #4105, and worth stating so this PR is not mistaken for the whole loop:

- a consumer for `POST /v1/workers/add` (the `+` button) — the broker enqueues it as an ordinary owner task with `source: worker-picker`; nothing consumes it yet
- a consumer for `POST /v1/workers/pin` — a room binding written from the client
- a sender for these two bodies
- **not ours:** the local rig's broker predates these endpoints (`/v1/agents/<a>/profile` and `/v1/workers` both 404 there) — until it is updated the picker stays empty regardless

Opened by worker-1 (Sutando pool worker) for qingyun.

## Owner decision, 2026-09-11 (relayed by her core; the PR body carries it because a third comment tripped the monologue gate)
**Model:** the client expresses intent; the broker stores it, versioned, and syncs it to runtimes and other clients; the runtime reports facts (applied, creating, recovering, failed). Desired and reported never merge: a runtime restarting with an old name only updates last-reported, never reverts the user's name. "Latest" is the broker-accepted config version; clients submit with the base version they edited from and older-base conflicts are detected; a rename is a field-level change that never overwrites bindings from a stale client cache. **Constraint on this PR, in her words:** the pool advertisement may update runtime state and report configuration-application progress; user configuration changes must go through the unified intent write path.

## The re-cut (head 2293eb6a8)
- `pool_advertise.report(roster, now)` is the source: `{ts, roster_version, workers: [{id, state (verbatim: live|recovering|abandoned|retired), runtime?}], applied: {config_version, labels, bindings}}`. `applied` is what this runtime is running with, for the broker to file as last-reported — never a source of names or bindings.
- `snapshot()` (POST /v1/workers) and `profile_workers()` (profile card) are projections of the report for the broker as it is today; they go away when the broker accepts the report. A `recovering` worker projects as not answering (`dead_cores`), never as "available" (the mapping the owner rejected).
- `state/pool-advertisement.json` carries `report` beside the compat bodies, so the bridge (#4162) can switch readers without a second file.
- Not in this PR: the broker's acceptance of the report and version rejection (ag2space-backend, follow-up to #1077), the periodic resync and idempotent retry (bridge, #4162), the intent write path for names and bindings.

Evidence: `tests/pool-advertise.test.py` Ran 31 tests (was 26; +5 for the report, the compat projection, the file), `tests/create-worker-command.test.py` green, `scripts/review-checks.sh --diff` PASS.
```text
report(ROSTER).workers = [{"id":"w1","state":"live","runtime":"claude"}, {"id":"w2","state":"recovering"}, {"id":"w3","state":"retired"}]
snapshot(ROSTER)       = live_cores ["w1"], dead_cores ["w2"]   # recovering: not answering, not available
```

## Re-homed onto the skill layout (head f29647c72, base feat/create-worker-command at 68c83399)
One commit replaces the seven above with the same content at the new paths: `skills/worker-pool/scripts/pool_advertise.py`, the create-worker hunks in `skills/worker-pool/scripts/create_worker.py`, tests under `skills/worker-pool/tests/`. Two changes agreed for the owner's boundary (src keeps only what the core needs with no pool installed):
- The `src/startup.sh --ensure` call and its boot test are **gone** — the core must not name a pool file by path. `ensure_advertisement()` stays a cheap idempotent call (a second call with nothing changed writes nothing; test added) and the pool's own handler calls it on its first run of each process; that call lands with the handler on the #4110 line, since `pool_route_handler` is not under this base.
- No `docs/src-map.md` entry: the module is no longer under `src/`.

Evidence at this head: `skills/worker-pool/tests/pool-advertise.test.py` 31 tests OK, `skills/worker-pool/tests/create-worker-command.test.py` 17 OK, `tests/state-paths-adoption.test.py` OK, `tests/ci-covers-every-python-test.test.py` OK (the new files are discovered), `scripts/review-checks.sh --diff` PASS.
