### PR TITLE
fix(hitl): keep room questions out of runtime permission handling

### DIFF
--- a/src/hitl/replies.py
+++ b/src/hitl/replies.py
@@ -48,6 +48,21 @@ def parse_reply(event: Dict[str, Any]) -> Optional[ActionReply]:
         return None
 
 
+def is_room_question_reply(event: Dict[str, Any]) -> bool:
+    """True when the action belongs to backend-owned room-question HITL.
+
+    Room questions deliberately reuse ``space.ag2.hitl`` presentation, but
+    their answers are accepted by the backend.  They must never enter this
+    local owner/runtime authority merely because their Matrix content reached
+    the agent event or task relay.
+    """
+    content = event.get("content") or {}
+    payload = content.get(REPLY_FIELD)
+    return isinstance(payload, dict) and (
+        payload.get("scope") == "room" or "question_id" in payload
+    )
+
+
 def write_driver_action(workspace: Path, req: HumanRequirement, action: Action) -> Path:
     """Atomically drop the driver's action file; the driver replaces it with a receipt."""
     d = actions_dir(workspace)
@@ -93,7 +108,11 @@ class HitlReplyHandler:
 
     def claims(self, event: Dict[str, Any]) -> bool:
         content = event.get("content") or {}
-        return event.get("type") == EVENT_TYPE and isinstance(content.get(REPLY_FIELD), dict)
+        return (
+            event.get("type") == EVENT_TYPE
+            and isinstance(content.get(REPLY_FIELD), dict)
+            and not is_room_question_reply(event)
+        )
 
     def offer(self, event: Dict[str, Any]) -> List[str]:
         eid = str(event.get("event_id") or "")

--- a/tests/hitl-replies.test.py
+++ b/tests/hitl-replies.test.py
@@ -82,6 +82,22 @@ class ReplyHandlerTests(unittest.TestCase):
         self.assertFalse(self.h.claims(event(reply_for(self.req, "allow"), etype="reaction.added")))
         self.assertFalse(self.h.claims(event("junk")))
 
+    def test_room_question_reply_is_never_claimed_by_local_runtime_hitl(self):
+        for payload in (
+            {"scope": "room", "question_id": "q_1", "expected_revision": 1,
+             "response": {"kind": "choice", "option_id": "minimal"}},
+            {"question_id": "q_1", "expected_revision": 1,
+             "response": {"kind": "text", "text": "Use the small change."}},
+        ):
+            with self.subTest(payload=payload):
+                self.assertFalse(self.h.claims(event(payload)))
+                # offer() preserves the handler contract's event-id echo even
+                # for an unclaimed event; HandlerChain consults claims() and
+                # routes this event onward to the backend/ambient path.
+                self.assertEqual(self.h.offer(event(payload)), ["$e1"])
+                self.assertEqual(self.mgr.get(self.req.id).status, "pending")
+                self.assertFalse(list(actions_dir(self.ws).glob("*.json")))
+
     def test_owner_reply_applies_and_unblocks(self):
         out = self.h.offer(event(reply_for(self.req, "allow")))
         self.assertEqual(out, ["$e1"])

--- a/tests/hitl-replies.test.py
+++ b/tests/hitl-replies.test.py
@@ -91,9 +91,8 @@ class ReplyHandlerTests(unittest.TestCase):
         ):
             with self.subTest(payload=payload):
                 self.assertFalse(self.h.claims(event(payload)))
-                # offer() preserves the handler contract's event-id echo even
-                # for an unclaimed event; HandlerChain consults claims() and
-                # routes this event onward to the backend/ambient path.
+                # The event-id echo remains; HandlerChain checks claims() and
+                # routes the unclaimed event to the backend/ambient path.
                 self.assertEqual(self.h.offer(event(payload)), ["$e1"])
                 self.assertEqual(self.mgr.get(self.req.id).status, "pending")
                 self.assertFalse(list(actions_dir(self.ws).glob("*.json")))


### PR DESCRIPTION
## What changed, and why?

Room questions reuse the `space.ag2.hitl` presentation namespace but are authorized and persisted by the room backend. This guard prevents `scope: room` / `question_id` answer candidates from entering Sutando's legacy local runtime HITL permission handler.

This is the complete Sutando compatibility slice for the stored/readable-answer MVP. It does not consume accepted-answer deliveries, bind originating tasks, resume work, or map continuation access tiers. Accepted answers remain retrievable through the backend `room.question.inspect` Action.

## Review first

- `src/hitl/replies.py` — caller-neutral room-question discriminator at the legacy handler boundary.
- `tests/hitl-replies.test.py` — room-scoped and question-id compatibility cases.

## User behavior proved

A room answer candidate cannot be interpreted as local permission authority or unblock a Sutando runtime requirement. Existing legacy runtime actions remain unchanged.

## Documentation consistency

N/A — this is a defensive compatibility boundary; room question persistence and inspection are backend-owned.

## Before/after evidence

Parent `0dbc801a`, running the regression against parent source:

```text
$ python3 tests/hitl-replies.test.py
FAIL: test_room_question_reply_is_never_claimed_by_local_runtime_hitl ...
AssertionError: True is not false
FAIL: test_room_question_reply_is_never_claimed_by_local_runtime_hitl ...
AssertionError: True is not false
Ran 44 tests in 0.056s
FAILED (failures=2)
```

HEAD `42960123`:

```text
$ python3 tests/hitl-replies.test.py
Ran 44 tests in 0.061s
OK

$ bash scripts/review-checks.sh --diff <(git diff 0dbc801a...HEAD)
review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
```

## Live path

No live runtime was started. This guard is covered at the handler boundary, including verification that the local requirement remains pending and no runtime action file is written.

## Edge cases

Covers explicit `scope: room` payloads and compatibility payloads carrying `question_id`; legacy owner runtime actions continue through the existing path.

## Risks and known gaps

No migration, config, permission, delivery-consumer, or automatic-continuation change. Rollback is a revert of these two commits.

Not stacked. The broader delivery-consumer work remains preserved separately in #4155 but is deferred from this MVP.