### PR TITLE
fix(proactive-loop): the monologue gate has no default repo

### DIFF
--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -102,7 +102,7 @@ caps this file and refuses date stamps in it).
    Not running with no trees → `Monitor` `bash src/watch-tasks-stream.sh` persistent. A missing sentinel
    is UNKNOWN, not dead; never hand-roll a process check.
 9.5. **PR thread gate**, before posting to a PR thread:
-   `python3 skills/proactive-loop/scripts/pr-monologue-check.py <number> --me <your-login>`
+   `python3 skills/proactive-loop/scripts/pr-monologue-check.py <PR url|number --repo owner/name> --me <your-login>`
    (0 safe · 1 refuse, run and span named · 2 cannot answer). On refuse, re-solicit through a stand.
 10. **Discord.** Check the channels in `reference_discord_channels.md`; forward actionable public items to
     the dev channel. #bot2bot tags: `claim:` `blocked:` `done:` `ping:` `nack:` `opinion-requested:`.

--- a/skills/proactive-loop/scripts/pr-monologue-check.py
+++ b/skills/proactive-loop/scripts/pr-monologue-check.py
@@ -12,12 +12,13 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 from datetime import datetime, timezone
 
-DEFAULT_REPO = "sonichi/sutando"
 DEFAULT_THRESHOLD = 3
+PR_URL_RE = re.compile(r"https?://github\.com/([\w.-]+/[\w.-]+)/pull/(\d+)")
 
 
 def parse_ts(value: str) -> datetime:
@@ -82,18 +83,33 @@ def fetch(repo: str, number: int):
 
 def main(argv=None) -> int:
     ap = argparse.ArgumentParser()
-    ap.add_argument("number", type=int)
+    ap.add_argument("number", help="PR number (needs --repo) or a full PR URL")
     ap.add_argument("--repo", default=None)
     ap.add_argument("--me", required=True)
     ap.add_argument("--threshold", type=int, default=DEFAULT_THRESHOLD)
     ap.add_argument("--count-bots", action="store_true",
                     help="treat bot comments as engagement (default: ignore them)")
     args = ap.parse_args(argv)
-    # A silently-defaulted repo makes this gate unable to refuse: on a PR in any
-    # other repo it reads the same-numbered thread here, which is usually empty.
-    if args.repo is None:
-        args.repo = DEFAULT_REPO
-        print(f"assuming --repo {DEFAULT_REPO} (not given)", file=sys.stderr)
+    # No default repo: a bare number in another repo reads an unrelated thread,
+    # so the only verdict this gate could reach there is "safe".
+    url = PR_URL_RE.match(args.number.strip())
+    if url:
+        if args.repo and args.repo != url.group(1):
+            print(f"CANNOT ANSWER: --repo {args.repo} disagrees with the URL's "
+                  f"{url.group(1)} — refusing rather than picking one", file=sys.stderr)
+            return 2
+        args.repo, args.number = url.group(1), int(url.group(2))
+    else:
+        if not args.number.isdigit():
+            print(f"CANNOT ANSWER: {args.number!r} is neither a PR number nor a "
+                  "github.com PR URL", file=sys.stderr)
+            return 2
+        args.number = int(args.number)
+        if args.repo is None:
+            print("CANNOT ANSWER: no --repo given, and a bare number could name a PR "
+                  "in any repo. Pass --repo <owner/name>, or the full PR URL.",
+                  file=sys.stderr)
+            return 2
 
     if args.threshold < 1:
         print("threshold must be >= 1", file=sys.stderr)

--- a/tests/proactive-loop-pr-monologue-check.test.py
+++ b/tests/proactive-loop-pr-monologue-check.test.py
@@ -15,6 +15,7 @@ sys.modules["pr_monologue_check"] = g
 spec.loader.exec_module(g)
 
 ME = "me"
+REPO = "sonichi/sutando"
 
 
 def c(ts, login):
@@ -95,18 +96,18 @@ class TestMain(unittest.TestCase):
 
     def test_refuses_at_the_threshold(self):
         ev = [c(T(1), ME), c(T(2), ME), c(T(3), ME)]
-        self.assertEqual(self._with_fetch(ev, [], ["1", "--me", ME]), 1)
+        self.assertEqual(self._with_fetch(ev, [], ["1", "--me", ME, "--repo", REPO]), 1)
 
     def test_allows_below_the_threshold(self):
         ev = [c(T(1), ME), c(T(2), ME)]
-        self.assertEqual(self._with_fetch(ev, [], ["1", "--me", ME]), 0)
+        self.assertEqual(self._with_fetch(ev, [], ["1", "--me", ME, "--repo", REPO]), 0)
 
     def test_threshold_is_configurable(self):
         ev = [c(T(1), ME), c(T(2), ME)]
-        self.assertEqual(self._with_fetch(ev, [], ["1", "--me", ME, "--threshold", "2"]), 1)
+        self.assertEqual(self._with_fetch(ev, [], ["1", "--me", ME, "--threshold", "2", "--repo", REPO]), 1)
 
     def test_empty_thread_is_safe(self):
-        self.assertEqual(self._with_fetch([], [], ["1", "--me", ME]), 0)
+        self.assertEqual(self._with_fetch([], [], ["1", "--me", ME, "--repo", REPO]), 0)
 
     def test_every_verdict_names_the_repo_it_measured(self):
         """A bare `#1` cannot be told apart from the same number in another repo,
@@ -115,7 +116,7 @@ class TestMain(unittest.TestCase):
         import io
         from contextlib import redirect_stdout
         for argv, want in (
-                (["1", "--me", ME], g.DEFAULT_REPO),
+                (["https://github.com/url-form/repo/pull/1", "--me", ME], "url-form/repo"),
                 (["1", "--me", ME, "--repo", "other/repo"], "other/repo"),
         ):
             # All three verdict branches, including REFUSE — the branch the tool
@@ -131,11 +132,11 @@ class TestMain(unittest.TestCase):
         real = g.fetch
         g.fetch = lambda repo, number: (seen.append(repo), ([], []))[1]
         try:
-            g.main(["1", "--me", ME])
+            g.main(["https://github.com/url-form/repo/pull/1", "--me", ME])
             g.main(["1", "--me", ME, "--repo", "other/repo"])
         finally:
             g.fetch = real
-        self.assertEqual(seen, [g.DEFAULT_REPO, "other/repo"])
+        self.assertEqual(seen, ["url-form/repo", "other/repo"])
 
     def test_a_fetch_failure_is_cannot_answer_not_a_green_light(self):
         real = g.fetch
@@ -145,12 +146,12 @@ class TestMain(unittest.TestCase):
 
         g.fetch = boom
         try:
-            self.assertEqual(g.main(["1", "--me", ME]), 2)
+            self.assertEqual(g.main(["1", "--me", ME, "--repo", REPO]), 2)
         finally:
             g.fetch = real
 
     def test_a_nonsense_threshold_refuses_rather_than_guessing(self):
-        self.assertEqual(self._with_fetch([], [], ["1", "--me", ME, "--threshold", "0"]), 2)
+        self.assertEqual(self._with_fetch([], [], ["1", "--me", ME, "--threshold", "0", "--repo", REPO]), 2)
 
 
 class TestFetchLayer(unittest.TestCase):
@@ -211,7 +212,7 @@ class TestFetchLayer(unittest.TestCase):
         real = g.subprocess.run
         g.subprocess.run = run
         try:
-            self.assertEqual(g.main(["1", "--me", ME]), 2)
+            self.assertEqual(g.main(["1", "--me", ME, "--repo", REPO]), 2)
         finally:
             g.subprocess.run = real
 
@@ -270,6 +271,55 @@ class TestPagination(unittest.TestCase):
         full, _ = g.trailing_run(g.merge_events(ev, []), ME)
         truncated, _ = g.trailing_run(g.merge_events(ev[:100], []), ME)
         self.assertEqual((full, truncated), (3, 0))
+
+
+class RepoMustBeNamed(unittest.TestCase):
+    """A bare number plus a defaulted repo is the shape that cannot refuse.
+
+    Naming the assumption in the output was necessary but not sufficient: on
+    2026-09-10 a run omitted --repo, printed a 404 that contained the wrong repo,
+    and the post went out anyway. A reader who has the repo in front of him and
+    posts regardless is not helped by being shown it again, so the default is gone.
+    """
+
+    def test_a_bare_number_without_repo_cannot_answer(self):
+        self.assertEqual(g.main(["1", "--me", ME]), 2)
+
+    def test_the_refusal_says_what_to_pass(self):
+        import io
+        from contextlib import redirect_stderr
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            g.main(["1", "--me", ME])
+        err = buf.getvalue()
+        self.assertIn("--repo", err)
+        self.assertIn("URL", err)
+
+    def test_a_full_url_supplies_the_repo(self):
+        seen = []
+        real = g.fetch
+        g.fetch = lambda repo, number: (seen.append((repo, number)), ([], []))[1]
+        try:
+            g.main(["https://github.com/o/r/pull/42", "--me", ME])
+        finally:
+            g.fetch = real
+        self.assertEqual(seen, [("o/r", 42)])
+
+    def test_a_url_disagreeing_with_repo_refuses_rather_than_picking(self):
+        self.assertEqual(
+            g.main(["https://github.com/o/r/pull/1", "--me", ME, "--repo", "other/repo"]), 2)
+
+    def test_a_url_agreeing_with_repo_is_fine(self):
+        real = g.fetch
+        g.fetch = lambda repo, number: ([], [])
+        try:
+            rc = g.main(["https://github.com/o/r/pull/1", "--me", ME, "--repo", "o/r"])
+        finally:
+            g.fetch = real
+        self.assertEqual(rc, 0)
+
+    def test_a_non_number_non_url_cannot_answer(self):
+        self.assertEqual(g.main(["not-a-pr", "--me", ME, "--repo", REPO]), 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The gap this closes

`#4114` (merged, `3fad43eb`) made the defaulted repo **visible**: `--repo` became `default=None` and an omitted flag prints `assuming --repo sonichi/sutando (not given)`. That is a real improvement and I approved it.

It is not sufficient, and I have an occurrence rather than an argument. **Hours after that merged, I ran the gate without `--repo` on a `cinny-webclient` PR, read a 404 that contained the wrong repo, and posted the review anyway.** Being shown the repo a second time does not help a reader who already has it in front of him. `#4103` names the class; this removes it.

## Before / after — actual output, same command

```
$ python3 skills/proactive-loop/scripts/pr-monologue-check.py 956 --me yixuan-ag2

# origin/main (299e4e55)                                            rc=2
assuming --repo sonichi/sutando (not given)
CANNOT ANSWER: gh api failed for repos/sonichi/sutando/pulls/956/reviews?per_page=100: gh: Not Found (HTTP 404)

# this branch                                                       rc=2
CANNOT ANSWER: no --repo given, and a bare number could name a PR in any repo.
Pass --repo <owner/name>, or the full PR URL.
```

The `main` line is verbatim what I saw today. Both refuse — the difference is that one refuses *about the wrong repo* and reads like a network problem, while the other names what is missing.

And the ergonomic half, which is the point rather than a bonus:

```
$ python3 skills/proactive-loop/scripts/pr-monologue-check.py \
      https://github.com/ag2-space/cinny-webclient/pull/956 --me yixuan-ag2      rc=0
ag2-space/cinny-webclient#956: trailing run of yours = 1 (threshold 3) — safe to post
```

That is the answer I never got today. Pasting the URL you already have is **less** work than typing a bare number, so the safe path is also the shorter one — which is why this is not simply `required=True`.

## What changed

- No default repo. Either the positional is a full PR URL, or `--repo` is given. A bare number with neither is `rc 2 CANNOT ANSWER` naming both fixes.
- A URL that disagrees with an explicit `--repo` refuses rather than silently picking one.
- A positional that is neither a number nor a github.com PR URL refuses.
- `SKILL.md` step 9.5 updated, since it documented the bare form.

## Tests

27 → 33. The six new arms are in `RepoMustBeNamed`; the existing suite changed because several tests passed a bare number and relied on the default.

**Two of those were passing for the wrong reason and would have kept passing.** `--threshold 0` and the fetch-failure test both assert `rc == 2`; without `--repo` they now return 2 for the *missing repo* instead of the thing they name. I found them by scanning every argv list for a repo rather than by grepping the one literal I had already fixed — the first pass missed both because they carry a trailing flag.

Mutation, restoring the default and leaving everything else:

```
Ran 33 tests   FAILED (failures=2)   # mutant
    FAIL: test_a_bare_number_without_repo_cannot_answer
    FAIL: test_the_refusal_says_what_to_pass
Ran 33 tests   OK                    # restored
```

`scripts/review-checks.sh --diff` passes (it caught a 5-line comment block on the first run; narrative moved here, which is where it belongs).

## Scope

Not a live path — `skills/proactive-loop/` plus its test. No bridge, delivery loop or startup file is touched, so harness proof is the right standard here.

Closes #4103. Follow-up to #4114, as offered in [that thread](https://github.com/sonichi/sutando/pull/4114#issuecomment-5621316356); nobody claimed it, so I picked it up.
