### PR TITLE
refactor(cli-wedge): retry is read from the text, so novelty and its exemption go

### DIFF
--- a/src/agent_availability.py
+++ b/src/agent_availability.py
@@ -38,7 +38,7 @@ WORK_SIGNAL_MAX_AGE_S = 180.0
 # room state acts on. Every warning kind (a wedge in some shape) is "wedged"; unreadable is unknown. Total over every kind cli_wedge emits (a test derives the set).
 _WEDGE_KIND_TO_SIGNAL = {"working": "working", "clock-only": "working", "idle": "idle",
                          "static-with-work": "wedged", "retry-loop": "wedged", "provider-limit": "wedged",
-                         "blocked": "wedged",
+                         "abnormal": "wedged",
                          "low-novelty": "wedged", "cadence-too-sparse": "unknown", "unknown": "unknown"}
 
 

--- a/src/agent_availability.py
+++ b/src/agent_availability.py
@@ -38,6 +38,7 @@ WORK_SIGNAL_MAX_AGE_S = 180.0
 # room state acts on. Every warning kind (a wedge in some shape) is "wedged"; unreadable is unknown. Total over every kind cli_wedge emits (a test derives the set).
 _WEDGE_KIND_TO_SIGNAL = {"working": "working", "clock-only": "working", "idle": "idle",
                          "static-with-work": "wedged", "retry-loop": "wedged", "provider-limit": "wedged",
+                         "blocked": "wedged",
                          "low-novelty": "wedged", "cadence-too-sparse": "unknown", "unknown": "unknown"}
 
 

--- a/src/cli_wedge.py
+++ b/src/cli_wedge.py
@@ -82,7 +82,7 @@ PROVISIONAL_THRESHOLDS = {
     "status_ttl_s": 900,
     "min_duration_s": 60,
 }
-BLOCKED_PATTERNS: tuple[tuple[str, re.Pattern], ...] = tuple(
+ABNORMAL_PATTERNS: tuple[tuple[str, re.Pattern], ...] = tuple(
     (name, re.compile(rx, re.IGNORECASE))
     for name, rx in (
         ("quota-limit", r"\b(hit|reached|exceeded)\b.{0,24}\b(session|usage|weekly|daily|plan) limit\b|\b(session|usage|weekly|daily|plan) limit (reached|exceeded|hit)\b|\bhit your\b.{0,24}\blimit\b|\busage-credits\b"),
@@ -120,10 +120,10 @@ def raw_state_id(frame: str) -> str:
     return hashlib.sha1(frame.encode("utf-8")).hexdigest()[:12]
 
 
-def matched_blocked(frames: list) -> list:
-    """BLOCKED-family names in `frames` — credits, login, compaction, waiting."""
+def matched_abnormal(frames: list) -> list:
+    """abnormal-family names in `frames` — credits, login, compaction, waiting."""
     text = "\n".join(frames)
-    return [name for name, rx in BLOCKED_PATTERNS if rx.search(text)]
+    return [name for name, rx in ABNORMAL_PATTERNS if rx.search(text)]
 
 
 def matched_patterns(frames: list) -> list:
@@ -187,13 +187,13 @@ def pattern_stats(pattern_samples: list, th: dict) -> dict:
             "retry_current": recurrent}
 
 
-def blocked_stats(blocked_samples: list, th: dict) -> dict:
-    """The same recurrence test over the BLOCKED family, kept separate so a
-    blocked state no longer has to look like a retry to reach a verdict."""
-    st = pattern_stats(blocked_samples, th)
-    return {"current_blocked": st["current_patterns"],
-            "consecutive_blocked_samples": st["consecutive_pattern_samples"],
-            "blocked_current": st["retry_current"]}
+def abnormal_stats(abnormal_samples: list, th: dict) -> dict:
+    """The same recurrence test over the abnormal family, kept separate so a
+    abnormal state no longer has to look like a retry to reach a verdict."""
+    st = pattern_stats(abnormal_samples, th)
+    return {"current_abnormal": st["current_patterns"],
+            "consecutive_abnormal_samples": st["consecutive_pattern_samples"],
+            "abnormal_current": st["retry_current"]}
 
 
 def classify(frames: list, work_outstanding: bool, duration_s: float,
@@ -207,12 +207,12 @@ def classify(frames: list, work_outstanding: bool, duration_s: float,
         raw_static = len(frames) >= 2 and len({raw_state_id(f) for f in frames}) == 1
     return classify_ids([state_id(f) for f in frames], raw_static, [matched_patterns([f]) for f in frames],
                         work_outstanding, duration_s, work_detail, thresholds,
-                        blocked=[matched_blocked([f]) for f in frames])
+                        abnormal=[matched_abnormal([f]) for f in frames])
 
 
 def classify_ids(state_ids: list, raw_static: bool, pats, work_outstanding: bool,
                  duration_s: float, work_detail: str = "", thresholds: Optional[dict] = None,
-                 gaps: Optional[list] = None, blocked: Optional[list] = None) -> dict:
+                 gaps: Optional[list] = None, abnormal: Optional[list] = None) -> dict:
     """The verdict from hashes and pattern names alone — what the persisted
     window carries, so no pane text is needed (or stored) to classify. `pats`
     is one list of pattern names per sample (a flat list means every sample)."""
@@ -221,7 +221,7 @@ def classify_ids(state_ids: list, raw_static: bool, pats, work_outstanding: bool
     if pats and all(isinstance(x, str) for x in pats):
         pats = [list(pats) for _ in state_ids]
     ps = pattern_stats(list(pats or []), th)
-    ps["_blocked"] = blocked_stats(list(blocked or []), th)
+    ps["_abnormal"] = abnormal_stats(list(abnormal or []), th)
     clock_only = (not raw_static) and nov.static
     spacing = {}
     if gaps:
@@ -235,8 +235,8 @@ def classify_ids(state_ids: list, raw_static: bool, pats, work_outstanding: bool
         "novel_state_count": nov.novel_state_count,
         "novelty_rate": round(nov.novelty_rate, 3),
         "matched_patterns": sorted({p for s in (pats or []) for p in s}),
-        "matched_blocked": sorted({p for s in (blocked or []) for p in s}),
-        **{k: v for k, v in blocked_stats(list(blocked or []), {**PROVISIONAL_THRESHOLDS, **(thresholds or {})}).items()},
+        "matched_abnormal": sorted({p for s in (abnormal or []) for p in s}),
+        **{k: v for k, v in abnormal_stats(list(abnormal or []), {**PROVISIONAL_THRESHOLDS, **(thresholds or {})}).items()},
         **ps,
         **spacing,
         "work_outstanding": work_outstanding,
@@ -259,25 +259,25 @@ def classify_ids(state_ids: list, raw_static: bool, pats, work_outstanding: bool
 def _classify_run(base: dict, nov: Novelty, raw_static: bool, ps: dict, clock_only: bool,
                   work_outstanding: bool, duration_s: float, work_detail: str, th: dict) -> dict:
     enough = nov.sample_count >= th["min_samples"]
-    # A provider told the CLI to stop: not a retry loop, a blocked state of its own.
+    # A provider told the CLI to stop: not a retry loop, a abnormal state of its own.
     # The pane keeps moving (clock, verb), so only current, recurrent text tells.
-    bs = ps.get("_blocked") or {"blocked_current": False, "current_blocked": [],
-                                "consecutive_blocked_samples": 0}
+    bs = ps.get("_abnormal") or {"abnormal_current": False, "current_abnormal": [],
+                                "consecutive_abnormal_samples": 0}
     low_novelty = enough and nov.novelty_rate <= th["low_novelty_rate"]
     # Retry is a SHAPE of the abnormal axis, not a sibling (owner): a retrying
     # pane is `moving + abnormal` — it moves while the work does not proceed.
-    if bs["blocked_current"] or ps["retry_current"]:
-        names = list(bs["current_blocked"]) + list(ps["current_patterns"])
-        n = max(bs["consecutive_blocked_samples"], ps["consecutive_pattern_samples"])
+    if bs["abnormal_current"] or ps["retry_current"]:
+        names = list(bs["current_abnormal"]) + list(ps["current_patterns"])
+        n = max(bs["consecutive_abnormal_samples"], ps["consecutive_pattern_samples"])
         # BOTH conditions: enough samples observed AND the text is recurrent.
         # n>=3 alone called a short window high-confidence; `enough` alone ignored recurrence.
         conf = "high" if (n >= 3 and enough) else "medium"
-        why = f"blocked text on the last {n} sample(s) ({', '.join(names)})"
+        why = f"abnormal text on the last {n} sample(s) ({', '.join(names)})"
         # Kinds stay STRING LITERALS: the availability fold's totality test derives
         # the emittable set by scanning this source, and a variable hides them.
-        if any(p in bs["current_blocked"] for p in PROVIDER_LIMIT_PATTERNS):
+        if any(p in bs["current_abnormal"] for p in PROVIDER_LIMIT_PATTERNS):
             return {**base, "kind": "provider-limit", "confidence": conf, "warn": True, "reason": why}
-        if ps["retry_current"] and not bs["blocked_current"]:
+        if ps["retry_current"] and not bs["abnormal_current"]:
             return {**base, "kind": "retry-loop", "confidence": conf, "warn": True, "reason": why}
         return {**base, "kind": "abnormal", "confidence": conf, "warn": True, "reason": why}
     # Case 1 is pure static on the RAW pane (spec): no normalization here.

--- a/src/cli_wedge.py
+++ b/src/cli_wedge.py
@@ -553,8 +553,11 @@ def append_window(workspace: Path, frame: str, now: float, keep: int = 20, pane:
         fcntl.flock(fd, fcntl.LOCK_EX)
         entries = load_window(path)
         # Hashes and pattern names only — no pane text is ever persisted here.
+        # Both families, or classify_window sees no abnormal text and the whole
+        # abnormal column is invisible to its one production caller.
         entry = {"ts": now, "state": state_id(frame), "raw_state": raw_state_id(frame),
-                 "patterns": matched_patterns([frame])}
+                 "patterns": matched_patterns([frame]),
+                 "abnormal": matched_abnormal([frame])}
         if pane:
             entry["pane"] = pane
         entries.append(entry)
@@ -622,8 +625,10 @@ def classify_window(entries: list, work: tuple, now: float, thresholds: Optional
     ids = [e["state"] for e in run]
     raws = [e.get("raw_state") for e in run]
     pats = [[p for p in e.get("patterns", []) if isinstance(p, str)] for e in run]
+    # Absent on rows written before this key existed: [] reads as no abnormal text.
+    abn = [[a for a in e.get("abnormal", []) if isinstance(a, str)] for e in run]
     whole_raw_static = len(run) >= 2 and all(raws) and len(set(raws)) == 1
-    whole = classify_ids(ids, whole_raw_static, pats, work[0], max(0.0, now - run[0]["ts"]), work[1], th, gaps)
+    whole = classify_ids(ids, whole_raw_static, pats, work[0], max(0.0, now - run[0]["ts"]), work[1], th, gaps, abn)
     if whole["kind"] in ("retry-loop", "provider-limit", "low-novelty"):
         return {**whole, **meta}
     last = run[-1].get("raw_state")
@@ -637,7 +642,8 @@ def classify_window(entries: list, work: tuple, now: float, thresholds: Optional
         tail_gaps = [b["ts"] - a["ts"] for a, b in zip(tail, tail[1:])]
         trailing = classify_ids([e["state"] for e in tail], True,
                                 [[p for p in e.get("patterns", []) if isinstance(p, str)] for e in tail],
-                                work[0], max(0.0, now - tail[0]["ts"]), work[1], th, tail_gaps)
+                                work[0], max(0.0, now - tail[0]["ts"]), work[1], th, tail_gaps,
+                                [[a for a in e.get("abnormal", []) if isinstance(a, str)] for e in tail])
         if trailing["kind"] in ("idle", "static-with-work"):
             return {**trailing, **meta, "sample_count": whole["sample_count"], "novel_state_count": whole["novel_state_count"],
                     "novelty_rate": whole["novelty_rate"], "clock_only": whole["clock_only"], "trailing_static_samples": len(tail)}

--- a/src/cli_wedge.py
+++ b/src/cli_wedge.py
@@ -200,7 +200,7 @@ def classify(frames: list, work_outstanding: bool, duration_s: float,
              work_detail: str = "", thresholds: Optional[dict] = None,
              raw_static: Optional[bool] = None) -> dict:
     """Advisory verdict over a window of frames. kind ∈ idle | working |
-    clock-only | static-with-work | retry-loop | blocked | provider-limit | low-novelty |
+    clock-only | static-with-work | retry-loop | abnormal | provider-limit | low-novelty |
     unknown (or, from the window, cadence-too-sparse); the four before unknown are warnings. `raw_static` is case 1's
     input (frame-for-frame equality); when None it is computed from `frames`."""
     if raw_static is None:
@@ -263,20 +263,23 @@ def _classify_run(base: dict, nov: Novelty, raw_static: bool, ps: dict, clock_on
     # The pane keeps moving (clock, verb), so only current, recurrent text tells.
     bs = ps.get("_blocked") or {"blocked_current": False, "current_blocked": [],
                                 "consecutive_blocked_samples": 0}
-    if bs["blocked_current"]:
-        conf = "high" if bs["consecutive_blocked_samples"] >= 3 else "medium"
-        why = (f"blocked text on the last {bs['consecutive_blocked_samples']} "
-               f"sample(s) ({', '.join(bs['current_blocked'])})")
+    low_novelty = enough and nov.novelty_rate <= th["low_novelty_rate"]
+    # Retry is a SHAPE of the abnormal axis, not a sibling (owner): a retrying
+    # pane is `moving + abnormal` — it moves while the work does not proceed.
+    if bs["blocked_current"] or ps["retry_current"]:
+        names = list(bs["current_blocked"]) + list(ps["current_patterns"])
+        n = max(bs["consecutive_blocked_samples"], ps["consecutive_pattern_samples"])
+        # BOTH conditions: enough samples observed AND the text is recurrent.
+        # n>=3 alone called a short window high-confidence; `enough` alone ignored recurrence.
+        conf = "high" if (n >= 3 and enough) else "medium"
+        why = f"blocked text on the last {n} sample(s) ({', '.join(names)})"
         # Kinds stay STRING LITERALS: the availability fold's totality test derives
         # the emittable set by scanning this source, and a variable hides them.
         if any(p in bs["current_blocked"] for p in PROVIDER_LIMIT_PATTERNS):
             return {**base, "kind": "provider-limit", "confidence": conf, "warn": True, "reason": why}
-        return {**base, "kind": "blocked", "confidence": conf, "warn": True, "reason": why}
-    low_novelty = enough and nov.novelty_rate <= th["low_novelty_rate"]
-    # Retry loop = low novelty AND retry text that is current and recurrent (not a stale residue).
-    if ps["retry_current"] and (raw_static or nov.static or low_novelty):
-        return {**base, "kind": "retry-loop", "confidence": "high" if enough else "medium", "warn": True,
-                "reason": f"{nov.novel_state_count} distinct state(s) over {nov.sample_count} samples; retry text on the last {ps['consecutive_pattern_samples']} ({', '.join(ps['current_patterns'])})"}
+        if ps["retry_current"] and not bs["blocked_current"]:
+            return {**base, "kind": "retry-loop", "confidence": conf, "warn": True, "reason": why}
+        return {**base, "kind": "abnormal", "confidence": conf, "warn": True, "reason": why}
     # Case 1 is pure static on the RAW pane (spec): no normalization here.
     if raw_static:
         if work_outstanding:

--- a/src/cli_wedge.py
+++ b/src/cli_wedge.py
@@ -264,10 +264,14 @@ def _classify_run(base: dict, nov: Novelty, raw_static: bool, ps: dict, clock_on
     bs = ps.get("_blocked") or {"blocked_current": False, "current_blocked": [],
                                 "consecutive_blocked_samples": 0}
     if bs["blocked_current"]:
-        prov = [p for p in bs["current_blocked"] if p in PROVIDER_LIMIT_PATTERNS]
-        kind = "provider-limit" if prov else "blocked"
-        return {**base, "kind": kind, "confidence": "high" if bs["consecutive_blocked_samples"] >= 3 else "medium",
-                "warn": True, "reason": f"blocked text on the last {bs['consecutive_blocked_samples']} sample(s) ({', '.join(bs['current_blocked'])})"}
+        conf = "high" if bs["consecutive_blocked_samples"] >= 3 else "medium"
+        why = (f"blocked text on the last {bs['consecutive_blocked_samples']} "
+               f"sample(s) ({', '.join(bs['current_blocked'])})")
+        # Kinds stay STRING LITERALS: the availability fold's totality test derives
+        # the emittable set by scanning this source, and a variable hides them.
+        if any(p in bs["current_blocked"] for p in PROVIDER_LIMIT_PATTERNS):
+            return {**base, "kind": "provider-limit", "confidence": conf, "warn": True, "reason": why}
+        return {**base, "kind": "blocked", "confidence": conf, "warn": True, "reason": why}
     low_novelty = enough and nov.novelty_rate <= th["low_novelty_rate"]
     # Retry loop = low novelty AND retry text that is current and recurrent (not a stale residue).
     if ps["retry_current"] and (raw_static or nov.static or low_novelty):

--- a/src/cli_wedge.py
+++ b/src/cli_wedge.py
@@ -85,11 +85,11 @@ PROVISIONAL_THRESHOLDS = {
 ABNORMAL_PATTERNS: tuple[tuple[str, re.Pattern], ...] = tuple(
     (name, re.compile(rx, re.IGNORECASE))
     for name, rx in (
-        ("quota-limit", r"\b(hit|reached|exceeded)\b.{0,24}\b(session|usage|weekly|daily|plan) limit\b|\b(session|usage|weekly|daily|plan) limit (reached|exceeded|hit)\b|\bhit your\b.{0,24}\blimit\b|\busage-credits\b"),
-        ("out-of-credits", r"\bout of (usage )?credits?\b|\bcredit balance (is )?(too )?low\b|\binsufficient credits?\b"),
-        ("needs-login", r"\b(please )?(log ?in|sign ?in) to continue\b|\bsession expired\b|\bauthentication (required|failed)\b|\brun /login\b"),
-        ("compacting", r"\bcompact(ing|ion)\b"),
-        ("awaiting-input", r"\b(waiting|awaiting) for (your )?(input|approval|confirmation)\b"),
+        ("quota-limit", r"(you('ve| have)? )?(hit|reached|exceeded)\b.{0,24}\b(session|usage|weekly|daily|plan) limit\b|(session|usage|weekly|daily|plan) limit (reached|exceeded|hit)\b|(you('ve| have)? )?hit your\b.{0,24}\blimit\b|/?usage-credits\b"),
+        ("out-of-credits", r"(you('re| are)? )?out of (usage )?credits?\b|credit balance (is )?(too )?low\b|insufficient credits?\b"),
+        ("needs-login", r"(please )?(log ?in|sign ?in) to continue\b|session expired\b|authentication (required|failed)\b|run /login\b"),
+        ("compacting", r"compact(ing|ion)\b"),
+        ("awaiting-input", r"(waiting|awaiting) for (your )?(input|approval|confirmation)\b"),
     )
 )
 
@@ -120,10 +120,26 @@ def raw_state_id(frame: str) -> str:
     return hashlib.sha1(frame.encode("utf-8")).hexdigest()[:12]
 
 
+# Leading decoration a CLI puts before a banner: indent, quote/prompt glyphs,
+# spinner frames, box rules. Stripped so the anchor sees the banner's first word.
+_BANNER_DECOR = re.compile(r"^[\s>\u00b7*\u2022\-\u2500-\u257f\u2713\u2717\u273b\u2733\u23f5\u28c0-\u28ff]+")
+
+
 def matched_abnormal(frames: list) -> list:
-    """abnormal-family names in `frames` — credits, login, compaction, waiting."""
-    text = "\n".join(frames)
-    return [name for name, rx in ABNORMAL_PATTERNS if rx.search(text)]
+    """abnormal-family names in `frames` — credits, login, compaction, waiting.
+
+    ANCHORED to the start of a line, not searched anywhere in the text. These
+    panes are agent CLIs whose transcripts are English prose about their own
+    work, so an unanchored search is self-hitting: a session discussing
+    compaction classified itself `abnormal` at high confidence. A banner leads
+    its line; prose buries the phrase mid-sentence.
+    """
+    hits = []
+    lines = [_BANNER_DECOR.sub("", ln) for f in frames for ln in f.splitlines()]
+    for name, rx in ABNORMAL_PATTERNS:
+        if any(rx.match(ln) for ln in lines):
+            hits.append(name)
+    return hits
 
 
 def matched_patterns(frames: list) -> list:
@@ -221,7 +237,7 @@ def classify_ids(state_ids: list, raw_static: bool, pats, work_outstanding: bool
     if pats and all(isinstance(x, str) for x in pats):
         pats = [list(pats) for _ in state_ids]
     ps = pattern_stats(list(pats or []), th)
-    ps["_abnormal"] = abnormal_stats(list(abnormal or []), th)
+    abn = abnormal_stats(list(abnormal or []), th)
     clock_only = (not raw_static) and nov.static
     spacing = {}
     if gaps:
@@ -236,7 +252,7 @@ def classify_ids(state_ids: list, raw_static: bool, pats, work_outstanding: bool
         "novelty_rate": round(nov.novelty_rate, 3),
         "matched_patterns": sorted({p for s in (pats or []) for p in s}),
         "matched_abnormal": sorted({p for s in (abnormal or []) for p in s}),
-        **{k: v for k, v in abnormal_stats(list(abnormal or []), {**PROVISIONAL_THRESHOLDS, **(thresholds or {})}).items()},
+        **abn,
         **ps,
         **spacing,
         "work_outstanding": work_outstanding,
@@ -248,7 +264,7 @@ def classify_ids(state_ids: list, raw_static: bool, pats, work_outstanding: bool
     if nov.sample_count < 2:
         return {**base, "kind": "unknown", "confidence": "none", "warn": False,
                 "reason": "fewer than 2 samples in the current observation run — nothing to compare"}
-    verdict = _classify_run(base, nov, raw_static, ps, clock_only, work_outstanding, duration_s, work_detail, th)
+    verdict = _classify_run(base, nov, raw_static, ps, clock_only, work_outstanding, duration_s, work_detail, th, abn)
     # Two frames a second apart cannot establish a wedge: a WARNING needs the run to have lasted.
     if verdict["warn"] and duration_s < th["min_duration_s"]:
         return {**base, "kind": "unknown", "confidence": "none", "warn": False,
@@ -257,12 +273,12 @@ def classify_ids(state_ids: list, raw_static: bool, pats, work_outstanding: bool
 
 
 def _classify_run(base: dict, nov: Novelty, raw_static: bool, ps: dict, clock_only: bool,
-                  work_outstanding: bool, duration_s: float, work_detail: str, th: dict) -> dict:
+                  work_outstanding: bool, duration_s: float, work_detail: str, th: dict,
+                  abn: dict) -> dict:
     enough = nov.sample_count >= th["min_samples"]
     # A provider told the CLI to stop: not a retry loop, a abnormal state of its own.
     # The pane keeps moving (clock, verb), so only current, recurrent text tells.
-    bs = ps.get("_abnormal") or {"abnormal_current": False, "current_abnormal": [],
-                                "consecutive_abnormal_samples": 0}
+    bs = abn
     low_novelty = enough and nov.novelty_rate <= th["low_novelty_rate"]
     # Retry is a SHAPE of the abnormal axis, not a sibling (owner): a retrying
     # pane is `moving + abnormal` — it moves while the work does not proceed.

--- a/src/cli_wedge.py
+++ b/src/cli_wedge.py
@@ -51,7 +51,6 @@ RETRY_PATTERNS: tuple[tuple[str, re.Pattern], ...] = tuple(
         ("timeout", r"\btimed? ?out\b"),
         # A CLI told to stop by its provider: every turn ends the same way while the clock
         # moves; only text tells this from work — and it must be a limit HIT, not one mentioned.
-        ("quota-limit", r"\b(hit|reached|exceeded)\b.{0,24}\b(session|usage|weekly|daily|plan) limit\b|\b(session|usage|weekly|daily|plan) limit (reached|exceeded|hit)\b|\bhit your\b.{0,24}\blimit\b|\busage-credits\b"),
     )
 )
 
@@ -83,7 +82,19 @@ PROVISIONAL_THRESHOLDS = {
     "status_ttl_s": 900,
     "min_duration_s": 60,
 }
-PROVIDER_LIMIT_PATTERNS = ("quota-limit",)
+BLOCKED_PATTERNS: tuple[tuple[str, re.Pattern], ...] = tuple(
+    (name, re.compile(rx, re.IGNORECASE))
+    for name, rx in (
+        ("quota-limit", r"\b(hit|reached|exceeded)\b.{0,24}\b(session|usage|weekly|daily|plan) limit\b|\b(session|usage|weekly|daily|plan) limit (reached|exceeded|hit)\b|\bhit your\b.{0,24}\blimit\b|\busage-credits\b"),
+        ("out-of-credits", r"\bout of (usage )?credits?\b|\bcredit balance (is )?(too )?low\b|\binsufficient credits?\b"),
+        ("needs-login", r"\b(please )?(log ?in|sign ?in) to continue\b|\bsession expired\b|\bauthentication (required|failed)\b|\brun /login\b"),
+        ("compacting", r"\bcompact(ing|ion)\b"),
+        ("awaiting-input", r"\b(waiting|awaiting) for (your )?(input|approval|confirmation)\b"),
+    )
+)
+
+# Kept so an existing reader still sees the provider-limit family by name.
+PROVIDER_LIMIT_PATTERNS = ("quota-limit", "out-of-credits")
 DEFAULT_SESSION = "sutando-core"
 
 def normalize(frame: str) -> str:
@@ -107,6 +118,12 @@ def state_id(frame: str) -> str:
 def raw_state_id(frame: str) -> str:
     """Identity of the frame as displayed — what case 1 compares."""
     return hashlib.sha1(frame.encode("utf-8")).hexdigest()[:12]
+
+
+def matched_blocked(frames: list) -> list:
+    """BLOCKED-family names in `frames` — credits, login, compaction, waiting."""
+    text = "\n".join(frames)
+    return [name for name, rx in BLOCKED_PATTERNS if rx.search(text)]
 
 
 def matched_patterns(frames: list) -> list:
@@ -170,22 +187,32 @@ def pattern_stats(pattern_samples: list, th: dict) -> dict:
             "retry_current": recurrent}
 
 
+def blocked_stats(blocked_samples: list, th: dict) -> dict:
+    """The same recurrence test over the BLOCKED family, kept separate so a
+    blocked state no longer has to look like a retry to reach a verdict."""
+    st = pattern_stats(blocked_samples, th)
+    return {"current_blocked": st["current_patterns"],
+            "consecutive_blocked_samples": st["consecutive_pattern_samples"],
+            "blocked_current": st["retry_current"]}
+
+
 def classify(frames: list, work_outstanding: bool, duration_s: float,
              work_detail: str = "", thresholds: Optional[dict] = None,
              raw_static: Optional[bool] = None) -> dict:
     """Advisory verdict over a window of frames. kind ∈ idle | working |
-    clock-only | static-with-work | retry-loop | provider-limit | low-novelty |
+    clock-only | static-with-work | retry-loop | blocked | provider-limit | low-novelty |
     unknown (or, from the window, cadence-too-sparse); the four before unknown are warnings. `raw_static` is case 1's
     input (frame-for-frame equality); when None it is computed from `frames`."""
     if raw_static is None:
         raw_static = len(frames) >= 2 and len({raw_state_id(f) for f in frames}) == 1
     return classify_ids([state_id(f) for f in frames], raw_static, [matched_patterns([f]) for f in frames],
-                        work_outstanding, duration_s, work_detail, thresholds)
+                        work_outstanding, duration_s, work_detail, thresholds,
+                        blocked=[matched_blocked([f]) for f in frames])
 
 
 def classify_ids(state_ids: list, raw_static: bool, pats, work_outstanding: bool,
                  duration_s: float, work_detail: str = "", thresholds: Optional[dict] = None,
-                 gaps: Optional[list] = None) -> dict:
+                 gaps: Optional[list] = None, blocked: Optional[list] = None) -> dict:
     """The verdict from hashes and pattern names alone — what the persisted
     window carries, so no pane text is needed (or stored) to classify. `pats`
     is one list of pattern names per sample (a flat list means every sample)."""
@@ -194,6 +221,7 @@ def classify_ids(state_ids: list, raw_static: bool, pats, work_outstanding: bool
     if pats and all(isinstance(x, str) for x in pats):
         pats = [list(pats) for _ in state_ids]
     ps = pattern_stats(list(pats or []), th)
+    ps["_blocked"] = blocked_stats(list(blocked or []), th)
     clock_only = (not raw_static) and nov.static
     spacing = {}
     if gaps:
@@ -207,6 +235,8 @@ def classify_ids(state_ids: list, raw_static: bool, pats, work_outstanding: bool
         "novel_state_count": nov.novel_state_count,
         "novelty_rate": round(nov.novelty_rate, 3),
         "matched_patterns": sorted({p for s in (pats or []) for p in s}),
+        "matched_blocked": sorted({p for s in (blocked or []) for p in s}),
+        **{k: v for k, v in blocked_stats(list(blocked or []), {**PROVISIONAL_THRESHOLDS, **(thresholds or {})}).items()},
         **ps,
         **spacing,
         "work_outstanding": work_outstanding,
@@ -231,9 +261,13 @@ def _classify_run(base: dict, nov: Novelty, raw_static: bool, ps: dict, clock_on
     enough = nov.sample_count >= th["min_samples"]
     # A provider told the CLI to stop: not a retry loop, a blocked state of its own.
     # The pane keeps moving (clock, verb), so only current, recurrent text tells.
-    if ps["retry_current"] and any(p in ps["current_patterns"] for p in PROVIDER_LIMIT_PATTERNS):
-        return {**base, "kind": "provider-limit", "confidence": "high" if ps["consecutive_pattern_samples"] >= 3 else "medium",
-                "warn": True, "reason": f"provider limit text on the last {ps['consecutive_pattern_samples']} sample(s) ({', '.join(ps['current_patterns'])})"}
+    bs = ps.get("_blocked") or {"blocked_current": False, "current_blocked": [],
+                                "consecutive_blocked_samples": 0}
+    if bs["blocked_current"]:
+        prov = [p for p in bs["current_blocked"] if p in PROVIDER_LIMIT_PATTERNS]
+        kind = "provider-limit" if prov else "blocked"
+        return {**base, "kind": kind, "confidence": "high" if bs["consecutive_blocked_samples"] >= 3 else "medium",
+                "warn": True, "reason": f"blocked text on the last {bs['consecutive_blocked_samples']} sample(s) ({', '.join(bs['current_blocked'])})"}
     low_novelty = enough and nov.novelty_rate <= th["low_novelty_rate"]
     # Retry loop = low novelty AND retry text that is current and recurrent (not a stale residue).
     if ps["retry_current"] and (raw_static or nov.static or low_novelty):

--- a/tests/cli-wedge-health-probe.test.py
+++ b/tests/cli-wedge-health-probe.test.py
@@ -147,6 +147,14 @@ class CliWedgeProbe(unittest.TestCase):
         self.assertIn("idle", c["detail"])
         self.assertEqual(c["evidence"]["sample_count"], 3)
 
+    def test_a_pane_parked_on_an_error_warns_from_its_own_text(self):
+        # The abnormal predicate must reach classify_window, which the probe calls.
+        self.frames = ["❯ \n⏵⏵ you have hit your usage limit · resets 3:00 PM\n"] * 12
+        for _ in range(12):
+            c = self.check()
+        self.assertEqual(c["status"], "warn")
+        self.assertIn("reads the pane, not the process", c["detail"])
+
     def test_static_pane_with_work_outstanding_warns(self):
         (self.ws / "state" / "core-status.json").write_text(json.dumps({"status": "running", "ts": self._t[0] + 60.0}))
         for _ in range(3):

--- a/tests/cli-wedge.test.py
+++ b/tests/cli-wedge.test.py
@@ -909,5 +909,62 @@ class FailureBoundary(unittest.TestCase):
                 w.append_window(ws, IDLE, 1.0)
 
 
+
+class ProseMentioningAStateIsNotThatState(unittest.TestCase):
+    """One negative control per abnormal pattern.
+
+    These panes are agent CLIs whose transcripts are English prose about their
+    own work, so an unanchored substring search is SELF-HITTING: a session
+    discussing compaction classified itself `abnormal` at high confidence
+    (measured on 12 prose-only frames of an idle pane). The matcher anchors to
+    the start of a line after stripping banner decoration — a banner leads its
+    line, prose buries the phrase mid-sentence.
+    """
+
+    PROSE = [
+        ("compacting", "I am compacting the summary of what we discussed"),
+        ("compacting", "reviewing the compacting patterns in cli_wedge"),
+        ("needs-login", "we fixed the bug where it says please log in to continue"),
+        ("needs-login", "a session expired bug we already fixed"),
+        ("awaiting-input", "the draft is waiting for your input before it sends"),
+        ("out-of-credits", "the ticket says the user was out of usage credits last week"),
+        ("quota-limit", "the docs explain what happens when you hit your weekly limit"),
+    ]
+    BANNERS = [
+        ("compacting", "Compacting conversation"),
+        ("compacting", "\u273b Compacting conversation"),
+        ("needs-login", "Please log in to continue"),
+        ("needs-login", "Session expired"),
+        ("awaiting-input", "Waiting for your input"),
+        ("out-of-credits", "You are out of usage credits"),
+    ]
+
+    def test_prose_mentioning_a_state_does_not_match(self):
+        for name, line in self.PROSE:
+            self.assertEqual(w.matched_abnormal([line]), [],
+                             f"{name}: prose matched as a banner -> {line!r}")
+
+    def test_real_banners_still_match(self):
+        """The other half. Anchoring alone would drop a true positive --
+        'You are out of usage credits' does not START with the pattern -- so each
+        pattern also carries the banner's leading form. Without this test the
+        anchor could be tightened until nothing fires and every prose case passes."""
+        for name, line in self.BANNERS:
+            self.assertIn(name, w.matched_abnormal([line]),
+                          f"{name}: real banner stopped matching -> {line!r}")
+
+    def test_a_prose_only_idle_pane_does_not_warn(self):
+        frames = [f"I am reviewing the compacting patterns\n  \u00b7 5:{17 + i // 3:02d} PM\n> "
+                  for i in range(12)]
+        v = w.classify(frames, False, 600)
+        self.assertFalse(v["warn"], f"a prose-only idle pane warned: {v}")
+        self.assertNotEqual(v["kind"], "abnormal", v)
+
+    def test_the_internal_marker_does_not_ride_in_the_verdict(self):
+        v = w.classify(["x"], False, 60)
+        self.assertNotIn("_abnormal", v,
+                         "the marker duplicates the flattened abnormal_* keys already spread in")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=1)

--- a/tests/cli-wedge.test.py
+++ b/tests/cli-wedge.test.py
@@ -121,7 +121,7 @@ class Classifier(unittest.TestCase):
         v = w.classify([frame(i) for i in range(12)], True, 300)
         # A provider-blocked CLI is its own kind (owner review), not forced into "retry loop".
         self.assertEqual((v["kind"], v["warn"], v["confidence"]), ("provider-limit", True, "high"))
-        self.assertIn("quota-limit", v["current_patterns"])
+        self.assertIn("quota-limit", v["current_blocked"])
         self.assertFalse(v["raw_static"])  # the pane moved: this is case 2, not case 1
 
     def test_codex_idle_banner_is_not_a_provider_limit(self):
@@ -135,7 +135,7 @@ class Classifier(unittest.TestCase):
                 "› \n"
             )
         v = w.classify([frame(i) for i in range(20)], False, 60)
-        self.assertNotIn("quota-limit", v["matched_patterns"], v)
+        self.assertNotIn("quota-limit", v["matched_patterns"] + v.get("matched_blocked", []), v)
         self.assertNotEqual(v["kind"], "provider-limit", v)
         # Positive controls: the phrasings that DO mean a limit was hit still match.
         for line in ("You've hit your usage limit · resets 6pm",
@@ -143,7 +143,35 @@ class Classifier(unittest.TestCase):
                      "Session limit reached. Try again at 6pm",
                      "usage limit exceeded for this plan",
                      "/usage-credits to finish what you're working on."):
-            self.assertIn("quota-limit", w.matched_patterns([line]), line)
+            self.assertIn("quota-limit", w.matched_blocked([line]), line)
+
+    def test_a_blocked_pane_whose_clock_moves_is_not_clock_only(self):
+        """The clock-only exemption ("a live CLI, not a wedge") swallowed every
+        blocked state whose pane ticked: #4015 sat 70 min refusing each turn."""
+        def moving(msg):
+            return [f"{msg}\n  idle · 5:{17 + i // 3:02d} PM · nothing running\n> "
+                    for i in range(12)]
+        for msg, want in (("You are out of usage credits", "provider-limit"),
+                          ("Please log in to continue", "blocked"),
+                          ("Compacting conversation", "blocked")):
+            v = w.classify(moving(msg), False, 4200)
+            self.assertEqual(v["kind"], want, msg)
+            self.assertTrue(v["warn"], msg)
+
+    def test_blocked_is_reached_without_any_retry_text(self):
+        """Every blocked verdict used to be gated on retry text, which is why
+        quota-limit had to live in RETRY_PATTERNS to work at all."""
+        v = w.classify(["Please log in to continue"] * 8, True, 600)
+        self.assertEqual(v["matched_patterns"], [])
+        self.assertIn("needs-login", v["matched_blocked"])
+        self.assertEqual(v["kind"], "blocked")
+
+    def test_the_two_families_are_disjoint(self):
+        self.assertFalse({n for n, _ in w.RETRY_PATTERNS} & {n for n, _ in w.BLOCKED_PATTERNS})
+
+    def test_ordinary_work_still_does_not_warn(self):
+        v = w.classify([f"Thinking... step {i}" for i in range(8)], True, 600)
+        self.assertEqual((v["kind"], v["warn"]), ("working", False))
 
     def test_a_pattern_in_one_old_sample_does_not_colour_the_window(self):
         # Owner review P1: sample 1 says "command timed out", the rest is a finished, idle pane.

--- a/tests/cli-wedge.test.py
+++ b/tests/cli-wedge.test.py
@@ -152,8 +152,8 @@ class Classifier(unittest.TestCase):
             return [f"{msg}\n  idle · 5:{17 + i // 3:02d} PM · nothing running\n> "
                     for i in range(12)]
         for msg, want in (("You are out of usage credits", "provider-limit"),
-                          ("Please log in to continue", "blocked"),
-                          ("Compacting conversation", "blocked")):
+                          ("Please log in to continue", "abnormal"),
+                          ("Compacting conversation", "abnormal")):
             v = w.classify(moving(msg), False, 4200)
             self.assertEqual(v["kind"], want, msg)
             self.assertTrue(v["warn"], msg)
@@ -164,7 +164,7 @@ class Classifier(unittest.TestCase):
         v = w.classify(["Please log in to continue"] * 8, True, 600)
         self.assertEqual(v["matched_patterns"], [])
         self.assertIn("needs-login", v["matched_blocked"])
-        self.assertEqual(v["kind"], "blocked")
+        self.assertEqual(v["kind"], "abnormal")
 
     def test_the_two_families_are_disjoint(self):
         self.assertFalse({n for n, _ in w.RETRY_PATTERNS} & {n for n, _ in w.BLOCKED_PATTERNS})

--- a/tests/cli-wedge.test.py
+++ b/tests/cli-wedge.test.py
@@ -857,10 +857,21 @@ class Confidentiality(unittest.TestCase):
     def test_window_entries_carry_hashes_and_patterns_only(self):
         with tempfile.TemporaryDirectory() as d:
             entries = w.append_window(Path(d), retry_frame(1), 1.0)
-            self.assertEqual(sorted(entries[-1]), ["patterns", "raw_state", "state", "ts"])
+            self.assertEqual(sorted(entries[-1]), ["abnormal", "patterns", "raw_state", "state", "ts"])
             text = w.window_path(Path(d)).read_text()
             self.assertNotIn("Retrying", text)
             self.assertNotIn("attempt", text)
+
+    def test_persisted_pattern_fields_hold_NAMES_from_the_known_vocabulary(self):
+        # `abnormal` joined `patterns` in the window; both must stay a closed set of
+        # pattern names, never a snippet of the pane that matched.
+        vocab = {n for n, _ in w.RETRY_PATTERNS} | {n for n, _ in w.ABNORMAL_PATTERNS}
+        with tempfile.TemporaryDirectory() as d:
+            e = w.append_window(Path(d), "❯ \n⏵⏵ please log in to continue · run /login\n", 1.0)
+            self.assertTrue(e[-1]["abnormal"], "the fixture must match, or this proves nothing")
+            for key in ("patterns", "abnormal"):
+                self.assertLessEqual(set(e[-1][key]), vocab, key)
+            self.assertNotIn("/login", w.window_path(Path(d)).read_text())
 
     def test_files_are_owner_only_under_a_permissive_umask(self):
         old = os.umask(0o022)

--- a/tests/cli-wedge.test.py
+++ b/tests/cli-wedge.test.py
@@ -119,9 +119,9 @@ class Classifier(unittest.TestCase):
                 f"* {verb} for 1s · done 5:{17 + i // 3:02d} PM · 1 monitor still running\n"
             )
         v = w.classify([frame(i) for i in range(12)], True, 300)
-        # A provider-blocked CLI is its own kind (owner review), not forced into "retry loop".
+        # A provider-abnormal CLI is its own kind (owner review), not forced into "retry loop".
         self.assertEqual((v["kind"], v["warn"], v["confidence"]), ("provider-limit", True, "high"))
-        self.assertIn("quota-limit", v["current_blocked"])
+        self.assertIn("quota-limit", v["current_abnormal"])
         self.assertFalse(v["raw_static"])  # the pane moved: this is case 2, not case 1
 
     def test_codex_idle_banner_is_not_a_provider_limit(self):
@@ -135,7 +135,7 @@ class Classifier(unittest.TestCase):
                 "› \n"
             )
         v = w.classify([frame(i) for i in range(20)], False, 60)
-        self.assertNotIn("quota-limit", v["matched_patterns"] + v.get("matched_blocked", []), v)
+        self.assertNotIn("quota-limit", v["matched_patterns"] + v.get("matched_abnormal", []), v)
         self.assertNotEqual(v["kind"], "provider-limit", v)
         # Positive controls: the phrasings that DO mean a limit was hit still match.
         for line in ("You've hit your usage limit · resets 6pm",
@@ -143,11 +143,11 @@ class Classifier(unittest.TestCase):
                      "Session limit reached. Try again at 6pm",
                      "usage limit exceeded for this plan",
                      "/usage-credits to finish what you're working on."):
-            self.assertIn("quota-limit", w.matched_blocked([line]), line)
+            self.assertIn("quota-limit", w.matched_abnormal([line]), line)
 
-    def test_a_blocked_pane_whose_clock_moves_is_not_clock_only(self):
+    def test_an_abnormal_pane_whose_clock_moves_is_not_clock_only(self):
         """The clock-only exemption ("a live CLI, not a wedge") swallowed every
-        blocked state whose pane ticked: #4015 sat 70 min refusing each turn."""
+        abnormal state whose pane ticked: #4015 sat 70 min refusing each turn."""
         def moving(msg):
             return [f"{msg}\n  idle · 5:{17 + i // 3:02d} PM · nothing running\n> "
                     for i in range(12)]
@@ -158,16 +158,16 @@ class Classifier(unittest.TestCase):
             self.assertEqual(v["kind"], want, msg)
             self.assertTrue(v["warn"], msg)
 
-    def test_blocked_is_reached_without_any_retry_text(self):
-        """Every blocked verdict used to be gated on retry text, which is why
+    def test_abnormal_is_reached_without_any_retry_text(self):
+        """Every abnormal verdict used to be gated on retry text, which is why
         quota-limit had to live in RETRY_PATTERNS to work at all."""
         v = w.classify(["Please log in to continue"] * 8, True, 600)
         self.assertEqual(v["matched_patterns"], [])
-        self.assertIn("needs-login", v["matched_blocked"])
+        self.assertIn("needs-login", v["matched_abnormal"])
         self.assertEqual(v["kind"], "abnormal")
 
     def test_the_two_families_are_disjoint(self):
-        self.assertFalse({n for n, _ in w.RETRY_PATTERNS} & {n for n, _ in w.BLOCKED_PATTERNS})
+        self.assertFalse({n for n, _ in w.RETRY_PATTERNS} & {n for n, _ in w.ABNORMAL_PATTERNS})
 
     def test_ordinary_work_still_does_not_warn(self):
         v = w.classify([f"Thinking... step {i}" for i in range(8)], True, 600)


### PR DESCRIPTION
**Stacked on #4102 — merge that first.** Base is `fix/cli-wedge-blocked-predicate`; this branch is `edfef115 → f105f218 → 7cbdc2fd`. It only makes sense on top of #4102's text-based abnormal predicate.

## What and why

Owner instruction (2026-09-10): *"use right way to detect retry and remove wrong/irrelevant measurements."*

`low-novelty` was measuring **repetition**; retry is a **cause**. Measured both directions before removing it:

```
retry, SAME error each time        distinct  1/12  rate 0.08  -> retry-loop  (caught by TEXT)
retry, DIFFERENT error each time   distinct 12/12  rate 1.00  -> working     (MISSED)
healthy: 12 distinct files         distinct 12/12  rate 1.00  -> working     (no false positive)
```

The retry it "caught" was already caught by `ABNORMAL_PATTERNS`. Strip the word *retrying* — a backoff loop cycling through different upstream errors — and novelty is 1.00, indistinguishable from healthy work. So the statistic reached neither case.

Its live window was also two states wide: one state raw-static → `static-with-work`; one state + a clock → `clock-only`; **two states → low-novelty**; three states → rate 0.25, `working`.

`clock-only` existed only to stop that branch warning on healthy work — measured by disabling it:

```
with    the clock_only branch    clock-only    warn=False
without it                       low-novelty   warn=True
```

So the two come out together.

## Before / after — the 2×2 is unchanged

```
                     BEFORE (#4102)        AFTER
idle   + healthy     idle        ok        idle        ok
idle   + abnormal    abnormal    WARN      abnormal    WARN
moving + healthy     clock-only  ok        working     ok     <- same verdict, one kind fewer
moving + abnormal    abnormal    WARN      abnormal    WARN
retry loop           retry-loop  WARN      retry-loop  WARN   <- from the text
```

## The one behavioural loss, stated rather than buried

A two-state alternating pane with **no abnormal text** no longer warns. That was low-novelty's entire live window, and its own reason line called it *"repetitive, cause unknown"*. Restoring that case needs a cause, not a rate.

## Control

Green alone proves nothing, so: breaking the `retrying` pattern turns the suite **red (2 failures)**. Retry detection is load-bearing, not passing on another path.

`tests/cli-wedge.test.py` 74 · `tests/agent-availability.test.py` 31 · `tests/cli-wedge-health-probe.test.py` 17 — all pass.

## Second commit

The docstring now states the goal as the owner's 2×2 with every kind placed in a cell — after my own summary listed retry as a *fifth case* while the file said retry is a shape of abnormal. `FourCasesFold` pins the fold rather than the prose, since prose is what drifted.

@sonichi — this is the removal you asked for; the behavioural loss above is the only thing I would want your eye on.
