### PR TITLE
feat(ag2space): ingest accepted room-question delivery

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py
+++ b/packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py
@@ -179,6 +179,9 @@ KNOWN_HEADER_KEYS = (
     # trusted bridge wrote it; the guard defangs a forged `platform_card:`
     # body line the same as `attachments:`.
     "platform_card",
+    # Backend-owned accepted room-question metadata. It is correlation data;
+    # runtime HITL authority remains in the legacy local requirement fields.
+    "question_delivery",
     # Which instance a task belongs to; header status defangs forged
     # body-line claims, consumers may verify before executing.
     "instance_id",

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -1726,11 +1726,68 @@ _TASK_FIELDS = ("id", "timestamp", "session_scope",
                 "source_message_id", "user_id", "interaction_type",
                 # Platform-signed metadata pointer — serialized as a one-line
                 # JSON header by a dedicated branch below (dict, not scalar).
-                "platform_card")
+                "platform_card",
+                # Backend-owned accepted room-question delivery. This is
+                # correlation data for an ordinary broker task, not local HITL
+                # authority and not an alternative source of access policy.
+                "question_delivery")
 
 # platform_card passes through with exactly these subkeys — a signed pointer
 # {card_url, card_sha256, sig, key_id, alg} to the platform's canonical agent
 _PLATFORM_CARD_KEYS = ("card_url", "card_sha256", "sig", "key_id", "alg")
+
+_QUESTION_DELIVERY_KEYS = (
+    "version", "delivery_id", "question_id", "question_event_id", "revision",
+    "status", "response", "respondent", "accepted_at",
+)
+
+
+def _question_delivery_header(value):
+    """Return compact validated room-question delivery metadata, or None."""
+    if not isinstance(value, dict) or set(value) != set(_QUESTION_DELIVERY_KEYS):
+        return None
+    if value.get("version") != 1 or value.get("status") != "resolved":
+        return None
+    if not isinstance(value.get("revision"), int) or value["revision"] < 1:
+        return None
+    bounded = {
+        "delivery_id": 128,
+        "question_id": 128,
+        "question_event_id": 255,
+        "respondent": 255,
+        "accepted_at": 64,
+    }
+    if any(
+        not isinstance(value.get(key), str)
+        or not value[key]
+        or len(value[key]) > limit
+        for key, limit in bounded.items()
+    ):
+        return None
+    response = value.get("response")
+    if not isinstance(response, dict):
+        return None
+    kind = response.get("kind")
+    if kind == "choice":
+        if set(response) - {"kind", "option_id", "note"}:
+            return None
+        if not isinstance(response.get("option_id"), str) or not response["option_id"]:
+            return None
+        if len(response["option_id"]) > 64:
+            return None
+        note = response.get("note")
+        if note is not None and (not isinstance(note, str) or len(note) > 2000):
+            return None
+    elif kind == "text":
+        if set(response) != {"kind", "text"}:
+            return None
+        if not isinstance(response.get("text"), str) or not response["text"]:
+            return None
+        if len(response["text"]) > 4000:
+            return None
+    else:
+        return None
+    return json.dumps(value, separators=(",", ":"), ensure_ascii=True)
 
 # Interaction-plane vocabulary (interaction-planes refactor step 1). Remote
 # values outside this set degrade to "message" rather than passing through.
@@ -2919,6 +2976,16 @@ def _write_task(task: dict) -> "tuple[str, bool] | None":
             if isinstance(pc, dict) and all(k in pc for k in _PLATFORM_CARD_KEYS):
                 card = {k: str(pc[k]) for k in _PLATFORM_CARD_KEYS}
                 lines.append(f"platform_card: {json.dumps(card, separators=(',', ':'))}")
+        elif f == "question_delivery":
+            delivery = _question_delivery_header(task.get(f))
+            expected_delivery_id = None
+            if delivery is not None:
+                expected_delivery_id = json.loads(delivery)["delivery_id"]
+            if (
+                task.get("source") == "ag2space-question-delivery"
+                and broker_tid == f"task-{expected_delivery_id}"
+            ):
+                lines.append(f"question_delivery: {delivery}")
         elif f in task and task[f] not in (None, ""):
             lines.append(f"{f}: {_one_line(task[f])}")
             # After id: so the canonical id-first / HMAC-stamp prefix stays line 0.

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -1727,9 +1727,8 @@ _TASK_FIELDS = ("id", "timestamp", "session_scope",
                 # Platform-signed metadata pointer — serialized as a one-line
                 # JSON header by a dedicated branch below (dict, not scalar).
                 "platform_card",
-                # Backend-owned accepted room-question delivery. This is
-                # correlation data for an ordinary broker task, not local HITL
-                # authority and not an alternative source of access policy.
+                # Backend-owned answer correlation for an ordinary broker task;
+                # never local HITL authority or an alternative access policy.
                 "question_delivery")
 
 # platform_card passes through with exactly these subkeys — a signed pointer

--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -213,7 +213,7 @@ const _CONF_HEADER_RE = new RegExp(
 	'thread_root|source_room_id|' +
 	'receiving_instance|' +
 	'call_sid|hint|instructions|transcript|schedule_name|schedule_slot|content_modalities|media_form|' +
-	'attachments|platform_card|instance_id|collaborator|requested_worker|hitl_click)\\s*:',
+	'attachments|platform_card|question_delivery|instance_id|collaborator|requested_worker|hitl_click)\\s*:',
 	'i',
 );
 const _CONF_FENCE_RE = /^={3,}/;

--- a/src/hitl/replies.py
+++ b/src/hitl/replies.py
@@ -48,6 +48,21 @@ def parse_reply(event: Dict[str, Any]) -> Optional[ActionReply]:
         return None
 
 
+def is_room_question_reply(event: Dict[str, Any]) -> bool:
+    """True when the action belongs to backend-owned room-question HITL.
+
+    Room questions deliberately reuse ``space.ag2.hitl`` presentation, but
+    their answers are accepted by the backend.  They must never enter this
+    local owner/runtime authority merely because their Matrix content reached
+    the agent event or task relay.
+    """
+    content = event.get("content") or {}
+    payload = content.get(REPLY_FIELD)
+    return isinstance(payload, dict) and (
+        payload.get("scope") == "room" or "question_id" in payload
+    )
+
+
 def write_driver_action(workspace: Path, req: HumanRequirement, action: Action) -> Path:
     """Atomically drop the driver's action file; the driver replaces it with a receipt."""
     d = actions_dir(workspace)
@@ -93,7 +108,11 @@ class HitlReplyHandler:
 
     def claims(self, event: Dict[str, Any]) -> bool:
         content = event.get("content") or {}
-        return event.get("type") == EVENT_TYPE and isinstance(content.get(REPLY_FIELD), dict)
+        return (
+            event.get("type") == EVENT_TYPE
+            and isinstance(content.get(REPLY_FIELD), dict)
+            and not is_room_question_reply(event)
+        )
 
     def offer(self, event: Dict[str, Any]) -> List[str]:
         eid = str(event.get("event_id") or "")

--- a/src/local_task_protocol.py
+++ b/src/local_task_protocol.py
@@ -179,6 +179,9 @@ KNOWN_HEADER_KEYS = (
     # trusted bridge wrote it; the guard defangs a forged `platform_card:`
     # body line the same as `attachments:`.
     "platform_card",
+    # Backend-owned accepted room-question metadata. It is correlation data;
+    # runtime HITL authority remains in the legacy local requirement fields.
+    "question_delivery",
     # Which instance a task belongs to; header status defangs forged
     # body-line claims, consumers may verify before executing.
     "instance_id",

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -98,7 +98,7 @@ const _HEADER_KEYS = [
 	'receiving_instance',
 	'from', 'call_sid', 'hint', 'instructions', 'transcript',
 	'schedule_name', 'schedule_slot',
-	'content_modalities', 'media_form', 'attachments', 'platform_card',
+	'content_modalities', 'media_form', 'attachments', 'platform_card', 'question_delivery',
 	'instance_id', 'collaborator', 'requested_worker', 'hitl_click',
 ];
 const _HEADER_RE = new RegExp(`^(?:${_HEADER_KEYS.join('|')})\\s*:`, 'i');

--- a/tests/gateway-question-delivery.test.py
+++ b/tests/gateway-question-delivery.test.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Focused gateway coverage for backend-owned room-question delivery."""
+import importlib.util
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+spec = importlib.util.spec_from_file_location(
+    "remote_gateway_bridge_question_delivery",
+    REPO / "src" / "remote-gateway-bridge.py",
+)
+gateway = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = gateway
+spec.loader.exec_module(gateway)
+
+root = Path(tempfile.mkdtemp(prefix="question-delivery-test-"))
+gateway.TASKS_DIR = root / "tasks"
+gateway.RESULTS_DIR = root / "results"
+gateway.ARCHIVE_RESULTS_DIR = root / "results" / "archive"
+gateway.LOCAL_TIER = "owner"
+
+delivery = {
+    "version": 1,
+    "delivery_id": "question-delivery-4bd08f",
+    "question_id": "q_01H",
+    "question_event_id": "$question",
+    "revision": 2,
+    "status": "resolved",
+    "response": {"kind": "choice", "option_id": "minimal", "note": "Ship it."},
+    "respondent": "@mark:ag2.space",
+    "accepted_at": "2026-09-11T01:05:00Z",
+}
+
+written = gateway._write_task({
+    "id": "task-question-delivery-4bd08f",
+    "source": "ag2space-question-delivery",
+    "task": "Continue after the accepted room answer.",
+    "access_tier": "guest",
+    "interaction_type": "system_event",
+    "session_scope": "room",
+    "channel_id": "!room:ag2.space",
+    "question_delivery": delivery,
+})
+assert written == ("task-question-delivery-4bd08f", True), written
+task_file = gateway.TASKS_DIR / "task-question-delivery-4bd08f.txt"
+body = task_file.read_text()
+header = next(line for line in body.splitlines() if line.startswith("question_delivery: "))
+assert json.loads(header.split(": ", 1)[1]) == delivery
+assert body.count("access_tier: guest") == 1
+assert "interaction_type: system_event" in body
+
+# Structured answer metadata never supplies access policy. Missing broker
+# attestation remains guest even when the local cap is owner.
+second = dict(delivery, delivery_id="question-delivery-no-tier")
+gateway._write_task({
+    "id": "task-question-delivery-no-tier",
+    "source": "ag2space-question-delivery",
+    "task": "Continue safely.",
+    "question_delivery": second,
+})
+assert "access_tier: guest" in (
+    gateway.TASKS_DIR / "task-question-delivery-no-tier.txt"
+).read_text()
+
+# Malformed metadata is not promoted to a trusted header. The ordinary task
+# remains guest and executable, allowing broker retry/inspection to recover.
+bad = dict(delivery, response={"kind": "runtime_action", "action_id": "allow"})
+gateway._write_task({
+    "id": "task-question-delivery-invalid",
+    "source": "ag2space-question-delivery",
+    "task": "Inspect the canonical question before continuing.",
+    "question_delivery": bad,
+})
+invalid = (gateway.TASKS_DIR / "task-question-delivery-invalid.txt").read_text()
+assert "question_delivery:" not in invalid
+assert "access_tier: guest" in invalid
+
+# The stable broker task identity and the canonical delivery identity must
+# agree, otherwise a replay could bypass the gateway's existing task dedup.
+gateway._write_task({
+    "id": "task-question-delivery-different",
+    "source": "ag2space-question-delivery",
+    "task": "Inspect the canonical question before continuing.",
+    "question_delivery": delivery,
+})
+mismatch = (gateway.TASKS_DIR / "task-question-delivery-different.txt").read_text()
+assert "question_delivery:" not in mismatch
+
+print("PASS — room-question delivery is correlated without local HITL authority")

--- a/tests/gateway-question-delivery.test.py
+++ b/tests/gateway-question-delivery.test.py
@@ -21,6 +21,8 @@ gateway.RESULTS_DIR = root / "results"
 gateway.ARCHIVE_RESULTS_DIR = root / "results" / "archive"
 gateway.LOCAL_TIER = "owner"
 
+assert "question_delivery" in gateway.local_task_protocol.KNOWN_HEADER_KEYS
+
 delivery = {
     "version": 1,
     "delivery_id": "question-delivery-4bd08f",
@@ -48,6 +50,8 @@ task_file = gateway.TASKS_DIR / "task-question-delivery-4bd08f.txt"
 body = task_file.read_text()
 header = next(line for line in body.splitlines() if line.startswith("question_delivery: "))
 assert json.loads(header.split(": ", 1)[1]) == delivery
+parsed = gateway.local_task_protocol.parse_task_headers_trusted(body)
+assert json.loads(parsed.headers["question_delivery"]) == delivery
 assert body.count("access_tier: guest") == 1
 assert "interaction_type: system_event" in body
 

--- a/tests/hitl-replies.test.py
+++ b/tests/hitl-replies.test.py
@@ -82,6 +82,22 @@ class ReplyHandlerTests(unittest.TestCase):
         self.assertFalse(self.h.claims(event(reply_for(self.req, "allow"), etype="reaction.added")))
         self.assertFalse(self.h.claims(event("junk")))
 
+    def test_room_question_reply_is_never_claimed_by_local_runtime_hitl(self):
+        for payload in (
+            {"scope": "room", "question_id": "q_1", "expected_revision": 1,
+             "response": {"kind": "choice", "option_id": "minimal"}},
+            {"question_id": "q_1", "expected_revision": 1,
+             "response": {"kind": "text", "text": "Use the small change."}},
+        ):
+            with self.subTest(payload=payload):
+                self.assertFalse(self.h.claims(event(payload)))
+                # offer() preserves the handler contract's event-id echo even
+                # for an unclaimed event; HandlerChain consults claims() and
+                # routes this event onward to the backend/ambient path.
+                self.assertEqual(self.h.offer(event(payload)), ["$e1"])
+                self.assertEqual(self.mgr.get(self.req.id).status, "pending")
+                self.assertFalse(list(actions_dir(self.ws).glob("*.json")))
+
     def test_owner_reply_applies_and_unblocks(self):
         out = self.h.offer(event(reply_for(self.req, "allow")))
         self.assertEqual(out, ["$e1"])

--- a/tests/hitl-replies.test.py
+++ b/tests/hitl-replies.test.py
@@ -91,9 +91,8 @@ class ReplyHandlerTests(unittest.TestCase):
         ):
             with self.subTest(payload=payload):
                 self.assertFalse(self.h.claims(event(payload)))
-                # offer() preserves the handler contract's event-id echo even
-                # for an unclaimed event; HandlerChain consults claims() and
-                # routes this event onward to the backend/ambient path.
+                # The event-id echo remains; HandlerChain checks claims() and
+                # routes the unclaimed event to the backend/ambient path.
                 self.assertEqual(self.h.offer(event(payload)), ["$e1"])
                 self.assertEqual(self.mgr.get(self.req.id).status, "pending")
                 self.assertFalse(list(actions_dir(self.ws).glob("*.json")))


### PR DESCRIPTION
## What changed, and why?

Separates backend-owned room questions from Sutando runtime HITL and preserves validated accepted-answer metadata on broker-delivered tasks. This prevents Matrix room answers from acquiring local runtime permission authority while allowing the existing task queue to carry server-attested answer correlation.

## Review first

- `src/hitl/replies.py` — room-question actions are not claimed as runtime HITL.
- `packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py` — validates and serializes canonical `question_delivery`.
- `packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py` and `src/local_task_protocol.py` — parser/guard vocabulary.
- `tests/gateway-question-delivery.test.py` and `tests/hitl-replies.test.py`.

## User behavior proved

Room question answers remain backend-authorized and cannot unblock local runtime HITL. A canonical accepted-answer delivery with matching stable task/delivery identity becomes structured task metadata; malformed or mismatched metadata is not promoted.

## Documentation consistency

N/A — this implements an external backend integration contract without changing Sutando user-facing configuration or documented commands.

## Before/after evidence

Parent `0dbc801a`, running the new isolation regression against parent source:

```text
$ python3 tests/hitl-replies.test.py
FAIL: test_room_question_reply_is_never_claimed_by_local_runtime_hitl ...
AssertionError: True is not false
FAIL: test_room_question_reply_is_never_claimed_by_local_runtime_hitl ...
AssertionError: True is not false
Ran 44 tests in 0.056s
FAILED (failures=2)
```

HEAD `2b846c8c`:

```text
$ python3 tests/hitl-replies.test.py
Ran 44 tests in 0.047s
OK
$ python3 tests/gateway-question-delivery.test.py
PASS — room-question delivery is correlated without local HITL authority
```

## Tests

```text
python3 src/remote-gateway-bridge.test.py
PASS — all checks green

python3 tests/task-body-guard.test.py
task-body-guard: 93/93 passed

python3 tests/hitl-task-relay-click.test.py
Ran 10 tests in 0.016s
OK

bash scripts/review-checks.sh --diff <(git diff 0dbc801a...HEAD)
review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
```

## Live path

No production restart or credentialed round trip was run: this isolated review worktree was explicitly restricted from starting live runtimes. The full localhost gateway integration suite passed.

## Edge cases

Checked missing broker tier, malformed response kinds, excess/invalid response fields, mismatched task/delivery IDs, replay-safe stable identity, and legacy HITL behavior.

## Risks and known gaps

No migration or config change. Rollback is a revert of these three commits. The backend contract fixture currently supplies `access_tier: write`, while Sutando recognizes `owner`, `team`, and `guest`; it therefore fails closed to guest until the cross-system tier mapping is settled. This PR ingests delivery into the existing task queue but does not add new originating-question binding or generic continuation machinery.

Not stacked.