### PR TITLE
fix(health-check,docs): a foreign hook cannot be installer-cleared; sync default is a whitelist

### DIFF
--- a/docs/workspace-design.md
+++ b/docs/workspace-design.md
@@ -79,7 +79,7 @@ Per-user runtime + content. Lives at `<repo>/workspace/` by default (post-M0). S
 | `skill-repos/<repo-name>/` | ❌ no | Per-host clone | Git checkouts of skill **source** repos; each is linked by its OWN installer, not by `skills/install.sh` |
 | `.env` | ❌ no | Per-host secret | Tokens, API keys — must NOT sync |
 
-The sync default is "synced unless excluded"; per-host runtime sub-paths are excluded via the carrier-set gitignore (per PR #1447) + `vault.sync.exclude` user overrides.
+The sync default is "excluded unless included": `sync-workspace.sh` writes a whitelist (`*` ignores everything, then the carrier set from `vault.sync.include` is un-ignored — see its Section 4 and `.git/info/exclude`). `vault.sync.exclude` narrows that carrier set; it is not what keeps an unlisted path out. Per-host runtime sub-paths (e.g. `data/`) are unsynced because nothing includes them (per PR #1447).
 
 ### `skill-repos/` — where skill source repos are cloned
 

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -11168,14 +11168,15 @@ def check_claude_hook_registration(
                   "you intend to enable it"
                   if only_archive else
                   "re-run `SUTANDO_HOOKS_OMIT_TRANSCRIPT_ARCHIVE=1 bash src/install-claude-hooks.sh`")
-        # The installer only writes hooks it owns, so it cannot remove a foreign entry:
-        # prescribing it there reports `added=0 skipped=N removed=0` and reads as success.
+        # The omit flag gates DEPRECATED_HOOKS, so prescribing it skips the very pruning a
+        # foreign entry needs and reports `removed=0`, which reads as a successful run.
         if foreign:
-            remedy = ("the installer cannot clear this — it only writes hooks it owns, so it leaves "
-                      "a foreign entry in place and reports `removed=0`; delete the offending "
-                      f"entry from the settings file by hand ({', '.join(foreign)}), then re-run "
-                      "`SUTANDO_HOOKS_OMIT_TRANSCRIPT_ARCHIVE=1 bash src/install-claude-hooks.sh` "
-                      "if anything it owns is also missing")
+            remedy = ("do NOT pass SUTANDO_HOOKS_OMIT_TRANSCRIPT_ARCHIVE=1 here — that flag gates "
+                      "the deprecated-hook pruning, so it reports `removed=0` and clears nothing. "
+                      "Run `bash src/install-claude-hooks.sh` plain: it prunes the legacy forms it "
+                      f"knows ({', '.join(foreign)}) and installs their successors. If an entry is "
+                      "genuinely foreign (another program or checkout) the installer cannot own it "
+                      "— remove that one by hand")
         if dead and not missing and not foreign:
             remedy = ("re-run the installer that owns each family — it prunes dead copies "
                       "(`bash scripts/install-personal-claude-hook.sh`, "

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -9116,6 +9116,7 @@ def apply_task_watcher_sentinel_fix(checks: list, stream=None) -> None:
 
 # The one owned hook whose effect leaves the workspace; excluded from unattended repair.
 _TRANSCRIPT_ARCHIVE_HOOK = "PreCompact:sutando-conversations/"
+_TRANSCRIPT_ARCHIVE_FAMILY = "sutando-conversations/"
 
 
 def apply_claude_hooks_fix(checks: list, stream=None) -> None:
@@ -11171,15 +11172,22 @@ def check_claude_hook_registration(
         # The omit flag gates DEPRECATED_HOOKS, so prescribing it skips the very pruning a
         # foreign entry needs and reports `removed=0`, which reads as a successful run.
         if foreign:
-            remedy = ("do NOT pass SUTANDO_HOOKS_OMIT_TRANSCRIPT_ARCHIVE=1 here — that flag gates "
-                      "the deprecated-hook pruning, so it reports `removed=0` and clears nothing. "
-                      "Run `bash src/install-claude-hooks.sh` plain: it prunes the legacy forms it "
-                      f"knows ({', '.join(foreign)}) and installs their successors. NOTE: one flag "
-                      "controls both, so a plain run ALSO registers the ~/Desktop transcript "
-                      "archiver — if this host does not want it, delete that one PreCompact entry "
-                      "afterwards (re-running with the flag would un-prune, not un-install). If an "
-                      "entry is genuinely foreign (another program or checkout) the installer cannot "
-                      "own it — remove that one by hand")
+            # The flag gates ONE deprecated entry (the legacy archive `cp`), not pruning
+            # at large — every other DEPRECATED_HOOKS entry is pruned with it set.
+            archive_foreign = [f for f in foreign if _TRANSCRIPT_ARCHIVE_FAMILY in f]
+            if archive_foreign:
+                remedy = ("for the archive family, do NOT pass SUTANDO_HOOKS_OMIT_TRANSCRIPT_ARCHIVE=1 "
+                          "— that flag is what adds the legacy archive form to the prune list, so with "
+                          f"it set {', '.join(archive_foreign)} is never cleared. Run `bash "
+                          "src/install-claude-hooks.sh` plain, which also REGISTERS the ~/Desktop "
+                          "archiver: if this host does not want it, delete that one PreCompact entry "
+                          "afterwards")
+            else:
+                remedy = ("re-run `SUTANDO_HOOKS_OMIT_TRANSCRIPT_ARCHIVE=1 bash "
+                          "src/install-claude-hooks.sh` — the flag scopes out only the archive entry, "
+                          f"so {', '.join(foreign)} is still pruned and the ~/Desktop archiver is not "
+                          "installed. If an entry is genuinely foreign (another program or checkout) "
+                          "the installer cannot own it — remove that one by hand")
         if dead and not missing and not foreign:
             remedy = ("re-run the installer that owns each family — it prunes dead copies "
                       "(`bash scripts/install-personal-claude-hook.sh`, "

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -11174,9 +11174,12 @@ def check_claude_hook_registration(
             remedy = ("do NOT pass SUTANDO_HOOKS_OMIT_TRANSCRIPT_ARCHIVE=1 here — that flag gates "
                       "the deprecated-hook pruning, so it reports `removed=0` and clears nothing. "
                       "Run `bash src/install-claude-hooks.sh` plain: it prunes the legacy forms it "
-                      f"knows ({', '.join(foreign)}) and installs their successors. If an entry is "
-                      "genuinely foreign (another program or checkout) the installer cannot own it "
-                      "— remove that one by hand")
+                      f"knows ({', '.join(foreign)}) and installs their successors. NOTE: one flag "
+                      "controls both, so a plain run ALSO registers the ~/Desktop transcript "
+                      "archiver — if this host does not want it, delete that one PreCompact entry "
+                      "afterwards (re-running with the flag would un-prune, not un-install). If an "
+                      "entry is genuinely foreign (another program or checkout) the installer cannot "
+                      "own it — remove that one by hand")
         if dead and not missing and not foreign:
             remedy = ("re-run the installer that owns each family — it prunes dead copies "
                       "(`bash scripts/install-personal-claude-hook.sh`, "

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -11168,6 +11168,14 @@ def check_claude_hook_registration(
                   "you intend to enable it"
                   if only_archive else
                   "re-run `SUTANDO_HOOKS_OMIT_TRANSCRIPT_ARCHIVE=1 bash src/install-claude-hooks.sh`")
+        # The installer only writes hooks it owns, so it cannot remove a foreign entry:
+        # prescribing it there reports `added=0 skipped=N removed=0` and reads as success.
+        if foreign:
+            remedy = ("the installer cannot clear this — it only writes hooks it owns, so it leaves "
+                      "a foreign entry in place and reports `removed=0`; delete the offending "
+                      f"entry from the settings file by hand ({', '.join(foreign)}), then re-run "
+                      "`SUTANDO_HOOKS_OMIT_TRANSCRIPT_ARCHIVE=1 bash src/install-claude-hooks.sh` "
+                      "if anything it owns is also missing")
         if dead and not missing and not foreign:
             remedy = ("re-run the installer that owns each family — it prunes dead copies "
                       "(`bash scripts/install-personal-claude-hook.sh`, "

--- a/src/install-claude-hooks.sh
+++ b/src/install-claude-hooks.sh
@@ -99,7 +99,10 @@ HOOKS=(
   "Stop|src/check-pending-tasks.sh|bash $(shq "$REPO_DIR/src/check-pending-tasks.sh")"
 )
 
-# The transcript archiver writes OUTSIDE the workspace (~/Desktop). Omitting it
+# The transcript archiver writes to ~/Desktop, OUTSIDE the vault carrier set.
+# The location is not what keeps transcripts out of the vault: sync is a whitelist
+# (see .git/info/exclude -- `*` then the include list), so a workspace path is
+# unsynced until vault.sync.include names it. Omitting it
 # drops it from HOOKS, which every phase iterates, so a registered one is untouched.
 if [ "${SUTANDO_HOOKS_OMIT_TRANSCRIPT_ARCHIVE:-0}" = "1" ]; then
   _kept=()

--- a/tests/health-check-claude-hook-registration.test.py
+++ b/tests/health-check-claude-hook-registration.test.py
@@ -184,6 +184,19 @@ class TestHookRegistration(unittest.TestCase):
                 self.assertEqual(out["status"], "warn", f"{label}: {out['detail']}")
                 self.assertIn("NOT running the installer's command", out["detail"])
 
+    def test_the_foreign_remedy_scopes_the_omit_flag_to_the_archive_family(self):
+        # Measured by qingyun-wu on the real installer: with the flag SET a non-archive
+        # foreign hook still prunes (removed=1). The flag adds ONE deprecated entry.
+        repo = self._one_hook_repo("nonarch", lambda r: "bash /opt/elsewhere/src/check-pending-tasks.sh")
+        out = self.hc.check_claude_hook_registration(repo_dir=repo)
+        self.assertEqual(out["status"], "warn", out["detail"])
+        remedy = out.get("remedy", "") or out["detail"]
+        self.assertIn("SUTANDO_HOOKS_OMIT_TRANSCRIPT_ARCHIVE=1", remedy)
+        self.assertNotIn("do NOT pass", remedy,
+                         "a NON-archive foreign hook must keep the opt-out: with the flag set it "
+                         "still prunes, and the plain run would install the ~/Desktop archiver "
+                         f"for nothing. got: {remedy}")
+
     def test_a_GENUINE_checkout_is_not_reported_foreign(self):
         # Over-trigger control for the fix above: a warning that fires on healthy hosts is
         # its own defect. Exact path, and the same path reached through a symlink (macOS


### PR DESCRIPTION
Three defects found while clearing a stale PreCompact hook on a live host. **The original version of this PR described defect 1 wrongly; both the code and this body have been corrected.** See the history below.

## 1. health-check prescribes the one flag that disables the cure

The `claude-hooks` probe sent every non-archive case to `re-run SUTANDO_HOOKS_OMIT_TRANSCRIPT_ARCHIVE=1 bash src/install-claude-hooks.sh` — including a **foreign** entry.

That flag gates the pruning the warn needs. `install-claude-hooks.sh:143-149`:

```bash
if [ "${SUTANDO_HOOKS_OMIT_TRANSCRIPT_ARCHIVE:-0}" != "1" ]; then
  # SCOPE, not egress: the flag already dropped the archiver from HOOKS, so an
  # ungated removal here would delete a registered hook and install no successor.
  DEPRECATED_HOOKS+=( "PreCompact|cp \"$TRANSCRIPT_PATH\" ..." )
fi
```

So the installer **can** clear the legacy form — on a plain run. With the flag set it skips that pruning, by design.

**Before** (measured on a live host, pre-#3999 archiver registered after a 33-commit pull):

```
$ SUTANDO_HOOKS_OMIT_TRANSCRIPT_ARCHIVE=1 bash src/install-claude-hooks.sh
install-claude-hooks: added=0 skipped=8 removed=0
```

Warn byte-identical afterwards. `removed=0` reads as a successful run, so following the printed remedy ends with the operator believing it fixed.

**After:** the remedy says not to pass the flag, to run the installer plain, and distinguishes a known deprecated form (pruned) from a genuinely foreign entry (which the installer cannot own).

**Correction history, since it matters for review:** the first revision asserted "the installer cannot remove a foreign entry — it only writes hooks it owns." A peer disproved it by reading `:143`. I had read `:96` and `:102` and never scrolled to the deprecation list — the same wrong-scope error the PR is about. Commit `b81b5d40` fixes the claim and the code.

## 2. docs/workspace-design.md:82 states the sync default backwards

It said *"The sync default is 'synced unless excluded'"*. `sync-workspace.sh` Section 4 builds a **whitelist** — its own comment: *"Whitelist mode: `*` ignores everything"*.

```
$ git -C <workspace> check-ignore -v data/
.git/info/exclude:10:*   data/
```

`data/` is matched by the bare `*`. Not on an exclude list — not on the include list. `vault.sync.exclude` narrows the carrier set; it is not what keeps an unlisted path out.

## 3. install-claude-hooks.sh:102 named a location where the reason belongs

*"writes OUTSIDE the workspace (~/Desktop)"* invites the reader to conclude the workspace boundary protects transcripts. Under a whitelist it does not. It sits beside a true consequence while naming none of the mechanism, so a reader who tests the inference finds it confirmed and learns the wrong rule — which is how I got it wrong.

## Notes

- Authored in a worktree off `origin/main`. Docs/comment only in 2 and 3; 1 changes one remedy string.
- Stacked child #4129 changes the archive destination; merge this first.
