### PR TITLE
fix(current-track): a hold is a line, so pin lines and not the entry

### DIFF
--- a/src/current_track.py
+++ b/src/current_track.py
@@ -201,6 +201,14 @@ def plan(text: str, keep_bytes: int, pin=PIN_DEFAULT) -> RotateResult:
     used, started = 0, order[0] in keep
     walked = set()
     for i in order:
+        if i in pinned and i not in ends:
+            # The stub is already charged, so reaching a pin buys back only the rest.
+            # The newest entry is exempt from the cap, or rotation hides the live anchor.
+            upgrade = _size(entries[i]) - _size(stub[i])
+            if i == order[0] or used + upgrade <= budget:
+                used += upgrade
+                walked.add(i)
+            continue
         if i in keep:
             continue
         if started and used + _size(entries[i]) > budget:

--- a/src/current_track.py
+++ b/src/current_track.py
@@ -59,6 +59,25 @@ PIN_DEFAULT = re.compile(
 )
 
 
+CONDENSED_NOTE = "_[rotation condensed this entry; the full text is in the archive]_\n"
+
+
+def condense(entry: str, pin=PIN_DEFAULT) -> str:
+    """Heading + only the lines a consumer greps as live state.
+
+    A hold is a LINE, so carrying its whole entry to keep it greppable spends
+    the read budget on prose no consumer reads.
+    """
+    lines = entry.splitlines(keepends=True)
+    if not lines or not pin:
+        return entry
+    held = [l for l in lines[1:] if pin.search(l)]
+    if not held:
+        return entry
+    body = lines[0] + CONDENSED_NOTE + "".join(held)
+    return body if body.endswith("\n") else body + "\n"
+
+
 def lock_path(path: Path) -> Path:
     return path.with_name(path.name + ".lock")
 
@@ -160,6 +179,9 @@ def plan(text: str, keep_bytes: int, pin=PIN_DEFAULT) -> RotateResult:
     if not entries:
         return RotateResult(text, "", True)
     pinned = {i for i, e in enumerate(entries) if pin and pin.search(e)}
+    # A pin buys its HOLD LINES a place in the head, not its whole entry. Charge
+    # the stub, so the bytes it no longer holds go back to the age walk.
+    stub = {i: condense(entries[i], pin) for i in pinned}
     facing = _orientation(entries)
     # Walk from the NEWEST end, whichever that is; a pin never stops the walk, or an
     # old hold would freeze the archive and rotation would free nothing.
@@ -168,12 +190,16 @@ def plan(text: str, keep_bytes: int, pin=PIN_DEFAULT) -> RotateResult:
     # Undetermined orientation protects BOTH ends: the live entry sits at one of
     # them, and no walk direction can be shown to keep it.
     keep = set(pinned) | ({0, len(entries) - 1} if facing is None else set())
+    ends = {0, len(entries) - 1} if facing is None else set()
     # Every entry kept BEFORE the walk is spent budget; charging only the pins let
     # the walk fill the whole cap on top of the protected ends.
-    budget = keep_bytes - _size(preamble) - sum(_size(entries[i]) for i in keep)
+    budget = keep_bytes - _size(preamble) - sum(
+        _size(stub.get(i, entries[i])) if i in pinned and i not in ends else _size(entries[i])
+        for i in keep)
     # The exception exists to keep the LIVE ANCHOR whole. Ask whether THAT entry is
     # already kept -- pinned, or a protected end -- not why it might have been.
     used, started = 0, order[0] in keep
+    walked = set()
     for i in order:
         if i in keep:
             continue
@@ -181,10 +207,17 @@ def plan(text: str, keep_bytes: int, pin=PIN_DEFAULT) -> RotateResult:
             break
         used += _size(entries[i])
         keep.add(i)
+        walked.add(i)
         started = True
-    head = preamble + "".join(entries[i] for i in sorted(keep))
-    archived = "".join(entries[i] for i in sorted(set(range(len(entries))) - keep))
-    pinned_bytes = sum(_size(entries[i]) for i in pinned)
+    # A pinned entry the walk also reached is recent, so it stays whole; one kept
+    # only by its pin is carried as the stub and its full text goes to the archive.
+    shrunk = {i for i in pinned if i not in walked and i not in ends
+              and _size(stub[i]) < _size(entries[i])}
+    render = {i: (stub[i] if i in shrunk else entries[i]) for i in keep}
+    head = preamble + "".join(render[i] for i in sorted(keep))
+    archived = "".join(entries[i]
+                       for i in sorted((set(range(len(entries))) - keep) | shrunk))
+    pinned_bytes = sum(_size(render[i]) for i in pinned if i in render)
     return RotateResult(head, archived, _size(head) > keep_bytes, pinned_bytes, len(pinned))
 
 

--- a/tests/current-track-rotate.test.py
+++ b/tests/current-track-rotate.test.py
@@ -685,6 +685,49 @@ class PinVocabularyDiscriminates(unittest.TestCase):
                 self.assertIn("github_formal_review=hold", r.head,
                               f"live config-value hold archived at keep={keep}")
 
+    def test_a_hold_line_does_not_pin_its_whole_entry(self):
+        """A pin buys the HOLD LINES a place in the head, not the entry carrying them.
+        Entry-granular pinning kept 15 KB of prose live for one 40-byte hold."""
+        pre, _ = fixture(0)
+        big = ("## 2026-09-01T10:00Z — status\n" + ("filler nobody greps\n" * 900)
+               + "HOLD: do not touch PR #123 until the owner says\n\n")
+        E = lambda n: f"## 2026-09-{n:02d}T00:00Z — entry {n}\n" + ("y" * 900) + "\n\n"
+        corpus = pre + big + "".join(E(i) for i in range(2, 9))
+        r = ct.plan(corpus, 8 * 1024)
+        self.assertIn("HOLD: do not touch PR #123", r.head,
+                      "the hold line must stay greppable in the head")
+        self.assertNotIn("filler nobody greps", r.head,
+                         "the carrier prose must not ride on the hold")
+        self.assertIn("filler nobody greps", r.archived,
+                      "the full entry must be archived, never dropped")
+        self.assertFalse(r.oversized, "condensing must bring the head under budget")
+
+    def test_the_walk_may_spend_the_bytes_condensing_freed(self):
+        """Charging a pin at its stub is what returns the carrier's bytes to the walk.
+        Charge the whole entry and the head stays far under budget with entries archived."""
+        pre, _ = fixture(0)
+        big = ("## 2026-09-01T10:00Z — status\n" + ("filler\n" * 900)
+               + "HOLD: do not touch PR #123\n\n")
+        E = lambda n: f"## 2026-09-{n:02d}T00:00Z — entry {n}\n" + ("y" * 400) + "\n\n"
+        corpus = pre + big + "".join(E(i) for i in range(2, 30))
+        r = ct.plan(corpus, 8 * 1024)
+        self.assertFalse(r.oversized)
+        used = len(r.head.encode("utf-8"))
+        self.assertGreater(used, int(8 * 1024 * 0.85),
+                           f"head used only {used} B of 8192 — the freed bytes were never spent")
+
+    def test_a_pinned_entry_the_walk_reached_stays_whole(self):
+        """Condensing is for entries kept ONLY by their pin; a recent one is not summarised."""
+        pre, _ = fixture(0)
+        recent = ("## 2026-09-20T10:00Z — recent\n" + "context that matters\n"
+                  + "HOLD: do not merge #9\n\n")
+        corpus = pre + "".join(f"## 2026-09-{i:02d}T00:00Z — old {i}\n" + ("y" * 100) + "\n\n"
+                               for i in range(2, 9)) + recent
+        r = ct.plan(corpus, 8 * 1024)
+        self.assertIn("context that matters", r.head,
+                      "a recent pinned entry was condensed despite fitting")
+
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/current-track-rotate.test.py
+++ b/tests/current-track-rotate.test.py
@@ -716,16 +716,36 @@ class PinVocabularyDiscriminates(unittest.TestCase):
         self.assertGreater(used, int(8 * 1024 * 0.85),
                            f"head used only {used} B of 8192 — the freed bytes were never spent")
 
+    # A corpus UNDER the cap makes plan() return it unchanged, so every "stayed
+    # whole" assertion passes without rotating. Each case below asserts it rotated.
+    def _pinned_walk_corpus(self):
+        pre, _ = fixture(0)
+        old_pin = ("## 2026-09-02T00:00Z — old\n" + ("y" * 1200) + "\n"
+                   + "HOLD: do not merge #1\n\n")
+        filler = "".join(f"## 2026-09-{i:02d}T00:00Z — mid {i}\n" + ("y" * 900) + "\n\n"
+                         for i in range(3, 12))
+        recent = ("## 2026-09-20T10:00Z — recent\n" + ("context that matters\n" * 8)
+                  + "HOLD: do not merge #9\n\n")
+        return pre + old_pin + filler + recent
+
     def test_a_pinned_entry_the_walk_reached_stays_whole(self):
         """Condensing is for entries kept ONLY by their pin; a recent one is not summarised."""
-        pre, _ = fixture(0)
-        recent = ("## 2026-09-20T10:00Z — recent\n" + "context that matters\n"
-                  + "HOLD: do not merge #9\n\n")
-        corpus = pre + "".join(f"## 2026-09-{i:02d}T00:00Z — old {i}\n" + ("y" * 100) + "\n\n"
-                               for i in range(2, 9)) + recent
-        r = ct.plan(corpus, 8 * 1024)
+        corpus = self._pinned_walk_corpus()
+        cap = 8 * 1024
+        self.assertGreater(len(corpus.encode("utf-8")), cap,
+                           "corpus is under the cap, so plan() returns it unrotated")
+        r = ct.plan(corpus, cap)
+        self.assertTrue(r.archived, "nothing was archived — the walk never ran")
         self.assertIn("context that matters", r.head,
                       "a recent pinned entry was condensed despite fitting")
+
+    def test_an_old_pin_the_walk_never_reached_is_still_condensed(self):
+        """Discriminating control: the fix must not make every pin whole."""
+        r = ct.plan(self._pinned_walk_corpus(), 8 * 1024)
+        self.assertIn("HOLD: do not merge #1", r.head, "the old hold LINE must survive")
+        self.assertIn(ct.CONDENSED_NOTE.strip(), r.head, "no entry was condensed at all")
+        self.assertNotIn("y" * 1200, r.head, "the old pin kept its whole body")
+
 
 
 


### PR DESCRIPTION
Closes #4122.

## The defect

`plan()` keeps a **whole entry** live whenever any line in it matches `PIN_DEFAULT`. The instinct is right — an aged-out hold reads as *not held* to every consumer that greps this file — but the granularity is wrong: a hold is a **line**.

On the reporting host, **38,784 B was resident in every pass's first read to carry 1,311 B of hold lines (3.4%)**, and rotation could only refuse.

## The change

A pin buys its hold **lines** a place in the head, not the entry carrying them.

- An entry kept *only* by its pin → rendered as heading + hold lines; full text goes to the archive.
- An entry the age walk *also* reached → recent, stays whole.
- Pins are charged at **stub size before the walk**, so the bytes condensing frees are spendable on recent entries rather than lost.

## Before / after, on the file the issue cites, at the size it had when it refused

The tool's own refusal is the "before":

```
current-track-rotate: ROTATED BUT STILL OVER BUDGET — ARCHIVED 4219 B; the head is
40420 B against a 32768 B budget because 12 pinned entries (owner holds and the like)
hold 39681 B, which rotation may not move. Raise --keep-bytes, or retire the holds
that have expired
```

After:

```
input        40420 B   budget 32768
head         31724 B   oversized=False
pinned_bytes  1664 B   (was 39,681)
archived     10360 B
hold lines   7 in the file, 7 still present in the head
```

Nothing is dropped: condensed entries are archived in full.

## Mutation testing

The suite must fail when each half is reverted, or it is asserting nothing:

```
condensing disabled          -> 2 fail  (whole-entry, budget-reuse)
budget charges whole entries -> 1 fail  (budget-reuse)
as committed                 -> 47 tests OK
```

I also added and then **removed** a third test — it passed under both mutants, so it asserted nothing the others do not.

## Scope

`src/current_track.py` only; `scripts/current-track-rotate.py` is unchanged and reports the new `pinned_bytes` without edits. Prior related work: #4031 (closed) narrowed the pin vocabulary; this fixes the granularity it left behind.