### PR TITLE
DO NOT MERGE — fix(x-twitter): keychain diagnosis falsified in review, needs a persistence test

### DIFF
--- a/skills/x-twitter/SKILL.md
+++ b/skills/x-twitter/SKILL.md
@@ -49,7 +49,8 @@ node skills/x-twitter/x-post-browser.mjs post "Your tweet text"
   a fresh sign-in. `$X_LOGIN_DONE_SENTINEL` and `$X_LOGIN_TIMEOUT_ITERS` are declared alongside it but are
   test/CI controls — there is no reason to set them by hand. Sign-in
   survives ONLY because `check`/`post` strip Playwright's `--use-mock-keychain` so
-  cookies decrypt with the real login keychain — see
+  cookies use a profile-local key (`--password-store=basic`), not the login
+  keychain — a context without keychain access would drop them all; see
   `memory/reference_x_browser_signin_oauth_blocked_use_email_phone.md`.
 - **Always `--dry-run` first and confirm with the owner before publishing.** Nothing
   posts without an explicit OK.

--- a/skills/x-twitter/x-post-browser.mjs
+++ b/skills/x-twitter/x-post-browser.mjs
@@ -279,6 +279,10 @@ function authTokenOnDisk() {
 }
 
 // ─── login: GUI launch via LaunchServices (REAL keychain, findable window) ───
+// Cookie encryption key lives in a profile-local file, not the login Keychain.
+// A context without keychain access would otherwise drop every cookie on load.
+const PASSWORD_STORE_ARG = '--password-store=basic';
+
 if (cmd === 'login') {
   if (!CHROME_APP) {
     console.error('Could not find a "Google Chrome for Testing.app" in the Playwright cache.');
@@ -292,6 +296,7 @@ if (cmd === 'login') {
   execFileSync('open', [
     '-n', '-a', CHROME_APP, '--args',
     `--user-data-dir=${PROFILE_DIR}`,
+    PASSWORD_STORE_ARG,
     '--no-first-run', '--no-default-browser-check',
     'https://x.com/login',
   ]);
@@ -330,6 +335,7 @@ const ctx = await chromium.launchPersistentContext(PROFILE_DIR, {
   // CRITICAL: strip --use-mock-keychain so cookie values are decrypted with the
   // SAME real login-keychain key the GUI login used. With the mock key, Chrome
   // can't decrypt the saved session and drops every cookie → silent sign-out.
+  args: [PASSWORD_STORE_ARG],
   ignoreDefaultArgs: ['--use-mock-keychain'],
 });
 

--- a/tests/x-profile-password-store.test.mjs
+++ b/tests/x-profile-password-store.test.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+/**
+ * Cookie encryption must not depend on the login Keychain.
+ *
+ * Measured 2026-09-10 on the 24/7 node: `security find-generic-password -s
+ * "Chrome for Testing Safe Storage"` returns rc=44 from the core's context, so the
+ * key the GUI login wrote is unreachable there. Chrome drops every cookie it cannot
+ * decrypt on load, so each headless `check` silently signed the profile out and no
+ * re-login survived. `--password-store=basic` keeps the key in the profile itself.
+ *
+ * The invariant is that BOTH launch sites carry it: the GUI `login` (LaunchServices)
+ * and the Playwright `check`/`post`. If they disagree, one writes cookies the other
+ * cannot read — the same failure with a different key.
+ *
+ * Run: node tests/x-profile-password-store.test.mjs
+ */
+import { readFileSync } from 'node:fs';
+
+const SRC = new URL('../skills/x-twitter/x-post-browser.mjs', import.meta.url);
+const src = readFileSync(SRC, 'utf8');
+let fails = 0;
+const check = (cond, msg) => {
+  console.log((cond ? '  ok   ' : '  FAIL ') + msg);
+  if (!cond) fails++;
+};
+
+check(/const PASSWORD_STORE_ARG = '--password-store=basic';/.test(src),
+  'the flag is defined once, as a named constant');
+check((src.match(/PASSWORD_STORE_ARG/g) || []).length === 3,
+  `defined once and used at BOTH sites (found ${(src.match(/PASSWORD_STORE_ARG/g) || []).length} refs, want 3)`);
+check(!/--password-store=basic/.test(src.replace(/const PASSWORD_STORE_ARG = '--password-store=basic';/, '')),
+  'no second literal — the two sites cannot drift apart');
+
+// Declared before BOTH uses: `const` has no hoisting, so a later declaration
+// makes the GUI login throw ReferenceError instead of launching.
+const decl = src.indexOf('const PASSWORD_STORE_ARG');
+const uses = [...src.matchAll(/PASSWORD_STORE_ARG/g)].map((m) => m.index).filter((i) => i !== decl);
+check(uses.every((i) => i > decl), 'declared before every use (temporal dead zone)');
+
+// Site 1: the LaunchServices GUI login argv.
+const loginBlock = src.slice(src.indexOf("execFileSync('open'"), src.indexOf("execFileSync('open'") + 400);
+check(loginBlock.includes('PASSWORD_STORE_ARG'), 'GUI login argv carries the flag');
+
+// Site 2: the Playwright persistent context.
+const pwBlock = src.slice(src.indexOf('launchPersistentContext'), src.indexOf('launchPersistentContext') + 500);
+check(pwBlock.includes('PASSWORD_STORE_ARG'), 'Playwright launch carries the flag');
+check(pwBlock.includes("ignoreDefaultArgs: ['--use-mock-keychain']"),
+  'the mock-keychain strip is still present (not replaced by this change)');
+
+console.log(fails ? `\n${fails} FAILED` : '\nall ok');
+process.exit(fails ? 1 : 0);


### PR DESCRIPTION
## What

The X browser profile silently signs itself out, repeatedly — 2026-09-03, and again 2026-09-10, where it cost an approved post and produced a false `posted:true`.

## Measured cause

On the 24/7 node, from the core's own context:

```
security find-generic-password -s "Chrome for Testing Safe Storage"   ->  rc=44
```

The key the GUI login wrote is unreachable there, and Chrome **drops every cookie it cannot decrypt on load**. The file's own header documents that mechanism (verified 2026-07-14: a GUI login wrote 9 cookies, one wrong-key open left 0).

Stripping `--use-mock-keychain` — which the tool already does — only *asks* for the real key. It cannot conjure one this context cannot see. So every headless `check` tore the session down, and no re-login survived the next probe.

## Fix

`--password-store=basic` keeps the encryption key in the profile directory, so any context that can read the profile can read its cookies.

**The invariant is that BOTH launch sites carry it** — the LaunchServices GUI `login` and the Playwright `check`/`post`. If they disagree, one writes cookies the other cannot read: the same failure with a different key. One named constant, declared above both uses.

The declaration position is load-bearing, not stylistic: `const` does not hoist, so declaring it after the login block makes `login` throw `ReferenceError` instead of launching. I hit that while writing this, which is why the test pins it.

## Evidence

`tests/x-profile-password-store.test.mjs`, 7 arms. Both mutations verified to fail:

```
drop the flag from the GUI login site     -> rc=1
move the declaration below its use        -> rc=1
restored                                  -> rc=0
```

## Note for whoever lands this

Existing profiles were encrypted with the old key, so **one re-login is required** after this change. That is a one-time cost against a session that currently does not survive at all.

## Not claimed

I have not demonstrated a session surviving a `check` under the new flag — doing so needs a sign-in, and the sign-in is what this fixes. The causal chain (rc=44 → cookies undecryptable → dropped) is documented in the file and consistent with two incidents, but the end-to-end proof is owed after the next login.
