### PR TITLE
docs(claude-gemini): name the workspace blind spot — ignored paths and no shell in plan mode

### DIFF
--- a/skills/claude-gemini/SKILL.md
+++ b/skills/claude-gemini/SKILL.md
@@ -26,6 +26,24 @@ ARGUMENTS: $ARGUMENTS
 - Keep Gemini in the same repo by changing into the target workspace before running it.
 - Prefer `--output-format json` or `stream-json` when another tool will consume the output.
 
+## Delegating Work That Touches `workspace/`
+
+Gemini's own file tools (`read_file`, `write_file`, `glob`, `search_file_content`) honor
+`.gitignore`. This repo ignores `workspace/*` (`.gitignore`), and the workspace is where every
+piece of per-user runtime state lives — `tasks/`, `results/`, `state/`, `logs/`, memory. So those
+tools cannot see any of it, and a run told to read or write there fails with
+`File path ... is ignored by configured ignore patterns`, often retrying the same call instead of
+falling back.
+
+- **A delegation that touches the workspace must be told to use shell commands only** — `cat`,
+  `ls`, `printf`, `mv`, heredocs. Say so in the prompt; the run will otherwise reach for a file
+  tool first and burn turns on the error.
+- **`--approval-mode plan` has no shell tool at all**, so read-only mode has no route to workspace
+  state: file tools are filtered out and `run_shell_command` is unavailable. Read-only questions
+  about runtime state need a mode that can run commands, or the caller must pass the content in.
+- **Paths outside the repo are rejected** as resolving outside the allowed directories (a
+  `~/Library/LaunchAgents` read, for example). Pass `--include-directories <dir>` for those.
+
 ## Quick Checks
 
 ```bash


### PR DESCRIPTION
## Problem

Any delegation through this skill that touches `workspace/` silently has no working file path.

Gemini's native file tools honor `.gitignore`. This repo ignores `workspace/*`, and per the
workspace contract that directory holds all per-user runtime state — `tasks/`, `results/`,
`state/`, `logs/`, memory. A run told to write a result file therefore gets
`File path ... is ignored by configured ignore patterns`, and in practice retries the same call
rather than falling back to the shell.

Sharper than that: **`--approval-mode plan` has no `run_shell_command` at all**, so read-only mode
has no route to workspace state whatsoever — file tools are filtered out and the shell tool is
absent. `SKILL.md` recommends `plan` as the default, which is exactly the mode that cannot answer a
question about runtime state.

Observed twice on a live core today, from two separate delegations:

```
Error executing tool read_file: File path '.../workspace/results/task-cron-pending-questions-<id>.txt'
  is ignored by configured ignore patterns
Error executing tool run_shell_command: Tool "run_shell_command" not found.
  Did you mean one of: "update_topic", "grep_search", "replace"?
Error executing tool read_file: Path not in workspace: Attempted path
  "/Users/<user>/Library/LaunchAgents" resolves outside the allowed workspace directories
```

The first run looped on the ignore error and completed none of its three assigned tasks. Re-running
it with an explicit "use only `run_shell_command`" instruction succeeded on the first try, which is
what identifies the gap as documentation rather than code.

## Scope

Documentation only. One new section in `skills/claude-gemini/SKILL.md`, 18 added lines, no code
touched. I deliberately did **not** add a `respectGitIgnore` setting or a `.geminiignore`: I could
not verify the setting key on this machine (`gemini --help` prints nothing here), and disabling
gitignore filtering wholesale would expose `node_modules/` and every other ignored tree to the
model. Shipping an unverified config key is worse than naming the constraint.

## Evidence

### Before — at parent a7806e6a
```
$ git show a7806e6a:skills/claude-gemini/SKILL.md | grep -inE "ignore|shell-only|workspace/" ; echo "exit=$?"
exit=1
```

### After — at HEAD 4cc2347e
```
$ grep -inE "ignore|shell-only|run_shell_command" skills/claude-gemini/SKILL.md
32:`.gitignore`. This repo ignores `workspace/*` (`.gitignore`), and the workspace is where every
35:`File path ... is ignored by configured ignore patterns`, often retrying the same call instead of
42:  state: file tools are filtered out and `run_shell_command` is unavailable. Read-only questions
```

### The filter that causes it
```
$ git check-ignore -v workspace/results/x.txt
.gitignore:135:workspace/*	workspace/results/x.txt
135:workspace/*
```

## Related

#3760 routes non-owner sandbox work through the Gemini CLI. Anything it delegates that reads or
writes workspace state hits this same filter, so the note lands in front of that work rather than
after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
