### PR TITLE
feat(pool): accept a stamped picker command, so prose becomes the fallback

### DIFF
--- a/docs/remote-gateway-protocol.md
+++ b/docs/remote-gateway-protocol.md
@@ -67,6 +67,16 @@ A task object **must** carry a unique `"id"`. Recognized string fields
 and written into the local task file the core consumes. For AG2 Space, the
 broker also supplies its room-policy `access_tier` attestation.
 
+A worker-picker button may be sent as `"picker_command"` (`add` | `pin` |
+`unpin`) plus optional `"picker_args"` — a JSON object, either inline or
+already serialized as a string; the bridge writes it as JSON either way. Both
+are written as trusted pre-body headers, because `worker_picker_commands.py`
+reads them with the parser that stops at `task:`. A command the reader cannot
+honour — an unknown verb, args that are not an object, or arguments that do not
+fit the verb — is refused by name rather than resolved from the sentence, and
+the room always comes from `channel_id`, never from `picker_args`. A broker
+that sends no `picker_command` keeps the prose fallback.
+
 An AG2 Space broker may additionally send `"session_scope": "room"`. The
 bridge writes only that exact value as a trusted pre-body header; missing,
 unknown, or malformed values are omitted, preserving the main-session path for

--- a/packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py
+++ b/packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py
@@ -191,6 +191,9 @@ KNOWN_HEADER_KEYS = (
     # A card click the HITL store already recorded, passed on for the turn it causes;
     # the core trusts it, so the guard must defang a forged copy in body text.
     "hitl_click",
+    # Which worker-picker button was pressed, and its JSON arguments. Header
+    # status is the whole point: the reader takes them from above `task:` only.
+    "picker_command", "picker_args",
 )
 _KNOWN_KEY_SET = frozenset(KNOWN_HEADER_KEYS)
 

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -1723,7 +1723,13 @@ _TASK_FIELDS = ("id", "timestamp", "session_scope",
                 # A card click already recorded in the HITL store, passed on for the turn it
                 # causes: the core answers [no-send] and lets its Stop hook do the work.
                 "hitl_click",
-                "task", "source", "channel_id",
+                # Which worker-picker button was pressed. Above "task" for the same
+                # reason: worker_picker_commands reads it with the safe parser.
+                "picker_command", "picker_args",
+                # Also above "task": these carry the picker's authorization, and a
+                # task-last reader cannot see a field written below the body.
+                "source", "channel_id",
+                "task",
                 # Context enrichment (AG2 broker writer side): human room/sender
                 # names + reply reference. Serialized only when the gateway sends
                 "room_name", "sender_name", "reply_to_event", "reply_to_me", "reply_to_sender",
@@ -2923,6 +2929,14 @@ def _write_task(task: dict) -> "tuple[str, bool] | None":
                 _mh = local_task_protocol.media_attachment_headers(_media_refs, bool(_txt.strip()))
                 if _mh:
                     lines.extend(_mh.rstrip("\n").split("\n"))
+        elif f == "picker_args":
+            # The reader parses this with json.loads, so an object must be
+            # re-serialized as JSON — _one_line would emit a Python repr.
+            pa = task.get(f)
+            if isinstance(pa, (dict, list)):
+                lines.append(f"picker_args: {json.dumps(pa, separators=(',', ':'))}")
+            elif pa not in (None, ""):
+                lines.append(f"picker_args: {_one_line(pa)}")
         elif f == "platform_card":
             # Signed platform-metadata pointer: re-serialize only the expected
             # subkeys as one compact JSON line (dict repr or extra keys never

--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -202,7 +202,7 @@ const esc = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replac
 
 /** U+200B — zero-width space; not whitespace, so it survives .trimStart(). */
 const _ZWSP = '​';
-// Mirrors local_task_protocol.KNOWN_HEADER_KEYS (42 keys) — injection-guard-sweep
+// Mirrors local_task_protocol.KNOWN_HEADER_KEYS (49 keys) — injection-guard-sweep
 // asserts this regex covers every py key. reply_chain_ids added with PR #2310.
 const _CONF_HEADER_RE = new RegExp(
 	'^(?:id|timestamp|session_scope|task|source|access_tier|user_id|channel_id|priority|' +
@@ -213,7 +213,8 @@ const _CONF_HEADER_RE = new RegExp(
 	'thread_root|source_room_id|' +
 	'receiving_instance|' +
 	'call_sid|hint|instructions|transcript|schedule_name|schedule_slot|content_modalities|media_form|' +
-	'attachments|platform_card|instance_id|collaborator|requested_worker|hitl_click)\\s*:',
+	'attachments|platform_card|instance_id|collaborator|requested_worker|hitl_click|' +
+	'picker_command|picker_args)\\s*:',
 	'i',
 );
 const _CONF_FENCE_RE = /^={3,}/;

--- a/skills/worker-pool/scripts/worker_picker_commands.py
+++ b/skills/worker-pool/scripts/worker_picker_commands.py
@@ -42,8 +42,8 @@ import local_task_protocol as ltp  # noqa: E402
 
 SOURCE = "worker-picker"
 
-# A header the broker may stamp instead of relying on the sentence. Read from
-# ABOVE `task:` only, like `requested_worker`, so a body cannot forge one.
+# A header the broker may stamp instead of relying on the sentence. In
+# KNOWN_HEADER_KEYS, so the strict parser reads it ABOVE `task:` only.
 COMMAND_HEADER = "picker_command"
 COMMAND_ARGS_HEADER = "picker_args"
 COMMANDS = ("add", "pin", "unpin")
@@ -67,38 +67,80 @@ def _refuse_no_room(action: str) -> None:
           file=sys.stderr)
 
 
-def _structured(headers: dict, room: str) -> "dict | None":
-    """The intent from a stamped command, or None when there is no usable one.
+def _bad(name: str, reason: str) -> dict:
+    """Refuse a stamped command and say which rule it broke — an unnamed
+    refusal is indistinguishable from 'the sentence did not match'."""
+    print(f"worker-picker: refusing {name!r} — {reason}", file=sys.stderr)
+    return {"action": "malformed", "command": name, "reason": reason}
 
-    An UNKNOWN command returns None rather than falling through to the prose:
-    a broker that names a verb we do not implement must not be answered by
-    guessing from a sentence written for a different one.
+
+def _worker_names(args: dict) -> "list | None":
+    """The pin target as a list of names, or None if it is not one.
+
+    A bare string is REJECTED, not accepted as a one-element list: iterating
+    one yields its characters, which is how `"w1"` became six workers.
     """
+    if "workers" in args:
+        got = args["workers"]
+        if not isinstance(got, list):
+            return None
+    elif "worker" in args:
+        got = [args["worker"]]
+    else:
+        return None
+    if not got or not all(isinstance(w, str) and w.strip() for w in got):
+        return None
+    return [w.strip() for w in got]
+
+
+def _structured(headers: dict, room: str) -> "dict | None":
+    """The intent from a stamped command, or None when none was stamped.
+
+    Only an ABSENT `picker_command` returns None and lets the sentence decide.
+    Present-but-unusable — empty, an unknown verb, args that are not an object
+    or do not fit the verb's schema — is an explicit refusal: a broker that
+    stamped something we cannot honour must not be answered by guessing from a
+    sentence written for a different command.
+    """
+    if COMMAND_HEADER not in headers:
+        return None
     name = (headers.get(COMMAND_HEADER) or "").strip()
     if not name:
-        return None
+        return _bad(name, "empty picker_command")
     if name not in COMMANDS:
         return {"action": "unsupported", "command": name}
-    args = {}
+
+    args: dict = {}
     raw = (headers.get(COMMAND_ARGS_HEADER) or "").strip()
     if raw:
         try:
             parsed = json.loads(raw)
-            args = parsed if isinstance(parsed, dict) else {}
         except ValueError:
-            # A stamped command we cannot read is a refusal, not a reason to
-            # trust the sentence: nothing proves the two say the same thing.
-            return {"action": "malformed", "command": name}
+            return _bad(name, "picker_args is not JSON")
+        if not isinstance(parsed, dict):
+            return _bad(name, "picker_args is not a JSON object")
+        args = parsed
+
     if name == "add":
         label = args.get("label")
-        return {"action": "add", "label": str(label) if label else None}
-    workers = args.get("workers") or ([args["worker"]] if args.get("worker") else [])
-    at = room or str(args.get("room") or "")
+        if label is not None and not isinstance(label, str):
+            return _bad(name, "label must be a string")
+        return {"action": "add", "label": label.strip() if label and label.strip() else None}
+
+    # Every remaining command is room-scoped, and the room is the header's
+    # alone — `picker_args` may name one, and it is never read.
+    if not room:
+        return _bad(name, "no channel_id header")
     if name == "unpin":
-        return {"action": "unpin", "room": at}
-    return {"action": "pin", "room": at,
-            "workers": [str(w) for w in workers],
-            "dedicated": bool(args.get("dedicated"))}
+        return {"action": "unpin", "room": room}
+    workers = _worker_names(args)
+    if workers is None:
+        return _bad(name, "workers must be a non-empty list of names")
+    dedicated = args.get("dedicated", False)
+    if not isinstance(dedicated, bool):
+        return _bad(name, "dedicated must be a boolean")
+    return {"action": "pin", "room": room,
+            "workers": workers, "dedicated": dedicated}
 
 
 def parse(headers: dict, body: str) -> "dict | None":

--- a/skills/worker-pool/scripts/worker_picker_commands.py
+++ b/skills/worker-pool/scripts/worker_picker_commands.py
@@ -42,6 +42,12 @@ import local_task_protocol as ltp  # noqa: E402
 
 SOURCE = "worker-picker"
 
+# A header the broker may stamp instead of relying on the sentence. Read from
+# ABOVE `task:` only, like `requested_worker`, so a body cannot forge one.
+COMMAND_HEADER = "picker_command"
+COMMAND_ARGS_HEADER = "picker_args"
+COMMANDS = ("add", "pin", "unpin")
+
 _ADD = re.compile(r"^Add a new worker to the pool\b", re.I)
 _LABEL = re.compile(r"Preferred label for the new worker:\s*(.+?)\.?\s*$", re.I)
 _UNPIN = re.compile(r"^Unpin room\s+(\S+)", re.I)
@@ -61,19 +67,58 @@ def _refuse_no_room(action: str) -> None:
           file=sys.stderr)
 
 
+def _structured(headers: dict, room: str) -> "dict | None":
+    """The intent from a stamped command, or None when there is no usable one.
+
+    An UNKNOWN command returns None rather than falling through to the prose:
+    a broker that names a verb we do not implement must not be answered by
+    guessing from a sentence written for a different one.
+    """
+    name = (headers.get(COMMAND_HEADER) or "").strip()
+    if not name:
+        return None
+    if name not in COMMANDS:
+        return {"action": "unsupported", "command": name}
+    args = {}
+    raw = (headers.get(COMMAND_ARGS_HEADER) or "").strip()
+    if raw:
+        try:
+            parsed = json.loads(raw)
+            args = parsed if isinstance(parsed, dict) else {}
+        except ValueError:
+            # A stamped command we cannot read is a refusal, not a reason to
+            # trust the sentence: nothing proves the two say the same thing.
+            return {"action": "malformed", "command": name}
+    if name == "add":
+        label = args.get("label")
+        return {"action": "add", "label": str(label) if label else None}
+    workers = args.get("workers") or ([args["worker"]] if args.get("worker") else [])
+    at = room or str(args.get("room") or "")
+    if name == "unpin":
+        return {"action": "unpin", "room": at}
+    return {"action": "pin", "room": at,
+            "workers": [str(w) for w in workers],
+            "dedicated": bool(args.get("dedicated"))}
+
+
 def parse(headers: dict, body: str) -> "dict | None":
     """The intent behind one task, or None when it is not the picker's.
 
     `headers` must come from the strict parser (see module docstring): every
     key read below is an authorization field, and a lenient scan would let the
-    body supply one. An unrecognised sentence from a genuine picker task
-    returns None rather than a guess: a wrong intent creates or re-routes a
-    worker. So does a room-scoped sentence with no stamped room.
+    body supply one. A stamped command wins over the sentence; the sentence is
+    the fallback for a broker that stamps none. An unrecognised sentence
+    returns None rather than a guess, and so does a room-scoped sentence with
+    no stamped room: a wrong intent creates or re-routes a worker.
     """
     if (headers.get("source") or "").strip() != SOURCE:
         return None
     text = " ".join((body or "").split())
     room = (headers.get("channel_id") or "").strip()
+
+    structured = _structured(headers, room)
+    if structured is not None:
+        return structured
 
     if _ADD.search(text):
         m = _LABEL.search(text)

--- a/skills/worker-pool/tests/worker-picker-commands.test.py
+++ b/skills/worker-pool/tests/worker-picker-commands.test.py
@@ -19,7 +19,9 @@ from pathlib import Path
 # The skill's repo root, for reading this module's source text in one test; not the workspace.
 REPO = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
 
+import local_task_protocol as ltp  # noqa: E402
 import worker_picker_commands as wpc  # noqa: E402
 
 ROOM = "!abc:ag2.space"
@@ -152,13 +154,87 @@ class TestAStampedCommandWinsOverProse(unittest.TestCase):
     def test_unparseable_args_refuse_rather_than_fall_back(self):
         # The sentence may describe the same intent, but nothing proves it, so
         # a corrupt stamp refuses instead of trusting prose beside it.
-        got = wpc.parse(hdr(picker_command="add", picker_args="{not json"), ADD)
-        self.assertEqual(got, {"action": "malformed", "command": "add"})
+        got, err = refusal(hdr(picker_command="add", picker_args="{not json"), ADD)
+        self.assertEqual(got, {"action": "malformed", "command": "add",
+                               "reason": "picker_args is not JSON"})
+        self.assertIn("picker_args is not JSON", err)
 
     def test_the_room_still_comes_from_the_header(self):
         got = wpc.parse(hdr(picker_command="pin",
                             picker_args='{"worker": "%s", "room": "!evil:x"}' % W1), "")
         self.assertEqual(got["room"], ROOM)
+
+    def test_a_stamped_room_scoped_command_with_no_header_room_refuses(self):
+        for name in ("pin", "unpin"):
+            with self.subTest(name):
+                got, err = refusal(
+                    {"source": wpc.SOURCE, "picker_command": name,
+                     "picker_args": '{"workers": ["%s"], "room": "!evil:x"}' % W1},
+                    f"Pin room {ROOM} to {W1} (worker picker)")
+                self.assertEqual(got["reason"], "no channel_id header")
+                self.assertIn("no channel_id header", err)
+
+
+class TestTheArgumentsAreValidatedAgainstTheCommand(unittest.TestCase):
+    """Valid JSON is not a valid command. Each refusal names the rule broken,
+    because `malformed` alone does not tell an operator what to fix."""
+
+    REFUSALS = [
+        ("pin", "[]", "picker_args is not a JSON object"),
+        ("pin", '"a string"', "picker_args is not a JSON object"),
+        ("pin", "7", "picker_args is not a JSON object"),
+        # A bare string used to be iterated into one worker per character.
+        ("pin", '{"workers": "%s"}' % W1, "workers must be a non-empty list of names"),
+        ("pin", '{"workers": 7}', "workers must be a non-empty list of names"),
+        ("pin", '{"workers": []}', "workers must be a non-empty list of names"),
+        ("pin", '{"workers": ["%s", ""]}' % W1, "workers must be a non-empty list of names"),
+        ("pin", '{"workers": [7]}', "workers must be a non-empty list of names"),
+        ("pin", "{}", "workers must be a non-empty list of names"),
+        ("pin", '{"worker": 7}', "workers must be a non-empty list of names"),
+        # "false" is a non-empty string, so truthiness made it dedicated.
+        ("pin", '{"workers": ["%s"], "dedicated": "false"}' % W1,
+         "dedicated must be a boolean"),
+        ("add", '{"label": {"a": 1}}', "label must be a string"),
+        ("add", '{"label": 7}', "label must be a string"),
+    ]
+
+    def test_each_invalid_shape_is_refused_by_name(self):
+        for command, args, reason in self.REFUSALS:
+            with self.subTest(f"{command} {args}"):
+                got, err = refusal(hdr(picker_command=command, picker_args=args),
+                                   f"Pin room {ROOM} to {W1} (worker picker)")
+                self.assertEqual(got, {"action": "malformed", "command": command,
+                                       "reason": reason})
+                self.assertIn(reason, err)
+
+    def test_the_valid_shapes_are_accepted(self):
+        # The control for the table above: the same fields, well formed.
+        self.assertEqual(
+            wpc.parse(hdr(picker_command="pin",
+                          picker_args='{"workers": ["%s"], "dedicated": false}' % W1), ""),
+            {"action": "pin", "room": ROOM, "workers": [W1], "dedicated": False})
+        self.assertEqual(
+            wpc.parse(hdr(picker_command="pin", picker_args='{"worker": "%s"}' % W1), ""),
+            {"action": "pin", "room": ROOM, "workers": [W1], "dedicated": False})
+        self.assertEqual(
+            wpc.parse(hdr(picker_command="unpin"), ""),
+            {"action": "unpin", "room": ROOM})
+        self.assertEqual(wpc.parse(hdr(picker_command="add"), ""),
+                         {"action": "add", "label": None})
+
+    def test_a_present_but_empty_command_is_not_no_command(self):
+        # It must not read as "the broker stamped nothing" and hand a
+        # privileged decision to whatever sentence happens to be in the body.
+        got, err = refusal(hdr(picker_command="   "),
+                           f"Pin room {ROOM} to {W1} (worker picker)")
+        self.assertEqual(got["action"], "malformed")
+        self.assertEqual(got["reason"], "empty picker_command")
+        self.assertIn("empty picker_command", err)
+
+    def test_an_absent_command_still_falls_through_to_prose(self):
+        # The control: only an ABSENT header may defer to the sentence.
+        got = wpc.parse(hdr(), f"Pin room {ROOM} to {W1} (worker picker)")
+        self.assertEqual(got["action"], "pin")
 
 
 class TestTaskFile(unittest.TestCase):
@@ -227,6 +303,62 @@ class TestTheBodyIsNotAHeader(unittest.TestCase):
                 real = ("id: task-1\nsource: worker-picker\n"
                         f"channel_id: {ROOM}\ntask: " + body + "\n")
                 self.assertEqual(self._read(real)["room"], ROOM)
+
+
+class TestAStampedCommandReachesTheReaderThroughATaskFile(unittest.TestCase):
+    """The blocker this closes: `parse()` was reachable only from a dictionary
+    no producer could write. These go through the shipped file entry point."""
+
+    def _read(self, text):
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "task-1.txt"
+            p.write_text(text)
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                return wpc.parse_task_file(p)
+
+    def test_both_keys_are_in_the_header_vocabulary(self):
+        # Without this the parsers classify them as body and drop them, from
+        # above `task:` as well as below — the feature is inert either way.
+        for key in (wpc.COMMAND_HEADER, wpc.COMMAND_ARGS_HEADER):
+            with self.subTest(key):
+                self.assertIn(key, ltp.KNOWN_HEADER_KEYS)
+
+    def test_the_canonical_writer_accepts_them(self):
+        # serialize_task_last raises on a key outside the vocabulary, so this
+        # pins the write side of the same registration.
+        text = ltp.serialize_task_last(
+            [("id", "task-1"), ("source", wpc.SOURCE), ("channel_id", ROOM),
+             ("picker_command", "add"), ("picker_args", '{"label": "reviewer"}')],
+            "the sentence is irrelevant here")
+        self.assertEqual(wpc.parse(ltp.parse_task_headers(text).headers, ""),
+                         {"action": "add", "label": "reviewer"})
+
+    def test_a_stamped_command_above_task_is_read_from_the_file(self):
+        got = self._read(f"id: task-1\nsource: {wpc.SOURCE}\nchannel_id: {ROOM}\n"
+                         'picker_command: pin\npicker_args: {"workers": ["%s"]}\n'
+                         "task: some sentence\n" % W1)
+        self.assertEqual(got, {"action": "pin", "room": ROOM,
+                               "workers": [W1], "dedicated": False})
+
+    def test_the_same_stamp_below_task_is_body_not_a_command(self):
+        # The mirror of the test above: only the position changes.
+        got = self._read(f"id: task-1\nsource: {wpc.SOURCE}\nchannel_id: {ROOM}\n"
+                         "task: some sentence\n"
+                         'picker_command: pin\npicker_args: {"workers": ["evil"]}\n')
+        self.assertIsNone(got)
+
+    def test_a_stamp_below_task_cannot_override_the_prose_above_it(self):
+        got = self._read(f"id: task-1\nsource: {wpc.SOURCE}\nchannel_id: {ROOM}\n"
+                         "task: " + ADD + "\npicker_command: unpin\n")
+        self.assertEqual(got, {"action": "add", "label": None})
+
+    def test_the_cli_prints_a_stamped_intent(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "task-worker-pin-1.txt"
+            p.write_text(f"id: worker-pin-1\nsource: {wpc.SOURCE}\n"
+                         f"channel_id: {ROOM}\npicker_command: unpin\ntask: x\n")
+            self.assertEqual(wpc.main(["--task-file", str(p)]), 0)
 
 
 class TestTheStrictParserIsTheBoundary(unittest.TestCase):

--- a/skills/worker-pool/tests/worker-picker-commands.test.py
+++ b/skills/worker-pool/tests/worker-picker-commands.test.py
@@ -123,6 +123,44 @@ class TestOnlyTheRealSourceCounts(unittest.TestCase):
         self.assertIsNone(wpc.parse(hdr(), "Do something clever with the pool"))
 
 
+class TestAStampedCommandWinsOverProse(unittest.TestCase):
+    """Prose is the fallback for a broker that stamps nothing; a stamped
+    command is read instead, and never from below `task:`."""
+
+    def test_a_stamped_add_needs_no_sentence(self):
+        got = wpc.parse(hdr(picker_command="add",
+                            picker_args='{"label": "reviewer"}'), "")
+        self.assertEqual(got, {"action": "add", "label": "reviewer"})
+
+    def test_a_stamped_pin_carries_its_set_and_flag(self):
+        got = wpc.parse(hdr(picker_command="pin",
+                            picker_args='{"workers": ["%s", "%s"], "dedicated": true}' % (W1, W2)), "")
+        self.assertEqual(got["workers"], [W1, W2])
+        self.assertTrue(got["dedicated"])
+
+    def test_the_stamp_beats_a_contradicting_sentence(self):
+        got = wpc.parse(hdr(picker_command="unpin"),
+                        f"Pin room {ROOM} to {W1} (worker picker)")
+        self.assertEqual(got["action"], "unpin")
+
+    def test_an_unknown_command_is_named_not_guessed_from_prose(self):
+        # A broker naming a verb we do not implement must not be answered by
+        # reading a sentence written for a different one.
+        got = wpc.parse(hdr(picker_command="retire"), ADD)
+        self.assertEqual(got, {"action": "unsupported", "command": "retire"})
+
+    def test_unparseable_args_refuse_rather_than_fall_back(self):
+        # The sentence may describe the same intent, but nothing proves it, so
+        # a corrupt stamp refuses instead of trusting prose beside it.
+        got = wpc.parse(hdr(picker_command="add", picker_args="{not json"), ADD)
+        self.assertEqual(got, {"action": "malformed", "command": "add"})
+
+    def test_the_room_still_comes_from_the_header(self):
+        got = wpc.parse(hdr(picker_command="pin",
+                            picker_args='{"worker": "%s", "room": "!evil:x"}' % W1), "")
+        self.assertEqual(got["room"], ROOM)
+
+
 class TestTaskFile(unittest.TestCase):
     def test_it_reads_a_real_task_file(self):
         with tempfile.TemporaryDirectory() as d:

--- a/src/local_task_protocol.py
+++ b/src/local_task_protocol.py
@@ -191,6 +191,9 @@ KNOWN_HEADER_KEYS = (
     # A card click the HITL store already recorded, passed on for the turn it causes;
     # the core trusts it, so the guard must defang a forged copy in body text.
     "hitl_click",
+    # Which worker-picker button was pressed, and its JSON arguments. Header
+    # status is the whole point: the reader takes them from above `task:` only.
+    "picker_command", "picker_args",
 )
 _KNOWN_KEY_SET = frozenset(KNOWN_HEADER_KEYS)
 

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -100,6 +100,7 @@ const _HEADER_KEYS = [
 	'schedule_name', 'schedule_slot',
 	'content_modalities', 'media_form', 'attachments', 'platform_card',
 	'instance_id', 'collaborator', 'requested_worker', 'hitl_click',
+	'picker_command', 'picker_args',
 ];
 const _HEADER_RE = new RegExp(`^(?:${_HEADER_KEYS.join('|')})\\s*:`, 'i');
 const _FENCE_RE = /^={3,}/;

--- a/tests/gateway-writeside-picker-command.test.py
+++ b/tests/gateway-writeside-picker-command.test.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""A worker-picker button, end to end: broker task -> gateway -> reader.
+
+The picker's blocker was never the parse — it was that nothing could deliver a
+stamped command to it. So this drives the SHIPPED writer (`_write_task`) and
+the SHIPPED reader (`worker_picker_commands.parse_task_file`) against a real
+file, rather than handing `parse()` a dictionary no producer can make.
+
+The two fields must land ABOVE `task:`: the reader uses the safe parser, which
+stops there, so a field written below the body is invisible to it.
+
+Run: python3 tests/gateway-writeside-picker-command.test.py   (0 pass / 1 fail)
+"""
+import importlib.util
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules[name] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+sys.path.insert(0, str(REPO / "src"))
+sys.path.insert(0, str(REPO / "skills" / "worker-pool" / "scripts"))
+ltp = _load("local_task_protocol", REPO / "src" / "local_task_protocol.py")
+rgb = _load("remote_gateway_bridge", REPO / "src" / "remote-gateway-bridge.py")
+import worker_picker_commands as wpc  # noqa: E402
+
+tmp = Path(tempfile.mkdtemp(prefix="rgb-picker-test-"))
+rgb.TASKS_DIR = tmp / "tasks"
+rgb.RESULTS_DIR = tmp / "results"
+rgb.ARCHIVE_RESULTS_DIR = tmp / "results" / "archive"
+
+ROOM = "!abc:ag2.space"
+W1 = "a3f91c2d4e5b6a7c8d9e0f1a2b3c4d5e"
+failures = []
+
+
+def check(name, cond, detail=""):
+    print(("  ok  " if cond else "  FAIL ") + name
+          + ((" — " + detail) if detail and not cond else ""))
+    if not cond:
+        failures.append(name)
+
+
+_n = [0]
+
+
+def write(task):
+    """Drive the real writer; return (file text, the reader's verdict)."""
+    _n[0] += 1
+    written = rgb._write_task({"id": f"picker-{_n[0]}", **task})
+    assert written, f"_write_task rejected {task!r}"
+    path = rgb.TASKS_DIR / f"{written[0]}.txt"
+    return path.read_text(), wpc.parse_task_file(path)
+
+
+def above_task(text, key):
+    """True iff `key:` appears before the `task:` line — the safe parser's
+    whole trust rule, asserted on the bytes rather than on the parse."""
+    lines = text.split("\n")
+    body = next((i for i, ln in enumerate(lines) if ln.startswith("task:")), len(lines))
+    return any(ln.startswith(f"{key}:") for ln in lines[:body])
+
+
+print("— the vocabulary carries both fields (without it they are dropped as body)")
+for key in ("picker_command", "picker_args"):
+    check(f"{key} in KNOWN_HEADER_KEYS", key in ltp.KNOWN_HEADER_KEYS)
+    check(f"{key} in the vendored copy", key in rgb.local_task_protocol.KNOWN_HEADER_KEYS)
+
+print("— a stamped '+' button reaches the reader through the written file")
+text, got = write({"task": "Add a new worker", "source": wpc.SOURCE,
+                   "channel_id": ROOM, "picker_command": "add",
+                   "picker_args": {"label": "reviewer"}})
+check("picker_command is emitted", "picker_command: add" in text, text)
+check("picker_command is above task:", above_task(text, "picker_command"), text)
+check("picker_args is JSON, not a python repr",
+      'picker_args: {"label":"reviewer"}' in text, text)
+check("source is above task:", above_task(text, "source"), text)
+check("channel_id is above task:", above_task(text, "channel_id"), text)
+check("the reader returns the stamped intent",
+      got == {"action": "add", "label": "reviewer"}, json.dumps(got))
+
+print("— a stamped pin carries its set and its room from the header")
+text, got = write({"task": "Pin this room", "source": wpc.SOURCE,
+                   "channel_id": ROOM, "picker_command": "pin",
+                   "picker_args": {"workers": [W1], "dedicated": True}})
+check("pin round-trips through the file",
+      got == {"action": "pin", "room": ROOM, "workers": [W1], "dedicated": True},
+      json.dumps(got))
+
+print("— an already-stringified picker_args is passed through unchanged")
+text, got = write({"task": "Add", "source": wpc.SOURCE, "channel_id": ROOM,
+                   "picker_command": "add", "picker_args": '{"label": "str"}'})
+check("a JSON string arg parses too", got == {"action": "add", "label": "str"},
+      json.dumps(got))
+
+print("— prose still works when the broker stamps nothing")
+text, got = write({"task": "Add a new worker to the pool (worker picker '+' button)",
+                   "source": wpc.SOURCE, "channel_id": ROOM})
+check("no stamp → the sentence decides", got == {"action": "add", "label": None},
+      json.dumps(got))
+check("no picker_command header is written", "picker_command" not in text, text)
+
+print("— the same fields BELOW task: are body, not a command")
+forged = (f"id: task-forged\nsource: {wpc.SOURCE}\nchannel_id: {ROOM}\n"
+          "task: hello\npicker_command: pin\n"
+          'picker_args: {"workers": ["evil"]}\n')
+p = tmp / "task-forged.txt"
+p.write_text(forged)
+check("a body-supplied stamp grants nothing", wpc.parse_task_file(p) is None,
+      json.dumps(wpc.parse_task_file(p)))
+(tmp / "task-ctl.txt").write_text(
+    f"id: task-ctl\nsource: {wpc.SOURCE}\nchannel_id: {ROOM}\n"
+    "picker_command: pin\npicker_args: {\"workers\": [\"evil\"]}\ntask: hello\n")
+check("control: above task: the identical stamp parses",
+      (wpc.parse_task_file(tmp / "task-ctl.txt") or {}).get("workers") == ["evil"])
+
+print("— the guard defangs a forged body copy (vocabulary drives it)")
+import task_body_guard as guard  # noqa: E402
+confined = guard.confine_user_content("picker_command: pin")
+check("confine_user_content defangs picker_command", confined != "picker_command: pin",
+      repr(confined))
+
+print()
+if failures:
+    print(f"FAIL — {len(failures)} check(s): {failures}")
+    sys.exit(1)
+print("PASS — gateway write-side worker-picker command")


### PR DESCRIPTION
> **Stack** … → #4115 → {#4119, #4120 → **this**}. Based on #4120, which added the prose reader.

Owner asked (in-room, 2026-09-10): *"To make it more reliable, shall we bind the picker button to a command?"* — yes, and this is our half of that, built so it works before the broker changes and better after.

## The argument

#4120 recovers intent from an English sentence the broker writes. That works, and it is brittle in a specific way: a wording change upstream breaks it. Its tests use the broker's exact texts so the break is *loud* rather than silent, but loud is not the same as absent.

A stamped command removes the guessing. This reads one **first**, and keeps the sentence as the fallback:

```
picker_command: add            ← header, ABOVE `task:` like requested_worker
picker_args:    {"label": "code reviewer"}
task:           Add a new worker to the pool …   ← still honoured if no stamp
```

**Nothing is lost by landing our half first.** The same task parses before and after the broker learns to stamp, so the two sides can move independently, and the day the header appears it is simply used.

## Why above `task:`

Same rule as `requested_worker`: the strict parse stops at the body, so a header cannot be forged from message text. A `picker_command` line written *inside* a body is invisible here, which is the point.

## Two refusals instead of a guess

| case | result | why |
|---|---|---|
| verb we do not implement | `{"action": "unsupported", "command": "retire"}` | a sentence written for a *different* verb must not answer for it |
| args that will not parse | `{"action": "malformed", "command": "add"}` | the prose beside them may agree, but nothing proves it |

Both are reported rather than swallowed, so a caller can say so instead of silently doing nothing.

The room still comes from `channel_id`, even when the args name one — a test pins that with args naming `!evil:x`.

## Evidence

20 tests, **100%** of the file, measured with the repo's `.coveragerc`. Controls:

| mutation | result |
|---|---|
| let an unknown command fall through to prose | `test_an_unknown_command_is_named_not_guessed_from_prose` fails |
| let malformed args fall through to prose | `test_unparseable_args_refuse_rather_than_fall_back` fails |

The second control found a real bug during development: my first cut returned `None` for malformed args, which fell through to the sentence. The test was right and the code was wrong, so the code changed.

Repo gate PASS on the cumulative diff.

## The other half, which is not ours

The broker has to stamp it. That is `ag2space-backend`'s `post_workers_add` / `post_workers_pin`, which today build only prose. Suggested shape is exactly what this reads: `picker_command` plus JSON `picker_args`, alongside the existing sentence so nothing regresses for an instance that has not updated.

Opened by worker-1 (Sutando pool worker) for qingyun.

## Re-homed with its base (head 9a86ecf35 on #4120 at 2d73fb118)
The two commits replay unchanged in substance: the picker-module hunks landed on the skill copy (`skills/worker-pool/scripts/worker_picker_commands.py`), the core-side edits (`src/local_task_protocol.py`, the sparrow copy, the gateway bridge, `task-bridge.ts`, the phone server, the protocol doc) as before, and the new `tests/gateway-writeside-picker-command.test.py` imports the shipped reader from the skill's scripts. Picker suite 39 OK, gateway write-side OK, protocol OK, gate PASS.
