### PR TITLE
feat(hooks): the transcript archive destination is overridable

### DIFF
--- a/docs/workspace-design.md
+++ b/docs/workspace-design.md
@@ -79,7 +79,7 @@ Per-user runtime + content. Lives at `<repo>/workspace/` by default (post-M0). S
 | `skill-repos/<repo-name>/` | ❌ no | Per-host clone | Git checkouts of skill **source** repos; each is linked by its OWN installer, not by `skills/install.sh` |
 | `.env` | ❌ no | Per-host secret | Tokens, API keys — must NOT sync |
 
-The sync default is "synced unless excluded"; per-host runtime sub-paths are excluded via the carrier-set gitignore (per PR #1447) + `vault.sync.exclude` user overrides.
+The sync default is "excluded unless included": `sync-workspace.sh` writes a whitelist (`*` ignores everything, then the carrier set from `vault.sync.include` is un-ignored — see its Section 4 and `.git/info/exclude`). `vault.sync.exclude` narrows that carrier set; it is not what keeps an unlisted path out. Per-host runtime sub-paths (e.g. `data/`) are unsynced because nothing includes them (per PR #1447).
 
 ### `skill-repos/` — where skill source repos are cloned
 

--- a/scripts/sutando-config.sh
+++ b/scripts/sutando-config.sh
@@ -98,6 +98,15 @@ print(resolve_workspace(), end='')
     fi
     ;;
 
+  transcript-archive-dir)
+    py -c "
+import sys
+sys.path.insert(0, '$REPO_ROOT')
+from src.sutando_config import resolve_transcript_archive_dir
+print(resolve_transcript_archive_dir(), end='')
+"
+    ;;
+
   vault-enabled)
     py -c "
 import sys

--- a/src/archive-transcript.sh
+++ b/src/archive-transcript.sh
@@ -8,9 +8,15 @@
 # replaces expanded empty and wrote nothing on every compaction (#3999).
 set -u
 
+# No argument: resolve from config AT FIRE TIME. The hook registration passes
+# none, so no absolute path is frozen into settings.json (see
+# install-claude-hooks.sh:61-93 for what that costs).
 DEST="${1:-}"
 if [ -z "$DEST" ]; then
-  echo "✗ archive-transcript: no destination directory given" >&2
+  DEST="$(bash "$(cd "$(dirname "$0")/.." && pwd)/scripts/sutando-config.sh" transcript-archive-dir 2>/dev/null || true)"
+fi
+if [ -z "$DEST" ]; then
+  echo "✗ archive-transcript: no destination — config resolution returned empty" >&2
   exit 2
 fi
 

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -11168,6 +11168,14 @@ def check_claude_hook_registration(
                   "you intend to enable it"
                   if only_archive else
                   "re-run `SUTANDO_HOOKS_OMIT_TRANSCRIPT_ARCHIVE=1 bash src/install-claude-hooks.sh`")
+        # The installer only writes hooks it owns, so it cannot remove a foreign entry:
+        # prescribing it there reports `added=0 skipped=N removed=0` and reads as success.
+        if foreign:
+            remedy = ("the installer cannot clear this — it only writes hooks it owns, so it leaves "
+                      "a foreign entry in place and reports `removed=0`; delete the offending "
+                      f"entry from the settings file by hand ({', '.join(foreign)}), then re-run "
+                      "`SUTANDO_HOOKS_OMIT_TRANSCRIPT_ARCHIVE=1 bash src/install-claude-hooks.sh` "
+                      "if anything it owns is also missing")
         if dead and not missing and not foreign:
             remedy = ("re-run the installer that owns each family — it prunes dead copies "
                       "(`bash scripts/install-personal-claude-hook.sh`, "

--- a/src/install-claude-hooks.sh
+++ b/src/install-claude-hooks.sh
@@ -162,9 +162,15 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 mkdir -p "$REPO_DIR/.claude"
-# The PreCompact archive hook is a bare `cp`, which cannot create its own
-# destination; without this the archiver fails on every compaction, silently.
-mkdir -p "$HOME/Desktop/sutando-conversations"
+# Create the archive destination only when the archiver is actually being
+# installed, and at the CONFIGURED path -- the unconditional `mkdir -p
+# $HOME/Desktop/sutando-conversations` this replaces ran on every install and
+# left an empty directory on hosts that never registered the hook, so directory
+# existence read as evidence the archiver had run when it had not.
+if [ "${SUTANDO_HOOKS_OMIT_TRANSCRIPT_ARCHIVE:-0}" != "1" ]; then
+  _ARCHIVE_DIR="$(bash "$REPO_DIR/scripts/sutando-config.sh" transcript-archive-dir 2>/dev/null || true)"
+  [ -n "$_ARCHIVE_DIR" ] && mkdir -p "$_ARCHIVE_DIR"
+fi
 if [ ! -f "$SETTINGS" ]; then
   echo '{}' > "$SETTINGS"
 fi

--- a/src/install-claude-hooks.sh
+++ b/src/install-claude-hooks.sh
@@ -99,7 +99,10 @@ HOOKS=(
   "Stop|src/check-pending-tasks.sh|bash $(shq "$REPO_DIR/src/check-pending-tasks.sh")"
 )
 
-# The transcript archiver writes OUTSIDE the workspace (~/Desktop). Omitting it
+# The transcript archiver writes to ~/Desktop, OUTSIDE the vault carrier set.
+# The location is not what keeps transcripts out of the vault: sync is a whitelist
+# (see .git/info/exclude -- `*` then the include list), so a workspace path is
+# unsynced until vault.sync.include names it. Omitting it
 # drops it from HOOKS, which every phase iterates, so a registered one is untouched.
 if [ "${SUTANDO_HOOKS_OMIT_TRANSCRIPT_ARCHIVE:-0}" = "1" ]; then
   _kept=()

--- a/src/install-claude-hooks.sh
+++ b/src/install-claude-hooks.sh
@@ -8,7 +8,8 @@
 # context, not in unrelated sessions.
 #
 # Hooks installed (4):
-#   PreCompact  → src/archive-transcript.sh ~/Desktop/sutando-conversations/
+#   PreCompact  → src/archive-transcript.sh
+#                 ${SUTANDO_TRANSCRIPT_ARCHIVE_DIR:-~/Desktop/sutando-conversations/}
 #   PreCompact  → bash src/session-handoff.sh "$TRANSCRIPT_PATH"
 #   SessionEnd  → bash src/session-handoff.sh "$TRANSCRIPT_PATH"
 #   Stop        → bash src/check-pending-tasks.sh
@@ -93,13 +94,17 @@ shq() {
 # ~/Desktop, so every hook installed by the old script pointed at a directory
 # that does not exist and failed silently on each fire.
 HOOKS=(
-  "PreCompact|sutando-conversations/|bash $(shq "$REPO_DIR/src/archive-transcript.sh") \"\$HOME/Desktop/sutando-conversations/\""
+  "PreCompact|sutando-conversations/|bash $(shq "$REPO_DIR/src/archive-transcript.sh") \"\${SUTANDO_TRANSCRIPT_ARCHIVE_DIR:-\$HOME/Desktop/sutando-conversations/}\""
   "PreCompact|src/session-handoff.sh|bash $(shq "$REPO_DIR/src/session-handoff.sh") \"\$TRANSCRIPT_PATH\""
   "SessionEnd|src/session-handoff.sh|bash $(shq "$REPO_DIR/src/session-handoff.sh") \"\$TRANSCRIPT_PATH\""
   "Stop|src/check-pending-tasks.sh|bash $(shq "$REPO_DIR/src/check-pending-tasks.sh")"
 )
 
-# The transcript archiver writes to ~/Desktop, OUTSIDE the vault carrier set.
+# The transcript archiver's destination is $SUTANDO_TRANSCRIPT_ARCHIVE_DIR, expanded
+# when the hook FIRES (not at install), defaulting to ~/Desktop/sutando-conversations/.
+# That default is historical -- a sibling of the old ~/Desktop/sutando clone location --
+# and no rationale for it is recorded; it is kept so an upgrade never relocates existing
+# archives. It is OUTSIDE the vault carrier set.
 # The location is not what keeps transcripts out of the vault: sync is a whitelist
 # (see .git/info/exclude -- `*` then the include list), so a workspace path is
 # unsynced until vault.sync.include names it. Omitting it

--- a/src/install-claude-hooks.sh
+++ b/src/install-claude-hooks.sh
@@ -9,7 +9,7 @@
 #
 # Hooks installed (4):
 #   PreCompact  → src/archive-transcript.sh
-#                 ${SUTANDO_TRANSCRIPT_ARCHIVE_DIR:-~/Desktop/sutando-conversations/}
+#                 (destination resolved at fire time via sutando-config.sh)
 #   PreCompact  → bash src/session-handoff.sh "$TRANSCRIPT_PATH"
 #   SessionEnd  → bash src/session-handoff.sh "$TRANSCRIPT_PATH"
 #   Stop        → bash src/check-pending-tasks.sh
@@ -94,17 +94,17 @@ shq() {
 # ~/Desktop, so every hook installed by the old script pointed at a directory
 # that does not exist and failed silently on each fire.
 HOOKS=(
-  "PreCompact|sutando-conversations/|bash $(shq "$REPO_DIR/src/archive-transcript.sh") \"\${SUTANDO_TRANSCRIPT_ARCHIVE_DIR:-\$HOME/Desktop/sutando-conversations/}\""
+  "PreCompact|sutando-conversations/|bash $(shq "$REPO_DIR/src/archive-transcript.sh")"
   "PreCompact|src/session-handoff.sh|bash $(shq "$REPO_DIR/src/session-handoff.sh") \"\$TRANSCRIPT_PATH\""
   "SessionEnd|src/session-handoff.sh|bash $(shq "$REPO_DIR/src/session-handoff.sh") \"\$TRANSCRIPT_PATH\""
   "Stop|src/check-pending-tasks.sh|bash $(shq "$REPO_DIR/src/check-pending-tasks.sh")"
 )
 
-# The transcript archiver's destination is $SUTANDO_TRANSCRIPT_ARCHIVE_DIR, expanded
-# when the hook FIRES (not at install), defaulting to ~/Desktop/sutando-conversations/.
-# That default is historical -- a sibling of the old ~/Desktop/sutando clone location --
-# and no rationale for it is recorded; it is kept so an upgrade never relocates existing
-# archives. It is OUTSIDE the vault carrier set.
+# The transcript archiver takes NO destination argument: archive-transcript.sh asks
+# sutando-config.sh for `transcript-archive-dir` when it fires, so the path is never
+# frozen into settings.json. Configure via hooks.transcript_archive_dir; the default
+# (~/Desktop/sutando-conversations) is historical and kept so upgrades never relocate
+# existing archives. It is OUTSIDE the vault carrier set.
 # The location is not what keeps transcripts out of the vault: sync is a whitelist
 # (see .git/info/exclude -- `*` then the include list), so a workspace path is
 # unsynced until vault.sync.include names it. Omitting it

--- a/src/sutando_config.py
+++ b/src/sutando_config.py
@@ -81,6 +81,17 @@ _SUPPORTED_CORE_RUNTIMES = {"claude", "codex"}
 _DOWN_BRIDGE_ACTIONS = {"restart", "alert", "off"}
 
 
+def resolve_transcript_archive_dir(repo_root: Optional[Path] = None) -> str:
+    """Where PreCompact archives conversation transcripts.
+
+    Resolved when the hook FIRES, never baked into settings.json: an absolute
+    path frozen at install time is the defect install-claude-hooks.sh:61-93 records.
+    """
+    hooks = load_config(repo_root).get("hooks") or {}
+    d = (hooks.get("transcript_archive_dir") or "").strip()
+    return d or str(Path.home() / "Desktop" / "sutando-conversations")
+
+
 def resolve_down_bridge_action(repo_root: Optional[Path] = None) -> str:
     """How ``health-check.py --fix`` handles a configured-but-down channel bridge."""
     hc = load_config(repo_root).get("health_check") or {}

--- a/src/sutando_config.py
+++ b/src/sutando_config.py
@@ -89,7 +89,12 @@ def resolve_transcript_archive_dir(repo_root: Optional[Path] = None) -> str:
     """
     hooks = load_config(repo_root).get("hooks") or {}
     d = (hooks.get("transcript_archive_dir") or "").strip()
-    return d or str(Path.home() / "Desktop" / "sutando-conversations")
+    if d:
+        return d
+    # The carrier set is a whitelist, so an unlisted workspace path is unsynced:
+    # local-only without leaving the system's bookkeeping.
+    from .workspace_default import resolve_workspace
+    return str(Path(resolve_workspace()) / "transcripts")
 
 
 def resolve_down_bridge_action(repo_root: Optional[Path] = None) -> str:


### PR DESCRIPTION
**Stacked on #4128 — merge that first.** Where PreCompact transcripts land, and why the old default was never really a choice.

## The default moves to `<workspace>/transcripts`

`~/Desktop/sutando-conversations` was hardcoded with no override. **No rationale for it is recorded anywhere.** The evidence says leftover: `docs/workspace-design.md:42` lists `~/Desktop/sutando` as a clone location of that era, and this script's `:61-93` documents the related defect where `$HOME/Desktop/sutando` was hardcoded as the *repo* path.

**Fleet measurement — the historical path protects nothing:**

```
Chis-Mac-mini          0 archived files   archiver registered, pre-#3999 cp form (inert)
Chis-MacBook-Pro       0 archived files   same broken form
Chis-MacBook-Air-Blue  0 archived files   archiver not registered at all
Chis-MacBook-Air       runs pre-migration code — unaffected
```

Three hosts measured independently (two by peers), zero transcripts anywhere. The "do not relocate existing archives" argument for keeping it turned out to protect an empty set.

**Why the workspace:** the carrier set is a whitelist, so an unlisted workspace path is unsynced — verified, not assumed:

```
$ git -C <workspace> check-ignore -v transcripts/
.git/info/exclude:10:*   transcripts/
```

That is the local-only property `~/Desktop` had **by accident**, now inside the system's bookkeeping instead of outside it.

## Resolution moved to fire time, through config

```
hooks.transcript_archive_dir  in sutando.config.local.json
  -> src/sutando_config.py      resolve_transcript_archive_dir()
  -> scripts/sutando-config.sh  transcript-archive-dir
  -> src/archive-transcript.sh  when it fires with no argument
```

The hook registration passes **no destination**, so nothing absolute is frozen into `settings.json` — the defect `install-claude-hooks.sh:61-93` records.

An earlier revision of this branch used a bare `$SUTANDO_TRANSCRIPT_ARCHIVE_DIR` env var. Nothing set, documented or read it — a knob with no panel, and exactly the ad-hoc env var CLAUDE.md says not to invent when `sutando-config.sh` exists. Replaced.

## The unconditional mkdir

`:159` ran `mkdir -p "$HOME/Desktop/sutando-conversations"` on **every** install, before any hook was written and regardless of whether the archiver was among them. Measured consequence on Chis-MacBook-Air-Blue: an empty archive directory on a host where no hook references it — so directory-existence read as evidence the archiver had run when it never had, on every host including mine. Now gated to actual installation, at the configured path.

Both arms exercised through the production resolver:

```
default     -> <workspace>/transcripts
configured  -> /tmp/xscripts   (hooks.transcript_archive_dir set, then restored)
```
