### PR TITLE
feat(telemetry): track watchdog recovery attempts and outcomes

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -13,6 +13,12 @@ Only bucketed / categorical **product events**:
 | `core_started` | `interval_s` | Count active installs (OSS + desktop) |
 | `feature_used` | `feature` (snake_case, e.g. `morning_briefing`, `skill:<name>`) | Which features matter |
 | `task_processed` | `source` (`discord`/`telegram`/`slack`; more surfaces as wired) | Activation — whether installs process any tasks after launch, and via which surface |
+| `core_recovery_attempted` | `trigger` (`wedged` / `dead`) | Confirmed wedge or dead-core restart attempts |
+| `core_restart_result` | `trigger`, `outcome` (`started` / `failed` / `exception`), `duration_bucket` | Whether the restart command succeeded |
+| `core_recovery_result` | `trigger`, `outcome` (`progress_resumed` / `still_unhealthy`), `duration_bucket` | Evidence of progress after a successful restart |
+| `core_recovery_gave_up` | none | Restart cap reached; deduplicated for one hour even if owner notification fails |
+| `health_fix_started` | none | Health-check `--fix` passes with non-OK checks |
+| `health_fix_result` | `outcome` (`all_resolved` / `partially_resolved` / `unresolved`), `duration_bucket` | Status of those checks at the next health-check invocation |
 
 Skill adoption arrives through `feature_used` as `skill:<name>`, emitted by
 `hooks/skill-usage-telemetry.py` for every skill invoked **through the `Skill`
@@ -90,3 +96,41 @@ use the Privacy toggle in Settings.
 > for skills invoked **through the `Skill` tool**, and only where the hook is
 > registered — see the scoped contract above. Same anonymity and opt-out as any other
 > `feature_used`.
+
+## Recovery metrics
+
+These events cover `src/health-check.py` core wedge/dead-core recovery and `--fix` passes.
+They reuse the existing PostHog project, anonymous install identity, surface
+property, and live opt-out controls. No additional configuration is needed.
+They do not cover repairs performed directly by an agent or individual skills.
+
+In PostHog, use event counts and outcome breakdowns to measure:
+
+- Restart command success rate: `core_restart_result` with `outcome=started`
+  divided by all `core_restart_result` events.
+- Observed recovery rate: `core_recovery_result` with `outcome=progress_resumed`
+  divided by all `core_recovery_result` events.
+- Recovery causes: `core_recovery_attempted` broken down by `trigger`.
+- Manual intervention signals: counts of `core_recovery_gave_up`.
+- Fix-pass effectiveness: `health_fix_result` broken down by `outcome`.
+
+Duration buckets are `<1m`, `1-5m`, `5-30m`, and `>=30m`. Recovery duration is
+from restart initiation to observed progress or a confirmed recurring wedge;
+fix duration is from a fix pass to its next health check. These are observation
+latencies, not exact downtime. Progress means the core is alive and its oldest
+queued task changes/disappears or its status timestamp advances. A successful
+restart command alone is never counted as recovered. Attempts without a later
+observation remain pending and are excluded from the observed recovery rate.
+
+Fix results describe the original non-OK checks (including warnings), some of
+which require manual repair. Missing checks count as unresolved. This is a
+before/after signal, not proof that a particular repair caused recovery.
+Healthy polling, confirmation windows, and cooldowns emit no attempt events.
+Check names, task identities, timestamps and check details are never sent.
+
+Recovery sends use the existing bounded synchronous path (one-second network
+timeout per event), so short-lived watchdog processes can deliver their events.
+Failures are swallowed and opt-out is checked for every event. Delivery is best
+effort, with no durable event queue or exactly-once guarantee. A PostHog outage
+can cause missing events; overlapping health-check invocations can race on the
+fix-pass observation file. Core recovery retains its existing exclusive lock.

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -14,7 +14,7 @@ Only bucketed / categorical **product events**:
 | `feature_used` | `feature` (snake_case, e.g. `morning_briefing`, `skill:<name>`) | Which features matter |
 | `task_processed` | `source` (`discord`/`telegram`/`slack`; more surfaces as wired) | Activation — whether installs process any tasks after launch, and via which surface |
 | `core_recovery_attempted` | `trigger` (`wedged` / `dead`) | Confirmed wedge or dead-core restart attempts |
-| `core_restart_result` | `trigger`, `outcome` (`started` / `failed` / `exception`), `duration_bucket` | Whether the restart command succeeded |
+| `core_restart_result` | `trigger`, `outcome` (`started` / `failed` / `exception`) | Whether the restart command succeeded |
 | `core_recovery_result` | `trigger`, `outcome` (`progress_resumed` / `still_unhealthy`), `duration_bucket` | Evidence of progress after a successful restart |
 | `core_recovery_gave_up` | none | Restart cap reached; deduplicated for one hour even if owner notification fails |
 | `health_fix_started` | none | Health-check `--fix` passes with non-OK checks |
@@ -121,6 +121,10 @@ latencies, not exact downtime. Progress means the core is alive and its oldest
 queued task changes/disappears or its status timestamp advances. A successful
 restart command alone is never counted as recovered. Attempts without a later
 observation remain pending and are excluded from the observed recovery rate.
+That rate is conditional on an observation existing: it can look healthier than
+reality when severe failures prevent later observations. Show attempted restarts
+and observed results alongside the rate. `core_restart_result` reports only the
+command outcome; it has no duration field.
 
 Fix results describe the original non-OK checks (including warnings), some of
 which require manual repair. Missing checks count as unresolved. This is a
@@ -132,5 +136,15 @@ Recovery sends use the existing bounded synchronous path (one-second network
 timeout per event), so short-lived watchdog processes can deliver their events.
 Failures are swallowed and opt-out is checked for every event. Delivery is best
 effort, with no durable event queue or exactly-once guarantee. A PostHog outage
-can cause missing events; overlapping health-check invocations can race on the
-fix-pass observation file. Core recovery retains its existing exclusive lock.
+can cause missing events. The synchronous attempt event can delay a restart by
+about one network-timeout interval when the endpoint is unreachable; additional
+events add their own send latency. This trades watchdog latency for delivery
+before a short-lived process exits; the network timeout is not an end-to-end
+deadline (for example, DNS resolution can take longer).
+
+Fix-pass state uses a nonblocking exclusive lock and atomic replacement. A
+competing writer skips tracking rather than overwriting an outstanding pass;
+a corrupt record is discarded so the next pass can be tracked. Platforms without
+file locking skip fix-pass metrics. Concurrent watchdogs can still observe a
+pass before all its repairs finish, so this remains a health snapshot, not a
+serialized repair transaction. Core recovery retains its existing exclusive lock.

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -13183,30 +13183,58 @@ def _recovery_metric(event: str, **properties) -> None:
 
 
 def _recovery_duration(seconds: float) -> str:
-    return "<1m" if seconds < 60 else "1-5m" if seconds < 300 else "5-30m" if seconds < 1800 else ">=30m"
+    for threshold, bucket in ((60, "<1m"), (300, "1-5m"), (1800, "5-30m")):
+        if seconds < threshold:
+            return bucket
+    return ">=30m"
 
 
 def track_health_fix(checks: list, *, start: bool = False, state_file=None, now=None) -> None:
-    """Observe non-OK checks after a fix pass; check names stay local."""
+    """Observe fix health; names are local correlation data, never telemetry properties."""
     try:
+        if fcntl is None:
+            return
         state_file = state_file or WORKSPACE_DIR / "state" / "health-fix-metrics.json"
         now = time.time() if now is None else now
-        if start:
-            names = [c["name"] for c in checks if c["status"] != "ok"]
-            if not names:
-                return
-            state_file.parent.mkdir(parents=True, exist_ok=True)
-            state_file.write_text(json.dumps({"started": now, "checks": names}))
-            _recovery_metric("health_fix_started")
-        elif state_file.exists():
-            pending = json.loads(state_file.read_text())
-            statuses = {c["name"]: c["status"] for c in checks}
-            names = pending["checks"]
-            resolved = sum(statuses.get(name) == "ok" for name in names)
-            outcome = "all_resolved" if resolved == len(names) else "partially_resolved" if resolved else "unresolved"
-            state_file.unlink()
-            _recovery_metric("health_fix_result", outcome=outcome,
-                             duration_bucket=_recovery_duration(now - pending["started"]))
+        state_file.parent.mkdir(parents=True, exist_ok=True)
+        with open(state_file.with_name(state_file.name + ".lock"), "a") as lock:
+            fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            pending = None
+            if state_file.exists():
+                try:
+                    pending = json.loads(state_file.read_text())
+                    if not (isinstance(pending, dict)
+                            and isinstance(pending.get("started"), (int, float))
+                            and isinstance(pending.get("checks"), list)
+                            and pending["checks"]
+                            and all(isinstance(name, str) for name in pending["checks"])):
+                        raise ValueError("invalid fix observation")
+                except (ValueError, TypeError):
+                    state_file.unlink()
+                    pending = None
+            if start:
+                names = [c["name"] for c in checks if c["status"] != "ok"]
+                if not names or pending is not None:
+                    return
+                tmp = None
+                try:
+                    with tempfile.NamedTemporaryFile(mode="w", dir=state_file.parent,
+                                                     prefix=".health-fix-", delete=False) as out:
+                        tmp = Path(out.name)
+                        json.dump({"started": now, "checks": names}, out)
+                    os.replace(tmp, state_file)
+                finally:
+                    if tmp is not None:
+                        tmp.unlink(missing_ok=True)
+                _recovery_metric("health_fix_started")
+            elif pending is not None:
+                statuses = {c["name"]: c["status"] for c in checks}
+                names = pending["checks"]
+                resolved = sum(statuses.get(name) == "ok" for name in names)
+                outcome = "all_resolved" if resolved == len(names) else "partially_resolved" if resolved else "unresolved"
+                state_file.unlink()
+                _recovery_metric("health_fix_result", outcome=outcome,
+                                 duration_bucket=_recovery_duration(now - pending["started"]))
     except Exception:
         pass
 
@@ -13431,15 +13459,13 @@ def recover_core_if_wedged(
             print("[recover-core] WARNING: wedge-restart DM failed; restarting anyway", flush=True)
 
         _recovery_metric("core_recovery_attempted", trigger=cur_mode)
-        restart_started = time.monotonic()
         try:
             restart_ok = restart_fn()
         except Exception:
-            _recovery_metric("core_restart_result", outcome="exception", trigger=cur_mode,
-                             duration_bucket=_recovery_duration(time.monotonic() - restart_started))
+            _recovery_metric("core_restart_result", outcome="exception", trigger=cur_mode)
             raise
         _recovery_metric("core_restart_result", outcome="started" if restart_ok else "failed",
-                         trigger=cur_mode, duration_bucket=_recovery_duration(time.monotonic() - restart_started))
+                         trigger=cur_mode)
         if not restart_ok:
             # Restart launch failed — don't burn a cooldown/history slot, and
             # keep the observation so we stay confirmed and retry next pass.

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -13173,6 +13173,44 @@ def _default_core_restart() -> bool:
         return False
 
 
+def _recovery_metric(event: str, **properties) -> None:
+    """Flush categorical events before watchdog exit; telemetry cannot break repairs."""
+    try:
+        from telemetry import capture
+        capture(event, properties, flush=True)
+    except Exception:
+        pass
+
+
+def _recovery_duration(seconds: float) -> str:
+    return "<1m" if seconds < 60 else "1-5m" if seconds < 300 else "5-30m" if seconds < 1800 else ">=30m"
+
+
+def track_health_fix(checks: list, *, start: bool = False, state_file=None, now=None) -> None:
+    """Observe non-OK checks after a fix pass; check names stay local."""
+    try:
+        state_file = state_file or WORKSPACE_DIR / "state" / "health-fix-metrics.json"
+        now = time.time() if now is None else now
+        if start:
+            names = [c["name"] for c in checks if c["status"] != "ok"]
+            if not names:
+                return
+            state_file.parent.mkdir(parents=True, exist_ok=True)
+            state_file.write_text(json.dumps({"started": now, "checks": names}))
+            _recovery_metric("health_fix_started")
+        elif state_file.exists():
+            pending = json.loads(state_file.read_text())
+            statuses = {c["name"]: c["status"] for c in checks}
+            names = pending["checks"]
+            resolved = sum(statuses.get(name) == "ok" for name in names)
+            outcome = "all_resolved" if resolved == len(names) else "partially_resolved" if resolved else "unresolved"
+            state_file.unlink()
+            _recovery_metric("health_fix_result", outcome=outcome,
+                             duration_bucket=_recovery_duration(now - pending["started"]))
+    except Exception:
+        pass
+
+
 def recover_core_if_wedged(
     state_file: Optional[Path] = None,
     now: Optional[float] = None,
@@ -13269,6 +13307,20 @@ def recover_core_if_wedged(
                   f"UNKNOWN, not dead; suppressing restart and RESETTING the "
                   f"confirmation window", file=sys.stderr)
             return {"action": "probe-failed", "probe": which}
+        pending = state.get("recovery_metric_pending")
+        if pending and alive and (
+            oldest is None or cur_key != pending["task"] or (
+                isinstance(status_ts, (int, float))
+                and isinstance(pending.get("status_ts"), (int, float))
+                and status_ts > pending["status_ts"]
+            )
+        ):
+            state.pop("recovery_metric_pending", None)
+            _save()
+            _recovery_metric("core_recovery_result", outcome="progress_resumed",
+                             trigger=pending["trigger"],
+                             duration_bucket=_recovery_duration(now - pending["started"]))
+
         wedged = (
             alive
             and oldest is not None
@@ -13319,9 +13371,22 @@ def recover_core_if_wedged(
         if last_restart and now - last_restart < RECOVER_COOLDOWN_SEC:
             return {"action": "cooldown", "oldest_age": oldest_age, "since_restart": int(now - last_restart)}
 
+        pending = state.pop("recovery_metric_pending", None)
+        if pending:
+            _save()
+            _recovery_metric("core_recovery_result", outcome="still_unhealthy",
+                             trigger=pending["trigger"],
+                             duration_bucket=_recovery_duration(now - pending["started"]))
+
         # Give-up cap: prune restart history to the trailing hour.
         history = [t for t in (state.get("restart_history") or []) if isinstance(t, (int, float)) and now - t < 3600]
         if len(history) >= RECOVER_MAX_PER_HOUR:
+            # Independent of notification success: a Slack outage must not
+            # emit a fresh give-up event on every watchdog tick.
+            if not state.get("recovery_metric_gave_up") or now - state["recovery_metric_gave_up"] > 3600:
+                state["recovery_metric_gave_up"] = now
+                _save()
+                _recovery_metric("core_recovery_gave_up")
             # DM once per give-up episode. Record gave_up_at only on a SUCCESSFUL
             # send so a Slack outage doesn't silence the give-up alert for an hour.
             if not state.get("gave_up_at") or now - state["gave_up_at"] > 3600:
@@ -13365,11 +13430,25 @@ def recover_core_if_wedged(
         if not dm_ok:
             print("[recover-core] WARNING: wedge-restart DM failed; restarting anyway", flush=True)
 
-        if not restart_fn():
+        _recovery_metric("core_recovery_attempted", trigger=cur_mode)
+        restart_started = time.monotonic()
+        try:
+            restart_ok = restart_fn()
+        except Exception:
+            _recovery_metric("core_restart_result", outcome="exception", trigger=cur_mode,
+                             duration_bucket=_recovery_duration(time.monotonic() - restart_started))
+            raise
+        _recovery_metric("core_restart_result", outcome="started" if restart_ok else "failed",
+                         trigger=cur_mode, duration_bucket=_recovery_duration(time.monotonic() - restart_started))
+        if not restart_ok:
             # Restart launch failed — don't burn a cooldown/history slot, and
             # keep the observation so we stay confirmed and retry next pass.
             return {"action": "restart_failed", "dm_sent": dm_ok}
 
+        state["recovery_metric_pending"] = {
+            "started": now, "task": cur_key, "status_ts": status_ts, "trigger": cur_mode,
+        }
+        state.pop("recovery_metric_gave_up", None)
         history.append(now)
         state["restart_history"] = history
         state["last_restart"] = now
@@ -13769,6 +13848,9 @@ def main():
     quiet = "--quiet" in sys.argv or "-q" in sys.argv
 
     checks = run_all_checks()
+    track_health_fix(checks)
+    if do_fix:
+        track_health_fix(checks, start=True)
     issues = [c for c in checks if is_issue(c)]
     codex_notifier = (
         next(

--- a/tests/health-check-fix-down-bridges.test.py
+++ b/tests/health-check-fix-down-bridges.test.py
@@ -49,6 +49,8 @@ REPO = Path(__file__).resolve().parent.parent
 spec = importlib.util.spec_from_file_location("health_check", REPO / "src" / "health-check.py")
 hc = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(hc)
+# Keep fix-run metrics isolated from real workspace state and analytics.
+hc.track_health_fix = lambda *args, **kwargs: None
 
 
 def check(name: str, status: str, detail: str) -> dict:

--- a/tests/health-check-recover-core.test.py
+++ b/tests/health-check-recover-core.test.py
@@ -13,6 +13,8 @@ REPO = Path(__file__).resolve().parent.parent
 spec = importlib.util.spec_from_file_location("health_check", REPO / "src" / "health-check.py")
 hc = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(hc)
+# Recovery tests must never send production analytics.
+hc._recovery_metric = lambda *args, **kwargs: None
 
 # Pin thresholds so the test is independent of any SUTANDO_RECOVER_* env override
 # present in the runner's environment.

--- a/tests/health-check-recovery-telemetry.test.py
+++ b/tests/health-check-recovery-telemetry.test.py
@@ -96,6 +96,64 @@ class RecoveryMetrics(unittest.TestCase):
         self.assertNotIn('private-plugin-name', json.dumps(self.events))
         self.assertNotIn('secret', json.dumps(self.events))
 
+    def test_restart_exception_is_reported_and_propagated(self):
+        self.run_core(10000)
+        with self.assertRaisesRegex(RuntimeError, 'restart exploded'):
+            hc.recover_core_if_wedged(
+                state_file=self.state, now=10121, alive_fn=lambda: True,
+                oldest_task_fn=lambda: ('private-task-path', 900),
+                status_ts_fn=lambda: 10, just_booted_fn=lambda: False,
+                stopped_fn=lambda: False, sender=lambda _: True,
+                restart_fn=lambda: (_ for _ in ()).throw(RuntimeError('restart exploded')))
+        self.assertEqual(self.events[-1], ('core_restart_result', {
+            'outcome': 'exception', 'trigger': 'wedged'}))
+        self.assertNotIn('recovery_metric_pending', json.loads(self.state.read_text()))
+
+    def test_corrupt_fix_record_is_discarded_and_tracking_resumes(self):
+        checks = [{'name': 'private-name', 'status': 'down'}]
+        for corrupt in ('{not json', 'null', '{"started": 1, "checks": []}',
+                        '{"started": 1, "checks": [42]}'):
+            with self.subTest(corrupt=corrupt):
+                self.state.write_text(corrupt)
+                hc.track_health_fix(checks, state_file=self.state, now=1)
+                self.assertFalse(self.state.exists())
+                hc.track_health_fix(checks, start=True, state_file=self.state, now=10)
+                hc.track_health_fix([], state_file=self.state, now=2000)
+                self.assertEqual(self.events[-1][1], {
+                    'outcome': 'unresolved', 'duration_bucket': '>=30m'})
+
+    def test_atomic_failure_does_not_publish_partial_state(self):
+        checks = [{'name': 'private-name', 'status': 'down'}]
+        with patch.object(hc.os, 'replace', side_effect=OSError('disk error')):
+            hc.track_health_fix(checks, start=True, state_file=self.state, now=1)
+        self.assertFalse(self.state.exists())
+        self.assertEqual(list(self.state.parent.glob('.health-fix-*')), [])
+        self.assertEqual(self.events, [])
+        hc.track_health_fix(checks, start=True, state_file=self.state, now=2)
+        self.assertTrue(self.state.exists())
+
+    def test_concurrent_starts_and_observers_emit_once(self):
+        from concurrent.futures import ThreadPoolExecutor
+        checks = [{'name': 'private-name', 'status': 'down'}]
+        def start(_):
+            hc.track_health_fix(checks, start=True, state_file=self.state, now=1)
+        def observe(_):
+            hc.track_health_fix([{'name': 'private-name', 'status': 'ok'}],
+                                state_file=self.state, now=400)
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            list(pool.map(start, range(16)))
+            list(pool.map(observe, range(16)))
+        self.assertEqual(self.events, [('health_fix_started', {}), ('health_fix_result', {
+            'outcome': 'all_resolved', 'duration_bucket': '5-30m'})])
+
+    def test_fix_tracking_skips_healthy_or_unsupported_hosts(self):
+        hc.track_health_fix([], start=True, state_file=self.state)
+        with patch.object(hc, 'fcntl', None):
+            hc.track_health_fix([{'name': 'a', 'status': 'down'}], start=True,
+                                state_file=self.state)
+        self.assertFalse(self.state.exists())
+        self.assertEqual(self.events, [])
+
     def test_telemetry_failure_cannot_break_recovery(self):
         self.mock.stop()
         import telemetry

--- a/tests/health-check-recovery-telemetry.test.py
+++ b/tests/health-check-recovery-telemetry.test.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Offline recovery lifecycle and privacy regression tests."""
+import importlib.util
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+os.environ['DO_NOT_TRACK'] = '1'
+ROOT = Path(__file__).resolve().parent.parent
+spec = importlib.util.spec_from_file_location('health_check', ROOT / 'src/health-check.py')
+hc = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hc)
+
+
+class RecoveryMetrics(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.state = Path(self.tmp.name) / 'recovery.json'
+        self.events = []
+        self.mock = patch.object(hc, '_recovery_metric', side_effect=lambda event, **props: self.events.append((event, props)))
+        self.mock.start()
+        self.addCleanup(self.mock.stop)
+        for name, value in [('RECOVER_WEDGE_SEC', 600), ('RECOVER_CONFIRM_SEC', 120),
+                            ('RECOVER_COOLDOWN_SEC', 1800), ('RECOVER_MAX_PER_HOUR', 3)]:
+            p = patch.object(hc, name, value)
+            p.start()
+            self.addCleanup(p.stop)
+
+    def run_core(self, now, key='private-task-path', age=900, alive=True, status_ts=10, restart=True):
+        return hc.recover_core_if_wedged(
+            state_file=self.state, now=now, alive_fn=lambda: alive,
+            oldest_task_fn=lambda: (key, age) if key else None,
+            status_ts_fn=lambda: status_ts, just_booted_fn=lambda: False,
+            restart_fn=lambda: restart, stopped_fn=lambda: False, sender=lambda _: False)
+
+    def restart(self):
+        self.run_core(10000)
+        self.assertEqual(self.run_core(10121)['action'], 'restarted')
+
+    def test_restart_is_not_recovery_and_progress_emits_once(self):
+        self.restart()
+        self.assertEqual([e[0] for e in self.events], ['core_recovery_attempted', 'core_restart_result'])
+        self.run_core(10130, alive=False)
+        self.assertEqual(len(self.events), 2)
+        self.run_core(10140, status_ts=11)
+        self.run_core(10150, status_ts=12)
+        self.assertEqual(self.events[-1], ('core_recovery_result', {
+            'outcome': 'progress_resumed', 'trigger': 'wedged', 'duration_bucket': '<1m'}))
+        self.assertEqual(len(self.events), 3)
+        self.assertNotIn('private-task-path', json.dumps(self.events))
+
+    def test_dead_core_trigger_and_unknown_probe(self):
+        self.run_core(10000, alive=False, key=None)
+        self.run_core(10121, alive=False, key=None)
+        self.assertEqual(self.events[0], ('core_recovery_attempted', {'trigger': 'dead'}))
+        self.run_core(10130, alive=None, key=None)
+        self.assertEqual(len(self.events), 2)
+        self.run_core(10140, alive=True, key=None)
+        self.assertEqual(self.events[-1][1]['outcome'], 'progress_resumed')
+
+    def test_failed_restart_and_no_guard_events(self):
+        self.run_core(10000)
+        self.run_core(10001)
+        self.assertEqual(self.events, [])
+        self.assertEqual(self.run_core(10121, restart=False)['action'], 'restart_failed')
+        self.assertEqual(self.events[-1][1]['outcome'], 'failed')
+        self.assertNotIn('recovery_metric_pending', json.loads(self.state.read_text()))
+
+    def test_recurrence_without_false_success(self):
+        self.restart()
+        self.run_core(12000)
+        self.run_core(12121)
+        self.assertEqual(self.events[2][1]['outcome'], 'still_unhealthy')
+        self.assertEqual(self.events[3], ('core_recovery_attempted', {'trigger': 'wedged'}))
+
+    def test_give_up_dedup_even_when_notification_fails(self):
+        self.state.write_text(json.dumps({'wedge_first_seen': 9000, 'wedge_task': 'private-task-path',
+                                         'wedge_status_ts': 10, 'wedge_mode': 'wedged', 'restart_history': [9900, 9910, 9920]}))
+        self.run_core(10000)
+        self.run_core(10030)
+        self.assertEqual(self.events, [('core_recovery_gave_up', {})])
+
+    def test_health_fix_observed_next_tick_and_only_once(self):
+        checks = [{'name': 'private-plugin-name', 'status': 'down', 'detail': 'secret'},
+                  {'name': 'voice-agent', 'status': 'down'}]
+        hc.track_health_fix(checks, start=True, state_file=self.state, now=10)
+        checks[0]['status'] = 'ok'
+        hc.track_health_fix(checks, state_file=self.state, now=100)
+        hc.track_health_fix(checks, state_file=self.state, now=110)
+        self.assertEqual(self.events, [('health_fix_started', {}), ('health_fix_result', {
+            'outcome': 'partially_resolved', 'duration_bucket': '1-5m'})])
+        self.assertNotIn('private-plugin-name', json.dumps(self.events))
+        self.assertNotIn('secret', json.dumps(self.events))
+
+    def test_telemetry_failure_cannot_break_recovery(self):
+        self.mock.stop()
+        import telemetry
+        with patch.object(telemetry, 'capture', side_effect=RuntimeError('offline')):
+            self.restart()
+
+    def test_opt_out_and_short_lived_delivery(self):
+        self.mock.stop()
+        import telemetry
+        with patch.object(telemetry, '_dispatch') as dispatch:
+            hc._recovery_metric('core_recovery_attempted', trigger='wedged')
+            dispatch.assert_not_called()
+        with patch.object(telemetry, 'capture') as capture:
+            hc._recovery_metric('core_recovery_attempted', trigger='wedged')
+            capture.assert_called_once_with('core_recovery_attempted', {'trigger': 'wedged'}, flush=True)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Sutando's watchdog repairs wedged or dead cores, but those attempts and their outcomes were invisible in PostHog. This adds anonymous events for attempted restarts, restart command outcomes, subsequently observed recovery, restart-cap give-ups, and health-check fix-pass results. A successful restart command is separate from evidence that the core resumed progress.

Review `src/health-check.py` first, then the event contract and rate formulas in `TELEMETRY.md`, and `tests/health-check-recovery-telemetry.test.py`. The existing PostHog sender, installation identity, surface tagging, and live opt-outs are reused. Payloads contain categorical trigger/outcome fields and duration buckets, never task identities, check details, or error text.

Based on current main, `299e4e55`. Recovery triggers are `wedged` and `dead`; this preserves main's configured-model restart policy and its unknown-probe/deliberate-stop guards. No context-window escalation is introduced. This is independent of #2148, which tracks model and token usage.

### Evidence and validation

A deterministic probe loaded the parent and changed health-check modules, intercepted `telemetry.capture`, and injected the same sequence: confirmed wedge, successful restart command, then an empty queue with a live core. Actual output:

```text
BEFORE: []
AFTER: ["core_recovery_attempted", "core_restart_result", "core_recovery_result"]
```

Targeted checks on the rebased branch:

```text
DO_NOT_TRACK=1 python3 tests/health-check-recovery-telemetry.test.py
Ran 13 tests in 0.017s
OK

DO_NOT_TRACK=1 python3 tests/health-check-recover-core.test.py
All core-recovery invariants hold.

DO_NOT_TRACK=1 python3 tests/health-check-fix-down-bridges.test.py
All fix_down_bridges tests passed.

DO_NOT_TRACK=1 python3 tests/health-check-fix-launchd-label.test.py
all passed

python3 tests/telemetry.test.py
ALL PASS (24 checks)

bash scripts/review-checks.sh --diff <(git diff origin/main...HEAD)
prose-cap: PASS (comment blocks within cap 2, exts .py)
review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
```

The new tests also verify corrupt-state recovery, concurrent starts/observers, atomic publication failure, and restart exceptions preserving propagation. They exercise failed restarts, recurring wedges, dead-core recovery, unknown probes, give-up deduplication despite notification failure, next-tick fix observations, telemetry failure isolation, payload privacy, opt-out, and bounded synchronous delivery. Existing recovery tests retain the destructive-action guard coverage. The automated tests use injected restart/notification functions. The separate live run below exercised a real isolated core restart; it did not restart the desktop core or send production analytics.

### Limits and deployment

Scoped live restart-boundary evidence at the current head is now posted: https://github.com/sonichi/sutando/pull/4135#issuecomment-5625544053. The production watchdog restarted a real isolated Codex core, a real task executed after restart, and a later watchdog process resolved persisted telemetry via actual HTTP sends to a local sink. The task was explicitly submitted after restart; unattended wake-up and Claude hook activity were not validated. Reviewer acceptance of that scope remains outstanding. No PostHog dashboard has been created.

Delivery is best effort; each event uses the existing one-second network timeout. The synchronous attempt event can delay restart by roughly one timeout interval when the endpoint is unreachable; other events add send latency, and this is not an end-to-end deadline. Recovery durations are observation latency buckets, not exact downtime. Attempts without a later observation remain pending, so the observed recovery rate is conditional and can overstate reliability if severe failures prevent observations. Fix-pass outcomes include warnings and checks without automatic remedies, so they describe before/after health rather than causal per-repair success. Fix-pass state now uses a nonblocking lock and atomic replacement, discards corrupt records, and preserves outstanding observations against competing starts. Concurrent watchdogs may still observe a pass before repairs finish; this is a health snapshot, not a serialized repair transaction. Core recovery retains its exclusive lock.

No dependency, configuration, permission, or migration changes. Additional state is stored under the existing workspace state directory; rollback removes instrumentation and older code ignores the new fields. Feature documentation is updated in the canonical telemetry contract, TELEMETRY.md; docs/catalog.json has no telemetry entry, and navigation is unchanged. Bug-fix reproduction: N/A, owner-requested instrumentation feature. TypeScript compilation and voice/audio manual evidence: N/A, no TypeScript or voice/audio behavior changes.




### Review follow-up validation (43b5fb97)

The four health-check suites above were rerun under coverage.py. With their combined coverage:

```text
diff-cover /tmp/sutando-recovery-coverage.xml --compare-branch=origin/main --fail-under=95
src/health-check.py (97.3%): Missing lines 13310-13311
Total:   75 lines
Missing: 2 lines
Coverage: 97%
```

`core_restart_result` now carries only trigger and outcome; duration buckets remain on the two observation events. The privacy comment and conditional-rate/latency tradeoffs are explicit in TELEMETRY.md.

