### PR TITLE
fix(gateway): an owner-released review posts its text, not its raw markers

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -912,10 +912,21 @@ def _match_review_decision(task: dict) -> "tuple[Path, dict, str] | None":
     return (*candidates[0], answer) if len(candidates) == 1 else None
 
 
+def _released_review_body(raw: str) -> str:
+    """Room text for an owner-released result. Markers are stripped, never executed:
+    the release posts to the original room only and uploads nothing."""
+    parsed = parse_markers(raw)
+    dropped = sum(1 for action in parsed.actions if action.kind == "attach")
+    if not dropped:
+        return parsed.body
+    note = f"({dropped} attachment{'' if dropped == 1 else 's'} not published)"
+    return f"{parsed.body}\n\n{note}" if parsed.body else note
+
+
 def _publish_review(path: Path, record: dict) -> bool:
     context = record.get("context") or {}
     room = str(context.get("channel_id") or "")
-    body = str(record.get("withheld_body") or "")
+    body = _released_review_body(str(record.get("withheld_body") or ""))
     if not room.startswith("!") or not body:
         record.update({"status": "publish_failed", "publish_error": "invalid origin/body",
                        "card_resolution_pending": True})

--- a/tests/withheld-review-dm.test.py
+++ b/tests/withheld-review-dm.test.py
@@ -263,6 +263,47 @@ with tempfile.TemporaryDirectory() as td:
           and (retry_path.parent / "archive" / retry_path.name).is_file(),
           "the retry loop must resolve and archive the kept-private review")
 
+    local_path = "/Users/owner/Library/Application Support/app/workspace/data/images/pic.png"
+    marked_body = (
+        "[channel: !elsewhere:ag2.space]\n"
+        "Here is the picture.\n\n"
+        f"[file: {local_path}]\n\n"
+        "A marker shown in code stays: `[file: /tmp/example.png]`")
+    guard.materialize_withheld_verdict(
+        leak, marked_body, bridge._STATE, "task-markers", context,
+        "@agent:ag2.space", now=1003)
+    marked_path = guard.withheld_review_path(bridge._STATE, "task-markers")
+    bridge._route_withheld_review(marked_path)
+    marked_record = json.loads(marked_path.read_text())
+    marked_dm = [p for _m, u, p in calls
+                 if u == "/v1/room" and p.get("room_id") == "!owner-dm:ag2.space"
+                 and marked_record["review_id"] in (p.get("body") or "")]
+    check(any(local_path in p["body"] for p in marked_dm),
+          "the owner's private review still shows the raw candidate, path included")
+    calls_before = len(calls)
+    check(bridge._handle_review_decision({
+        **no_task, "id": "decision-markers", "task": f"No {marked_record['review_id']}"}),
+        "an owner No on a marker-bearing result must be consumed")
+    marked_archive = marked_path.parent / "archive" / marked_path.name
+    check(json.loads(marked_archive.read_text())["status"] == "published",
+          "a marker-bearing result still publishes")
+    new_calls = calls[calls_before:]
+    shared_posts = [p for _m, u, p in new_calls
+                    if u == "/v1/room" and p.get("op") == "message"
+                    and p.get("room_id") == "!shared:ag2.space"]
+    check(len(shared_posts) == 1, "exactly one post to the original room")
+    released = shared_posts[0]["body"]
+    check(local_path not in released and "[file:" not in released.split("`")[0]
+          and "[channel:" not in released,
+          "released text carries no local path and no unparsed control marker")
+    check(released.startswith("Here is the picture.")
+          and "`[file: /tmp/example.png]`" in released
+          and "(1 attachment not published)" in released,
+          "prose and shown-in-code markers survive; the dropped file is noted without its path")
+    check(not any(p and p.get("room_id") == "!elsewhere:ag2.space" for _m, _u, p in new_calls)
+          and not any("/media" in u for _m, u, _p in new_calls),
+          "a release never executes a redirect or uploads a file")
+
     bridge._tier_for = lambda *_args: "team"
     check(not bridge._handle_review_decision({**yes_task, "id": "team-forgery"}),
           "a collaborator cannot release a pending review")


### PR DESCRIPTION
## Priority

**Level:** high
**Reason:** privacy fix. Releasing a withheld result printed the owner's absolute local file path into a shared AG2 Space room.

## Closes

No issue filed. Found while investigating an AG2 Space Signal Room incident on 2026-09-10.

## Summary

When the Team result guard withholds a result, the owner reviews it in a private DM. Answering **No** (false positive) calls `_publish_review`, which posted `withheld_body` verbatim to the original room. That body is raw core output. The normal result path runs it through `parse_markers` first, but the release path did not, so control markers reached the room as literal text.

In the incident, a `[file: /Users/<owner>/Library/Application Support/space.ag2.app/workspace/data/images/….png]` line was posted to a room with a dozen members. The guard had withheld the result because the attach path was outside the task's results directory. The owner judged the text harmless and answered No, and the path went out with it.

The fix adds `_released_review_body`, which passes the withheld body through `parse_markers`, the single marker-grammar owner, and posts its body. No marker action runs on release:

- **Redirect:** a leading `[channel: …]` never moves the post out of the original room.
- **Attach:** a `[file:]` marker never uploads. A path-free note such as `(1 attachment not published)` replaces it, so the room isn't left with prose that promises a missing picture.
- **Shown in code:** a marker inside a code span stays visible, per `parse_markers`' existing contract.

The owner's private review DM is unchanged. It still shows the raw candidate, path included, because the owner needs it to decide. A body without markers publishes unchanged, so the existing "exact body" assertion still holds.

## Checklist

- [x] Confirmed no other open PR closes the same issue. No open PR edits `_publish_review` or `withheld_body`.
- [x] Git author email matches my CLA-signed email (`yixuan@ag2.ai`).
- [x] Single concern per PR.
- [x] Confirmed bug exists on `upstream/main`. The new test fails at the parent commit, `79e53e090`.
- [x] Test added.
- [x] Before/after evidence pasted below.
- [x] Every claim in this PR body is verifiable from the diff or the pasted output.
- [ ] **Live path:** not done. See "Not verified" below.
- [x] Stacked PR: N/A.
- [x] Scanned added lines for host-specific hardcoded paths. The only `/Users/` string is a fictional fixture path (`/Users/owner/…`) inside the test. `lint-sutando-home-path --diff` is clean.
- [x] CI workflow edits: N/A.
- [x] Workspace/home-path resolution: N/A, no path resolution added.

## Before / after evidence

The new test case, run against the parent commit's bridge:

```
$ python3 tests/withheld-review-dm.test.py
    raise AssertionError(message)
AssertionError: released text carries no local path and no unparsed control marker
```

At HEAD:

```
$ python3 tests/withheld-review-dm.test.py
PASS: withheld results route privately; Yes keeps private and No publishes once.
```

The real withheld body from the incident, replayed through `_released_review_body`:

```
raw: home paths = 1 | [file: markers = 1
released: home paths = 0 | [file: markers = 0 | len 3694 -> 3614
```

## Test plan

- `tests/withheld-review-dm.test.py` gains a release of a body carrying a leading `[channel:]` redirect, a `[file:]` marker with a local path, and a marker shown in code. It asserts one post to the original room with no path and no unparsed marker, the code-span marker kept, the path-free note present, and no redirect post or `/media` upload.
- The 15 out-of-tree suites from `ci.yml` pass, including `tools/test_no_drift.py`, except the one noted below.
- The 99 `tests/*.test.py` suites that import the bridge, `result_markers`, or the result guard pass, except the same one.
- `ruff==0.15.22` passes on both changed files. `lint-hermetic-bridge-tests.py` and `lint-sutando-home-path.sh --diff` are clean.

**The one failure:** the `env-fallback: no env token and no file yields empty token` check in `src/remote-gateway-bridge.test.py` and its `tests/` delegator. It fails identically on unmodified `main` on my machine, because the token resolver falls back to the local keychain vault, which holds a gateway token here. It is unrelated to this change and should pass on a runner with no vault.

## Not verified

- **No live post-restart round trip.** A live check means getting a real Team result withheld, answering No, and watching the post land in a shared room. That's an outward post into a room other people are in, so I did not run it. A reviewer with a scratch room can: trigger a Team result containing `[file: <any path>]`, answer No in the review DM, and confirm the room gets the prose plus `(1 attachment not published)`.

## Related, left for separate changes

- The normal result path's failure note, `[attachment not sent: {fp} ({reason})]`, also prints the full local path into the room when an upload fails. Existing tests pin that text, `tests/remote-gateway-file-attach.test.py:159` and `tests/gateway-signal-task-media.test.py:454`, so changing it to a basename is a separate decision.
- The release posts at the room's top level, not as a thread reply to the original request. A Signal Room host therefore never renders the result's `signal-card` fence, and the raw card JSON shows in the room. That's noise, not a disclosure, but it's the same root cause: the release bypasses the normal result route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
