### PR TITLE
feat(gateway): the bridge advertises the pool from the roster-written state file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,7 @@ jobs:
           timeout -k 5 120 python3 packages/ag2-sparrow/tests/test_launch_diagnostics.py
           timeout -k 5 120 python3 packages/ag2-sparrow/tests/test_vault_token_tier.py
           timeout -k 5 120 python3 packages/ag2-sparrow/tests/test_env_token_quotes.py
+          timeout -k 5 120 python3 packages/ag2-sparrow/tests/test_pool_advertisement_push.py
           timeout -k 5 120 python3 packages/ag2-sparrow/tools/test_no_drift.py
           timeout -k 5 120 python3 skills/agent-room-ops/test_room_ops.py
           timeout -k 5 120 python3 skills/make-viral-video/scripts/test_source_tag.py

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -2423,6 +2423,9 @@ def _read_core_status() -> tuple[str | None, str | None]:
 
 
 _POOL_ADVERTISEMENT_FILE = _STATE / "pool-advertisement.json"
+# A roster row is ~100 bytes, so this is >10k workers; past it the loop would
+# re-read and re-parse a runaway file every pass before it can poll for tasks.
+_POOL_ADVERTISEMENT_MAX_BYTES = 1 << 20
 _workers_push_mtime = 0.0
 _workers_push_retry_at = 0.0
 _advertisement_unavailable_logged = False
@@ -2444,12 +2447,19 @@ def _read_pool_advertisement() -> "tuple[float, dict | None]":
     with no `workers`, and the broker REPLACES that document.
 
     Both halves are validated from this one read so a one-sided record cannot
-    POST a status map whose labels never ship. This runs in the task loop and
-    may never raise."""
+    POST a status map whose labels never ship. This runs in the task loop
+    BEFORE the /v1/tasks poll and may never raise: the outer handler backs off
+    and retries the same file, so any exception here — a RecursionError from a
+    deeply nested value, not only OSError/ValueError — would stall intake for
+    as long as that file stays. The size is bounded before the parse so a
+    runaway file cannot cost the loop a full read per pass either."""
     try:
-        mtime = _POOL_ADVERTISEMENT_FILE.stat().st_mtime
+        st = _POOL_ADVERTISEMENT_FILE.stat()
+        if st.st_size > _POOL_ADVERTISEMENT_MAX_BYTES:
+            return (0.0, None)
+        mtime = st.st_mtime
         rec = json.loads(_POOL_ADVERTISEMENT_FILE.read_text())
-    except (OSError, ValueError):
+    except Exception:  # noqa: BLE001 — a parser/resource failure is UNAVAILABLE, never a stalled poll
         return (0.0, None)
     if not isinstance(rec, dict):
         return (0.0, None)

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -2422,6 +2422,112 @@ def _read_core_status() -> tuple[str | None, str | None]:
         return (None, None)
 
 
+_POOL_ADVERTISEMENT_FILE = _STATE / "pool-advertisement.json"
+_workers_push_mtime = 0.0
+_workers_push_retry_at = 0.0
+
+
+def _read_pool_advertisement() -> "tuple[float, dict]":
+    """The pool's roster-derived advertisement -> (mtime, record). Absent,
+    mid-write or malformed reads as (0.0, {}), which every caller treats as
+    "no pool" — this runs in the task loop and may never raise."""
+    try:
+        mtime = _POOL_ADVERTISEMENT_FILE.stat().st_mtime
+        rec = json.loads(_POOL_ADVERTISEMENT_FILE.read_text())
+    except (OSError, ValueError):
+        return (0.0, {})
+    return (mtime, rec) if isinstance(rec, dict) else (0.0, {})
+
+
+def _maybe_push_workers_snapshot() -> bool:
+    """Push-on-change relay of the pool's workers snapshot (the worker
+    picker's read path). No file = no pool = no-op; a broker without the
+    endpoint (404) backs the push off an hour; nothing here may ever
+    break the task loop."""
+    global _workers_push_mtime, _workers_push_retry_at
+    now = time.time()
+    if now < _workers_push_retry_at:
+        return False
+    mtime, ad = _read_pool_advertisement()
+    if mtime <= _workers_push_mtime:
+        return False
+    snap = ad.get("workers")
+    if not isinstance(snap, dict):
+        return False  # nothing to advertise yet; the next write retries
+    try:
+        _req("POST", "/v1/workers", snap, timeout=15)
+    except urllib.error.HTTPError as e:
+        _workers_push_retry_at = now + 3600
+        _log(f"workers-snapshot push deferred 1h (HTTP {e.code}"
+             f"{': broker has no /v1/workers yet' if e.code == 404 else ''})")
+        return False
+    except Exception as e:  # noqa: BLE001 — relay must never kill the loop
+        _workers_push_retry_at = now + 300
+        _log(f"workers-snapshot push failed, retrying in 5m: {e}")
+        return False
+    _workers_push_mtime = mtime
+    _log("workers-snapshot pushed")
+    return True
+
+
+_profile_push_key = ""
+_profile_push_retry_at = 0.0
+
+
+def _build_agent_profile() -> "dict":
+    """The instance's identity card for PUT /v1/agents/{mxid}/profile.
+    Only instance-authoritative fields — appearance is user/platform-owned
+    and the broker drops it from instance PUTs anyway."""
+    name = (os.environ.get("SUTANDO_DISPLAY_NAME") or "Sutando").strip()
+    try:
+        host_id = socket.gethostname().split(".")[0]
+    except OSError:
+        host_id = "unknown-host"
+    card = {"display": {"name": name},
+            "host": {"host_id": host_id, "kind": "local"}}
+    # The broker REPLACES the profile document, so an omitted workers map
+    # deletes the pool the picker was drawing.
+    workers = _read_pool_advertisement()[1].get("profile_workers")
+    if isinstance(workers, dict):
+        card["workers"] = workers
+    return card
+
+
+def _maybe_push_agent_profile() -> bool:
+    """Push-on-change relay of the agent's profile card. Same failure
+    contract as the workers-snapshot push: 404 defers an hour (broker not
+    deployed yet), other errors 5m; nothing here may break the task loop."""
+    global _profile_push_key, _profile_push_retry_at
+    now = time.time()
+    if now < _profile_push_retry_at:
+        return False
+    mxid = _reenroll_identity()
+    if not mxid:
+        return False  # identity may appear mid-episode; recheck next loop
+    card = _build_agent_profile()
+    # The advertisement's mtime is in the key so a roster rewrite re-puts the
+    # card even when the workers map serialises identically.
+    key = (f"{mxid}\n{_read_pool_advertisement()[0]}\n"
+           + json.dumps(card, sort_keys=True))
+    if key == _profile_push_key:
+        return False
+    try:
+        _req("PUT", f"/v1/agents/{urllib.parse.quote(mxid)}/profile",
+             card, timeout=15)
+    except urllib.error.HTTPError as e:
+        _profile_push_retry_at = now + 3600
+        _log(f"agent-profile push deferred 1h (HTTP {e.code}"
+             f"{': broker has no profile API yet' if e.code == 404 else ''})")
+        return False
+    except Exception as e:  # noqa: BLE001 — relay must never kill the loop
+        _profile_push_retry_at = now + 300
+        _log(f"agent-profile push failed, retrying in 5m: {e}")
+        return False
+    _profile_push_key = key
+    _log(f"agent-profile pushed for {mxid}")
+    return True
+
+
 def _post_heartbeat(inflight: set[str], force: bool = False) -> bool:
     """Best-effort liveness + core-status ping. Liveness feeds hosted dashboards;
     the status/step feed the broker's presence sweep (agent working/available/…)."""
@@ -4253,6 +4359,8 @@ def main() -> None:
                     _results_watcher.join(timeout=5)
                 return
             _post_heartbeat(inflight)
+            _maybe_push_workers_snapshot()
+            _maybe_push_agent_profile()
             _retry_pending_publications()
             _retry_review_card_resolutions()
             _retry_review_control_results()

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -51,6 +51,7 @@ from __future__ import annotations
 
 import atexit
 import base64
+import hashlib
 import json
 import os
 import uuid
@@ -2426,7 +2427,7 @@ _POOL_ADVERTISEMENT_FILE = _STATE / "pool-advertisement.json"
 # A roster row is ~100 bytes, so this is >10k workers; past it the loop would
 # re-read and re-parse a runaway file every pass before it can poll for tasks.
 _POOL_ADVERTISEMENT_MAX_BYTES = 1 << 20
-_workers_push_mtime = 0.0
+_workers_pushed_identity = ""
 _workers_push_retry_at = 0.0
 _advertisement_unavailable_logged = False
 
@@ -2435,10 +2436,15 @@ _advertisement_unavailable_logged = False
 _UNSUPPORTED_ENDPOINT_STATUS = frozenset({404, 405, 501})
 
 
-def _read_pool_advertisement() -> "tuple[float, dict | None]":
-    """The pool's roster-derived advertisement -> (mtime, record), or
-    (0.0, None) when the record is UNAVAILABLE — absent, unreadable, mid-write,
+def _read_pool_advertisement() -> "tuple[str, dict | None]":
+    """The pool's roster-derived advertisement -> (identity, record), or
+    ("", None) when the record is UNAVAILABLE — absent, unreadable, mid-write,
     malformed, or carrying only one of its two halves.
+
+    The identity is a digest of the record's canonical content and is the ONE
+    change signal both publications key on. mtime is not: a restore that lands
+    below the prior file's mtime is new content the picker must see, and the
+    two halves keyed on different signals disagreed on exactly that record.
 
     Availability is a tri-state, and None is the only "cannot read it" value: a
     record whose maps are empty is AVAILABLE and means "the pool is empty", an
@@ -2454,27 +2460,26 @@ def _read_pool_advertisement() -> "tuple[float, dict | None]":
     as long as that file stays. The size is bounded before the parse so a
     runaway file cannot cost the loop a full read per pass either."""
     try:
-        st = _POOL_ADVERTISEMENT_FILE.stat()
-        if st.st_size > _POOL_ADVERTISEMENT_MAX_BYTES:
-            return (0.0, None)
-        mtime = st.st_mtime
+        if _POOL_ADVERTISEMENT_FILE.stat().st_size > _POOL_ADVERTISEMENT_MAX_BYTES:
+            return ("", None)
         rec = json.loads(_POOL_ADVERTISEMENT_FILE.read_text())
+        canonical = json.dumps(rec, sort_keys=True, separators=(",", ":"))
     except Exception:  # noqa: BLE001 — a parser/resource failure is UNAVAILABLE, never a stalled poll
-        return (0.0, None)
+        return ("", None)
     if not isinstance(rec, dict):
-        return (0.0, None)
+        return ("", None)
     if not isinstance(rec.get("workers"), dict):
-        return (0.0, None)
+        return ("", None)
     if not isinstance(rec.get("profile_workers"), dict):
-        return (0.0, None)
-    return (mtime, rec)
+        return ("", None)
+    return (hashlib.sha256(canonical.encode()).hexdigest(), rec)
 
 
-def _advertisement_or_none() -> "tuple[float, dict | None]":
+def _advertisement_or_none() -> "tuple[str, dict | None]":
     """_read_pool_advertisement, logging the availability edge once per edge so
     an absent producer cannot fill the log at the loop's cadence."""
     global _advertisement_unavailable_logged
-    mtime, rec = _read_pool_advertisement()
+    identity, rec = _read_pool_advertisement()
     if rec is None:
         if not _advertisement_unavailable_logged:
             _advertisement_unavailable_logged = True
@@ -2483,7 +2488,7 @@ def _advertisement_or_none() -> "tuple[float, dict | None]":
     elif _advertisement_unavailable_logged:
         _advertisement_unavailable_logged = False
         _log("pool advertisement readable again")
-    return (mtime, rec)
+    return (identity, rec)
 
 
 def _defer_push(what: str, e: "urllib.error.HTTPError", now: float) -> float:
@@ -2501,14 +2506,14 @@ def _maybe_push_workers_snapshot() -> bool:
     leaves the broker holding the last snapshot we sent; an unsupported
     endpoint backs the push off an hour and any other HTTP status 5m;
     nothing here may ever break the task loop."""
-    global _workers_push_mtime, _workers_push_retry_at
+    global _workers_pushed_identity, _workers_push_retry_at
     now = time.time()
     if now < _workers_push_retry_at:
         return False
-    mtime, ad = _advertisement_or_none()
+    identity, ad = _advertisement_or_none()
     if ad is None:
         return False
-    if mtime <= _workers_push_mtime:
+    if identity == _workers_pushed_identity:
         return False
     try:
         _req("POST", "/v1/workers", ad["workers"], timeout=15)
@@ -2519,12 +2524,12 @@ def _maybe_push_workers_snapshot() -> bool:
         _workers_push_retry_at = now + 300
         _log(f"workers-snapshot push failed, retrying in 5m: {e}")
         return False
-    _workers_push_mtime = mtime
+    _workers_pushed_identity = identity
     _log("workers-snapshot pushed")
     return True
 
 
-_profile_push_key = ""
+_profile_pushed_identity = ""
 _profile_push_retry_at = 0.0
 
 
@@ -2552,22 +2557,22 @@ def _maybe_push_agent_profile() -> bool:
     picker draws and the broker REPLACES the document, so a card built from
     a record we could not read would erase the pool. Same retry taxonomy as
     the workers-snapshot push; nothing here may break the task loop."""
-    global _profile_push_key, _profile_push_retry_at
+    global _profile_pushed_identity, _profile_push_retry_at
     now = time.time()
     if now < _profile_push_retry_at:
         return False
     mxid = _reenroll_identity()
     if not mxid:
         return False  # identity may appear mid-episode; recheck next loop
-    mtime, ad = _advertisement_or_none()
+    identity, ad = _advertisement_or_none()
     if ad is None:
         return False
-    card = _build_agent_profile(ad["profile_workers"])
-    # The advertisement's mtime is in the key so a roster rewrite re-puts the
-    # card even when the workers map serialises identically.
-    key = f"{mxid}\n{mtime}\n" + json.dumps(card, sort_keys=True)
-    if key == _profile_push_key:
+    # The same record identity the workers push keys on, so the two halves
+    # can never disagree on whether a record is new; mxid may change mid-run.
+    key = f"{mxid}\n{identity}"
+    if key == _profile_pushed_identity:
         return False
+    card = _build_agent_profile(ad["profile_workers"])
     try:
         _req("PUT", f"/v1/agents/{urllib.parse.quote(mxid)}/profile",
              card, timeout=15)
@@ -2578,7 +2583,7 @@ def _maybe_push_agent_profile() -> bool:
         _profile_push_retry_at = now + 300
         _log(f"agent-profile push failed, retrying in 5m: {e}")
         return False
-    _profile_push_key = key
+    _profile_pushed_identity = key
     _log(f"agent-profile pushed for {mxid}")
     return True
 

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -2425,41 +2425,85 @@ def _read_core_status() -> tuple[str | None, str | None]:
 _POOL_ADVERTISEMENT_FILE = _STATE / "pool-advertisement.json"
 _workers_push_mtime = 0.0
 _workers_push_retry_at = 0.0
+_advertisement_unavailable_logged = False
+
+# 404/405/501 are the broker saying "this endpoint does not exist here"; every
+# other status is a live endpoint failing, which a short retry can clear.
+_UNSUPPORTED_ENDPOINT_STATUS = frozenset({404, 405, 501})
 
 
-def _read_pool_advertisement() -> "tuple[float, dict]":
-    """The pool's roster-derived advertisement -> (mtime, record). Absent,
-    mid-write or malformed reads as (0.0, {}), which every caller treats as
-    "no pool" — this runs in the task loop and may never raise."""
+def _read_pool_advertisement() -> "tuple[float, dict | None]":
+    """The pool's roster-derived advertisement -> (mtime, record), or
+    (0.0, None) when the record is UNAVAILABLE — absent, unreadable, mid-write,
+    malformed, or carrying only one of its two halves.
+
+    Availability is a tri-state, and None is the only "cannot read it" value: a
+    record whose maps are empty is AVAILABLE and means "the pool is empty", an
+    intentional clear the callers must push. Collapsing the two (the pre-fix
+    (0.0, {})) is what let a deleted or half-written file PUT a profile card
+    with no `workers`, and the broker REPLACES that document.
+
+    Both halves are validated from this one read so a one-sided record cannot
+    POST a status map whose labels never ship. This runs in the task loop and
+    may never raise."""
     try:
         mtime = _POOL_ADVERTISEMENT_FILE.stat().st_mtime
         rec = json.loads(_POOL_ADVERTISEMENT_FILE.read_text())
     except (OSError, ValueError):
-        return (0.0, {})
-    return (mtime, rec) if isinstance(rec, dict) else (0.0, {})
+        return (0.0, None)
+    if not isinstance(rec, dict):
+        return (0.0, None)
+    if not isinstance(rec.get("workers"), dict):
+        return (0.0, None)
+    if not isinstance(rec.get("profile_workers"), dict):
+        return (0.0, None)
+    return (mtime, rec)
+
+
+def _advertisement_or_none() -> "tuple[float, dict | None]":
+    """_read_pool_advertisement, logging the availability edge once per edge so
+    an absent producer cannot fill the log at the loop's cadence."""
+    global _advertisement_unavailable_logged
+    mtime, rec = _read_pool_advertisement()
+    if rec is None:
+        if not _advertisement_unavailable_logged:
+            _advertisement_unavailable_logged = True
+            _log(f"pool advertisement unavailable ({_POOL_ADVERTISEMENT_FILE.name}"
+                 " missing or unreadable) — keeping the last pushed pool state")
+    elif _advertisement_unavailable_logged:
+        _advertisement_unavailable_logged = False
+        _log("pool advertisement readable again")
+    return (mtime, rec)
+
+
+def _defer_push(what: str, e: "urllib.error.HTTPError", now: float) -> float:
+    """The retry taxonomy both pushes share -> the absolute retry-at."""
+    if e.code in _UNSUPPORTED_ENDPOINT_STATUS:
+        _log(f"{what} deferred 1h: broker has no such endpoint (HTTP {e.code})")
+        return now + 3600
+    _log(f"{what} failed, retrying in 5m: endpoint exists, HTTP {e.code}")
+    return now + 300
 
 
 def _maybe_push_workers_snapshot() -> bool:
     """Push-on-change relay of the pool's workers snapshot (the worker
-    picker's read path). No file = no pool = no-op; a broker without the
-    endpoint (404) backs the push off an hour; nothing here may ever
-    break the task loop."""
+    picker's read path). An unavailable advertisement pushes NOTHING and
+    leaves the broker holding the last snapshot we sent; an unsupported
+    endpoint backs the push off an hour and any other HTTP status 5m;
+    nothing here may ever break the task loop."""
     global _workers_push_mtime, _workers_push_retry_at
     now = time.time()
     if now < _workers_push_retry_at:
         return False
-    mtime, ad = _read_pool_advertisement()
+    mtime, ad = _advertisement_or_none()
+    if ad is None:
+        return False
     if mtime <= _workers_push_mtime:
         return False
-    snap = ad.get("workers")
-    if not isinstance(snap, dict):
-        return False  # nothing to advertise yet; the next write retries
     try:
-        _req("POST", "/v1/workers", snap, timeout=15)
+        _req("POST", "/v1/workers", ad["workers"], timeout=15)
     except urllib.error.HTTPError as e:
-        _workers_push_retry_at = now + 3600
-        _log(f"workers-snapshot push deferred 1h (HTTP {e.code}"
-             f"{': broker has no /v1/workers yet' if e.code == 404 else ''})")
+        _workers_push_retry_at = _defer_push("workers-snapshot push", e, now)
         return False
     except Exception as e:  # noqa: BLE001 — relay must never kill the loop
         _workers_push_retry_at = now + 300
@@ -2474,29 +2518,30 @@ _profile_push_key = ""
 _profile_push_retry_at = 0.0
 
 
-def _build_agent_profile() -> "dict":
+def _build_agent_profile(workers: "dict") -> "dict":
     """The instance's identity card for PUT /v1/agents/{mxid}/profile.
     Only instance-authoritative fields — appearance is user/platform-owned
-    and the broker drops it from instance PUTs anyway."""
+    and the broker drops it from instance PUTs anyway.
+
+    `workers` comes from an advertisement the caller already established is
+    AVAILABLE: the broker REPLACES the profile document, so this function must
+    never be reached with a map it could not read."""
     name = (os.environ.get("SUTANDO_DISPLAY_NAME") or "Sutando").strip()
     try:
         host_id = socket.gethostname().split(".")[0]
     except OSError:
         host_id = "unknown-host"
-    card = {"display": {"name": name},
-            "host": {"host_id": host_id, "kind": "local"}}
-    # The broker REPLACES the profile document, so an omitted workers map
-    # deletes the pool the picker was drawing.
-    workers = _read_pool_advertisement()[1].get("profile_workers")
-    if isinstance(workers, dict):
-        card["workers"] = workers
-    return card
+    return {"display": {"name": name},
+            "host": {"host_id": host_id, "kind": "local"},
+            "workers": workers}
 
 
 def _maybe_push_agent_profile() -> bool:
-    """Push-on-change relay of the agent's profile card. Same failure
-    contract as the workers-snapshot push: 404 defers an hour (broker not
-    deployed yet), other errors 5m; nothing here may break the task loop."""
+    """Push-on-change relay of the agent's profile card. An unavailable
+    advertisement pushes NOTHING: the card carries the `workers` map the
+    picker draws and the broker REPLACES the document, so a card built from
+    a record we could not read would erase the pool. Same retry taxonomy as
+    the workers-snapshot push; nothing here may break the task loop."""
     global _profile_push_key, _profile_push_retry_at
     now = time.time()
     if now < _profile_push_retry_at:
@@ -2504,20 +2549,20 @@ def _maybe_push_agent_profile() -> bool:
     mxid = _reenroll_identity()
     if not mxid:
         return False  # identity may appear mid-episode; recheck next loop
-    card = _build_agent_profile()
+    mtime, ad = _advertisement_or_none()
+    if ad is None:
+        return False
+    card = _build_agent_profile(ad["profile_workers"])
     # The advertisement's mtime is in the key so a roster rewrite re-puts the
     # card even when the workers map serialises identically.
-    key = (f"{mxid}\n{_read_pool_advertisement()[0]}\n"
-           + json.dumps(card, sort_keys=True))
+    key = f"{mxid}\n{mtime}\n" + json.dumps(card, sort_keys=True)
     if key == _profile_push_key:
         return False
     try:
         _req("PUT", f"/v1/agents/{urllib.parse.quote(mxid)}/profile",
              card, timeout=15)
     except urllib.error.HTTPError as e:
-        _profile_push_retry_at = now + 3600
-        _log(f"agent-profile push deferred 1h (HTTP {e.code}"
-             f"{': broker has no profile API yet' if e.code == 404 else ''})")
+        _profile_push_retry_at = _defer_push("agent-profile push", e, now)
         return False
     except Exception as e:  # noqa: BLE001 — relay must never kill the loop
         _profile_push_retry_at = now + 300
@@ -4359,11 +4404,13 @@ def main() -> None:
                     _results_watcher.join(timeout=5)
                 return
             _post_heartbeat(inflight)
-            _maybe_push_workers_snapshot()
-            _maybe_push_agent_profile()
             _retry_pending_publications()
             _retry_review_card_resolutions()
             _retry_review_control_results()
+            # Behind the delivery retries: these are 15s best-effort pushes and
+            # must never sit between a pending result and its next attempt.
+            _maybe_push_workers_snapshot()
+            _maybe_push_agent_profile()
             try:
                 resp = _req("GET", f"/v1/tasks?wait={POLL_WAIT}", timeout=POLL_WAIT + 10)
                 last_poll_ok = time.time()

--- a/packages/ag2-sparrow/tests/test_pool_advertisement_push.py
+++ b/packages/ag2-sparrow/tests/test_pool_advertisement_push.py
@@ -1,9 +1,13 @@
 """The pool advertisement is what the broker draws the worker picker from.
 
 Both halves ship from one file: POST /v1/workers gives each row its STATUS,
-the profile card's `workers` map gives it a LABEL. A restart must re-send both
-— the broker REPLACES the profile document, so a card without `workers` wipes
-the pool it was showing.
+the profile card's `workers` map gives it a LABEL. The broker REPLACES the
+profile document, so a card sent without `workers` wipes the pool it was
+showing — which makes AVAILABILITY, not content, the load-bearing property
+these tests pin. The file is read-if-present and its producer ships separately
+(#4119): absent, unreadable, half-written and one-sided records are all
+UNAVAILABLE and must push NOTHING, while a valid record whose maps are empty
+is an intentional clear and must push.
 
 Run: python3 packages/ag2-sparrow/tests/test_pool_advertisement_push.py
 """
@@ -14,6 +18,7 @@ import pathlib
 import sys
 import tempfile
 import time
+import urllib.error
 
 MXID = "@sutando-test:ag2.space"
 W1 = "a3f91c2d4e5b6a7c8d9e0f1a2b3c4d5e"
@@ -36,9 +41,13 @@ def _load(base):
 
 
 def _advertise(m, record, age=0.0):
+    return _write_raw(m, json.dumps(record), age)
+
+
+def _write_raw(m, text, age=0.0):
     p = m._POOL_ADVERTISEMENT_FILE
     p.parent.mkdir(parents=True, exist_ok=True)
-    p.write_text(json.dumps(record))
+    p.write_text(text)
     if age:
         os.utime(p, (time.time() + age, time.time() + age))
     return p
@@ -50,6 +59,18 @@ def _record(ts=1):
             "profile_workers": {W1: {"label": "reviewer", "runtime": "codex"}}}
 
 
+def _capture(m):
+    calls = []
+    m._req = lambda *a, **k: calls.append(a) or {}
+    return calls
+
+
+def _raiser(code):
+    def boom(*a, **k):
+        raise urllib.error.HTTPError("https://gw.example/x", code, "e", {}, None)
+    return boom
+
+
 def test_boot_pushes_workers_and_a_card_carrying_them():
     """A fresh process has pushed nothing, so a file that predates it is new."""
     with tempfile.TemporaryDirectory() as d:
@@ -59,8 +80,7 @@ def test_boot_pushes_workers_and_a_card_carrying_them():
         (base / "state" / "pool-advertisement.json").write_text(
             json.dumps(_record()))
         m = _load(base)
-        calls = []
-        m._req = lambda *a, **k: calls.append(a) or {}
+        calls = _capture(m)
 
         assert m._maybe_push_workers_snapshot() is True
         assert m._maybe_push_agent_profile() is True
@@ -72,53 +92,122 @@ def test_boot_pushes_workers_and_a_card_carrying_them():
         print("PASS test_boot_pushes_workers_and_a_card_carrying_them")
 
 
-def test_no_advertisement_file_pushes_a_card_without_workers():
+def test_a_missing_file_pushes_nothing_at_all():
+    """Read-if-present: with no producer installed the bridge is a no-op, and
+    in particular does not PUT a card whose absent `workers` clears the pool."""
     with tempfile.TemporaryDirectory() as d:
         m = _load(pathlib.Path(d))
-        calls = []
-        m._req = lambda *a, **k: calls.append(a) or {}
+        calls = _capture(m)
 
         assert m._maybe_push_workers_snapshot() is False
+        assert m._maybe_push_agent_profile() is False
+        assert calls == [], "no advertisement = no request of either kind"
+        print("PASS test_a_missing_file_pushes_nothing_at_all")
+
+
+def test_malformed_json_pushes_nothing_and_keeps_the_prior_snapshot():
+    """valid -> mid-write truncation -> restored. The corrupt read must not
+    push, must not advance the push key, and must not disturb what the broker
+    is already holding; the restored read pushes the real map again."""
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        calls = _capture(m)
+        _advertise(m, _record(1))
+        assert m._maybe_push_workers_snapshot() is True
         assert m._maybe_push_agent_profile() is True
-        assert len(calls) == 1, "no pool = no /v1/workers request"
-        assert "workers" not in calls[0][2]
-        print("PASS test_no_advertisement_file_pushes_a_card_without_workers")
+        good_key, good_mtime = m._profile_push_key, m._workers_push_mtime
+
+        _write_raw(m, '{"workers": {"ts": 2}, "profile_wor', age=5)
+        assert m._maybe_push_workers_snapshot() is False
+        assert m._maybe_push_agent_profile() is False
+        assert len(calls) == 2, "a corrupt read issues no request"
+        assert m._profile_push_key == good_key, "prior card is still the live one"
+        assert m._workers_push_mtime == good_mtime, "prior snapshot is still live"
+
+        _advertise(m, _record(3), age=10)
+        assert m._maybe_push_workers_snapshot() is True
+        assert m._maybe_push_agent_profile() is True
+        assert calls[3][2]["workers"] == _record(3)["profile_workers"]
+        print("PASS test_malformed_json_pushes_nothing_and_keeps_the_prior_snapshot")
+
+
+def test_a_deleted_file_after_a_good_push_changes_nothing():
+    """valid -> missing. The pre-fix key (mxid + mtime 0.0 + a workers-less
+    card) was GUARANTEED to differ from the last one, so the push-on-change
+    guard fired exactly on the transition that erased the map."""
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        calls = _capture(m)
+        _advertise(m, _record(1))
+        assert m._maybe_push_agent_profile() is True
+        assert "workers" in calls[0][2]
+
+        m._POOL_ADVERTISEMENT_FILE.unlink()
+        assert m._maybe_push_agent_profile() is False
+        assert m._maybe_push_workers_snapshot() is False
+        assert len(calls) == 1, "the deletion is not a profile replacement"
+        print("PASS test_a_deleted_file_after_a_good_push_changes_nothing")
+
+
+def test_a_one_sided_record_pushes_neither_half():
+    """A status map with no label map would POST rows the card never names."""
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        calls = _capture(m)
+        _advertise(m, {"ts": 4, "workers": {"ts": 4, "live_cores": [W1]}})
+        assert m._maybe_push_workers_snapshot() is False
+        assert m._maybe_push_agent_profile() is False
+
+        _advertise(m, {"ts": 5, "profile_workers": {W1: {"label": "x"}}}, age=5)
+        assert m._maybe_push_workers_snapshot() is False
+        assert m._maybe_push_agent_profile() is False
+        assert calls == [], "one-sided is unavailable, not half-available"
+        print("PASS test_a_one_sided_record_pushes_neither_half")
+
+
+def test_a_valid_empty_map_is_an_intentional_clear_and_ships():
+    """The other side of the tri-state: "the pool is empty" is a fact the
+    picker must be told, and is not the same as "cannot read the pool"."""
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        calls = _capture(m)
+        _advertise(m, {"ts": 6, "workers": {"ts": 6, "live_cores": []},
+                       "profile_workers": {}})
+        assert m._maybe_push_workers_snapshot() is True
+        assert m._maybe_push_agent_profile() is True
+        assert calls[1][2]["workers"] == {}, "the empty map ships, explicitly"
+        print("PASS test_a_valid_empty_map_is_an_intentional_clear_and_ships")
 
 
 def test_a_file_without_the_keys_pushes_nothing_extra():
     """A half-written or foreign record must not blank the picker."""
     with tempfile.TemporaryDirectory() as d:
         m = _load(pathlib.Path(d))
-        calls = []
-        m._req = lambda *a, **k: calls.append(a) or {}
+        calls = _capture(m)
         _advertise(m, {"ts": 7})
 
         assert m._maybe_push_workers_snapshot() is False
-        assert m._maybe_push_agent_profile() is True
-        assert [c[1] for c in calls] == [
-            f"/v1/agents/{m.urllib.parse.quote(MXID)}/profile"]
-        assert "workers" not in calls[0][2]
+        assert m._maybe_push_agent_profile() is False
+        assert calls == []
         print("PASS test_a_file_without_the_keys_pushes_nothing_extra")
 
 
 def test_a_non_dict_workers_value_is_ignored():
     with tempfile.TemporaryDirectory() as d:
         m = _load(pathlib.Path(d))
-        calls = []
-        m._req = lambda *a, **k: calls.append(a) or {}
+        calls = _capture(m)
         _advertise(m, {"ts": 7, "workers": ["core-1"], "profile_workers": []})
 
         assert m._maybe_push_workers_snapshot() is False
-        assert m._maybe_push_agent_profile() is True
-        assert len(calls) == 1 and "workers" not in calls[0][2]
+        assert m._maybe_push_agent_profile() is False
+        assert calls == []
         print("PASS test_a_non_dict_workers_value_is_ignored")
 
 
 def test_a_later_mtime_repushes_both():
     with tempfile.TemporaryDirectory() as d:
         m = _load(pathlib.Path(d))
-        calls = []
-        m._req = lambda *a, **k: calls.append(a) or {}
+        calls = _capture(m)
         _advertise(m, _record(1))
         assert m._maybe_push_workers_snapshot() is True
         assert m._maybe_push_agent_profile() is True
@@ -140,8 +229,7 @@ def test_mtime_alone_repushes_the_card():
     """The roster is the authority; an identical serialisation still re-puts."""
     with tempfile.TemporaryDirectory() as d:
         m = _load(pathlib.Path(d))
-        calls = []
-        m._req = lambda *a, **k: calls.append(a) or {}
+        calls = _capture(m)
         _advertise(m, _record(1))
         assert m._maybe_push_agent_profile() is True
         _advertise(m, _record(1), age=5)
@@ -150,11 +238,101 @@ def test_mtime_alone_repushes_the_card():
         print("PASS test_mtime_alone_repushes_the_card")
 
 
+def test_a_server_error_takes_the_short_retry_not_the_hour():
+    """A transient 500 must not leave the picker stale for an hour."""
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        _advertise(m, _record(1))
+        m._req = _raiser(500)
+        t0 = time.time()
+        assert m._maybe_push_workers_snapshot() is False
+        assert m._maybe_push_agent_profile() is False
+        assert 250 < m._workers_push_retry_at - t0 < 350, "5m, not 1h"
+        assert 250 < m._profile_push_retry_at - t0 < 350, "5m, not 1h"
+        print("PASS test_a_server_error_takes_the_short_retry_not_the_hour")
+
+
+def test_an_auth_error_takes_the_short_retry_not_the_hour():
+    """401/403 is a live endpoint refusing us; recovery is minutes away."""
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        _advertise(m, _record(1))
+        m._req = _raiser(401)
+        t0 = time.time()
+        assert m._maybe_push_workers_snapshot() is False
+        assert m._maybe_push_agent_profile() is False
+        assert 250 < m._workers_push_retry_at - t0 < 350
+        assert 250 < m._profile_push_retry_at - t0 < 350
+        print("PASS test_an_auth_error_takes_the_short_retry_not_the_hour")
+
+
+def test_only_an_unsupported_endpoint_earns_the_hour_backoff():
+    """404/405/501 is the broker saying the route does not exist here."""
+    for code in (404, 405, 501):
+        with tempfile.TemporaryDirectory() as d:
+            m = _load(pathlib.Path(d))
+            _advertise(m, _record(1))
+            m._req = _raiser(code)
+            t0 = time.time()
+            assert m._maybe_push_workers_snapshot() is False
+            assert m._maybe_push_agent_profile() is False
+            assert 3550 < m._workers_push_retry_at - t0 < 3650, code
+            assert 3550 < m._profile_push_retry_at - t0 < 3650, code
+    print("PASS test_only_an_unsupported_endpoint_earns_the_hour_backoff")
+
+
+def test_a_network_error_keeps_the_five_minute_control():
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        _advertise(m, _record(1))
+
+        def urlerr(*a, **k):
+            raise urllib.error.URLError("connection refused")
+        m._req = urlerr
+        t0 = time.time()
+        assert m._maybe_push_workers_snapshot() is False
+        assert m._maybe_push_agent_profile() is False
+        assert 250 < m._workers_push_retry_at - t0 < 350
+        assert 250 < m._profile_push_retry_at - t0 < 350
+        print("PASS test_a_network_error_keeps_the_five_minute_control")
+
+
+def test_the_unavailable_edge_logs_once_not_every_pass():
+    """The loop calls these every few seconds; an absent producer would
+    otherwise write one line per pass forever."""
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        _capture(m)
+        lines = []
+        m._log = lines.append
+        for _ in range(5):
+            m._maybe_push_workers_snapshot()
+            m._maybe_push_agent_profile()
+        assert sum("unavailable" in ln for ln in lines) == 1, lines
+
+        _advertise(m, _record(1))
+        assert m._maybe_push_agent_profile() is True
+        assert sum("readable again" in ln for ln in lines) == 1, lines
+        m._POOL_ADVERTISEMENT_FILE.unlink()
+        m._maybe_push_agent_profile()
+        assert sum("unavailable" in ln for ln in lines) == 2, "re-armed per edge"
+        print("PASS test_the_unavailable_edge_logs_once_not_every_pass")
+
+
 if __name__ == "__main__":
     test_boot_pushes_workers_and_a_card_carrying_them()
-    test_no_advertisement_file_pushes_a_card_without_workers()
+    test_a_missing_file_pushes_nothing_at_all()
+    test_malformed_json_pushes_nothing_and_keeps_the_prior_snapshot()
+    test_a_deleted_file_after_a_good_push_changes_nothing()
+    test_a_one_sided_record_pushes_neither_half()
+    test_a_valid_empty_map_is_an_intentional_clear_and_ships()
     test_a_file_without_the_keys_pushes_nothing_extra()
     test_a_non_dict_workers_value_is_ignored()
     test_a_later_mtime_repushes_both()
     test_mtime_alone_repushes_the_card()
+    test_a_server_error_takes_the_short_retry_not_the_hour()
+    test_an_auth_error_takes_the_short_retry_not_the_hour()
+    test_only_an_unsupported_endpoint_earns_the_hour_backoff()
+    test_a_network_error_keeps_the_five_minute_control()
+    test_the_unavailable_edge_logs_once_not_every_pass()
     print("ALL PASS test_pool_advertisement_push")

--- a/packages/ag2-sparrow/tests/test_pool_advertisement_push.py
+++ b/packages/ag2-sparrow/tests/test_pool_advertisement_push.py
@@ -1,0 +1,160 @@
+"""The pool advertisement is what the broker draws the worker picker from.
+
+Both halves ship from one file: POST /v1/workers gives each row its STATUS,
+the profile card's `workers` map gives it a LABEL. A restart must re-send both
+— the broker REPLACES the profile document, so a card without `workers` wipes
+the pool it was showing.
+
+Run: python3 packages/ag2-sparrow/tests/test_pool_advertisement_push.py
+"""
+import importlib
+import json
+import os
+import pathlib
+import sys
+import tempfile
+import time
+
+MXID = "@sutando-test:ag2.space"
+W1 = "a3f91c2d4e5b6a7c8d9e0f1a2b3c4d5e"
+
+
+def _load(base):
+    os.environ["AGENT_CONNECT_TASK_DIR"] = str(base / "tasks")
+    os.environ["AGENT_CONNECT_RESULT_DIR"] = str(base / "results")
+    os.environ["AGENT_CONNECT_STATE_DIR"] = str(base / "state")
+    os.environ["AGENT_MXID"] = MXID
+    os.environ.pop("SUTANDO_DISPLAY_NAME", None)
+    os.environ.setdefault("REMOTE_TASK_URL", "https://gw.example/relay")
+    os.environ.setdefault("REMOTE_TASK_TOKEN", "dummy-secret")
+    sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+    mod = importlib.import_module("ag2_sparrow.remote_gateway_bridge")
+    m = importlib.reload(mod)
+    # hermetic: the channel .env fallback must not leak this host's identity
+    m._config_from_channel_env = lambda *a, **k: ""
+    return m
+
+
+def _advertise(m, record, age=0.0):
+    p = m._POOL_ADVERTISEMENT_FILE
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(record))
+    if age:
+        os.utime(p, (time.time() + age, time.time() + age))
+    return p
+
+
+def _record(ts=1):
+    return {"ts": ts,
+            "workers": {"ts": ts, "live_cores": [W1], "dead_cores": []},
+            "profile_workers": {W1: {"label": "reviewer", "runtime": "codex"}}}
+
+
+def test_boot_pushes_workers_and_a_card_carrying_them():
+    """A fresh process has pushed nothing, so a file that predates it is new."""
+    with tempfile.TemporaryDirectory() as d:
+        base = pathlib.Path(d)
+        os.environ["AGENT_CONNECT_STATE_DIR"] = str(base / "state")
+        (base / "state").mkdir(parents=True, exist_ok=True)
+        (base / "state" / "pool-advertisement.json").write_text(
+            json.dumps(_record()))
+        m = _load(base)
+        calls = []
+        m._req = lambda *a, **k: calls.append(a) or {}
+
+        assert m._maybe_push_workers_snapshot() is True
+        assert m._maybe_push_agent_profile() is True
+        assert calls[0][0] == "POST" and calls[0][1] == "/v1/workers"
+        assert calls[0][2] == _record()["workers"], "the body ships verbatim"
+        assert calls[1][0] == "PUT" and "/profile" in calls[1][1]
+        assert calls[1][2]["workers"] == _record()["profile_workers"]
+        assert calls[1][2]["display"]["name"] == "Sutando", "card keeps identity"
+        print("PASS test_boot_pushes_workers_and_a_card_carrying_them")
+
+
+def test_no_advertisement_file_pushes_a_card_without_workers():
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        calls = []
+        m._req = lambda *a, **k: calls.append(a) or {}
+
+        assert m._maybe_push_workers_snapshot() is False
+        assert m._maybe_push_agent_profile() is True
+        assert len(calls) == 1, "no pool = no /v1/workers request"
+        assert "workers" not in calls[0][2]
+        print("PASS test_no_advertisement_file_pushes_a_card_without_workers")
+
+
+def test_a_file_without_the_keys_pushes_nothing_extra():
+    """A half-written or foreign record must not blank the picker."""
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        calls = []
+        m._req = lambda *a, **k: calls.append(a) or {}
+        _advertise(m, {"ts": 7})
+
+        assert m._maybe_push_workers_snapshot() is False
+        assert m._maybe_push_agent_profile() is True
+        assert [c[1] for c in calls] == [
+            f"/v1/agents/{m.urllib.parse.quote(MXID)}/profile"]
+        assert "workers" not in calls[0][2]
+        print("PASS test_a_file_without_the_keys_pushes_nothing_extra")
+
+
+def test_a_non_dict_workers_value_is_ignored():
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        calls = []
+        m._req = lambda *a, **k: calls.append(a) or {}
+        _advertise(m, {"ts": 7, "workers": ["core-1"], "profile_workers": []})
+
+        assert m._maybe_push_workers_snapshot() is False
+        assert m._maybe_push_agent_profile() is True
+        assert len(calls) == 1 and "workers" not in calls[0][2]
+        print("PASS test_a_non_dict_workers_value_is_ignored")
+
+
+def test_a_later_mtime_repushes_both():
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        calls = []
+        m._req = lambda *a, **k: calls.append(a) or {}
+        _advertise(m, _record(1))
+        assert m._maybe_push_workers_snapshot() is True
+        assert m._maybe_push_agent_profile() is True
+        assert m._maybe_push_workers_snapshot() is False, "unchanged: no re-post"
+        assert m._maybe_push_agent_profile() is False, "unchanged: no re-put"
+        assert len(calls) == 2
+
+        rec = _record(2)
+        rec["profile_workers"][W1]["label"] = "shipper"
+        _advertise(m, rec, age=5)
+        assert m._maybe_push_workers_snapshot() is True
+        assert m._maybe_push_agent_profile() is True
+        assert calls[2][2] == rec["workers"]
+        assert calls[3][2]["workers"][W1]["label"] == "shipper"
+        print("PASS test_a_later_mtime_repushes_both")
+
+
+def test_mtime_alone_repushes_the_card():
+    """The roster is the authority; an identical serialisation still re-puts."""
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        calls = []
+        m._req = lambda *a, **k: calls.append(a) or {}
+        _advertise(m, _record(1))
+        assert m._maybe_push_agent_profile() is True
+        _advertise(m, _record(1), age=5)
+        assert m._maybe_push_agent_profile() is True, "mtime is part of the key"
+        assert len(calls) == 2
+        print("PASS test_mtime_alone_repushes_the_card")
+
+
+if __name__ == "__main__":
+    test_boot_pushes_workers_and_a_card_carrying_them()
+    test_no_advertisement_file_pushes_a_card_without_workers()
+    test_a_file_without_the_keys_pushes_nothing_extra()
+    test_a_non_dict_workers_value_is_ignored()
+    test_a_later_mtime_repushes_both()
+    test_mtime_alone_repushes_the_card()
+    print("ALL PASS test_pool_advertisement_push")

--- a/packages/ag2-sparrow/tests/test_pool_advertisement_push.py
+++ b/packages/ag2-sparrow/tests/test_pool_advertisement_push.py
@@ -115,14 +115,14 @@ def test_malformed_json_pushes_nothing_and_keeps_the_prior_snapshot():
         _advertise(m, _record(1))
         assert m._maybe_push_workers_snapshot() is True
         assert m._maybe_push_agent_profile() is True
-        good_key, good_mtime = m._profile_push_key, m._workers_push_mtime
+        good_key, good_id = m._profile_pushed_identity, m._workers_pushed_identity
 
         _write_raw(m, '{"workers": {"ts": 2}, "profile_wor', age=5)
         assert m._maybe_push_workers_snapshot() is False
         assert m._maybe_push_agent_profile() is False
         assert len(calls) == 2, "a corrupt read issues no request"
-        assert m._profile_push_key == good_key, "prior card is still the live one"
-        assert m._workers_push_mtime == good_mtime, "prior snapshot is still live"
+        assert m._profile_pushed_identity == good_key, "prior card is still the live one"
+        assert m._workers_pushed_identity == good_id, "prior snapshot is still live"
 
         _advertise(m, _record(3), age=10)
         assert m._maybe_push_workers_snapshot() is True
@@ -244,7 +244,7 @@ def test_a_parser_failure_of_any_kind_is_unavailable_not_a_stalled_poll():
 
         real_path = m._POOL_ADVERTISEMENT_FILE
         m._POOL_ADVERTISEMENT_FILE = _ReadRaises(RecursionError("maximum recursion depth exceeded"))
-        assert m._read_pool_advertisement() == (0.0, None), "the UNAVAILABLE sentinel"
+        assert m._read_pool_advertisement() == ("", None), "the UNAVAILABLE sentinel"
         assert m._maybe_push_workers_snapshot() is False
         assert m._maybe_push_agent_profile() is False
         assert len(calls) == n, "a parser failure issues no request"
@@ -268,7 +268,7 @@ def test_an_oversized_record_is_unavailable_before_it_is_parsed():
         rec = _record(1)
         rec["pad"] = "x" * m._POOL_ADVERTISEMENT_MAX_BYTES
         _advertise(m, rec)
-        assert m._read_pool_advertisement() == (0.0, None)
+        assert m._read_pool_advertisement() == ("", None)
         assert m._maybe_push_workers_snapshot() is False
         assert m._maybe_push_agent_profile() is False
         assert calls == [], "an oversized record pushes nothing"
@@ -300,17 +300,56 @@ def test_a_later_mtime_repushes_both():
         print("PASS test_a_later_mtime_repushes_both")
 
 
-def test_mtime_alone_repushes_the_card():
-    """The roster is the authority; an identical serialisation still re-puts."""
+def test_a_bumped_mtime_with_unchanged_content_repushes_neither():
+    """Content, not mtime, is the change identity — for BOTH halves."""
     with tempfile.TemporaryDirectory() as d:
         m = _load(pathlib.Path(d))
         calls = _capture(m)
         _advertise(m, _record(1))
+        assert m._maybe_push_workers_snapshot() is True
         assert m._maybe_push_agent_profile() is True
         _advertise(m, _record(1), age=5)
-        assert m._maybe_push_agent_profile() is True, "mtime is part of the key"
+        assert m._maybe_push_workers_snapshot() is False, "same content: no re-post"
+        assert m._maybe_push_agent_profile() is False, "same content: no re-put"
         assert len(calls) == 2
-        print("PASS test_mtime_alone_repushes_the_card")
+        print("PASS test_a_bumped_mtime_with_unchanged_content_repushes_neither")
+
+
+def test_a_restore_at_or_below_the_prior_mtime_repushes_both():
+    """valid -> missing -> restored with a LOWER, then an EQUAL, mtime. Keyed
+    on mtime as a high-water mark the workers POST skipped the restore while
+    the profile (keyed on content) advanced, so /v1/workers sat on revision 1
+    under a card already labelling revision 2 until a later mtime arrived."""
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        calls = _capture(m)
+        _advertise(m, _record(1))
+        first_mtime = m._POOL_ADVERTISEMENT_FILE.stat().st_mtime
+        assert m._maybe_push_workers_snapshot() is True
+        assert m._maybe_push_agent_profile() is True
+
+        m._POOL_ADVERTISEMENT_FILE.unlink()
+        assert m._maybe_push_workers_snapshot() is False
+        assert m._maybe_push_agent_profile() is False
+
+        rec = _record(2)
+        rec["profile_workers"][W1]["label"] = "restored"
+        _advertise(m, rec, age=-10)
+        assert m._POOL_ADVERTISEMENT_FILE.stat().st_mtime < first_mtime
+        assert m._maybe_push_workers_snapshot() is True, "lower mtime, new content"
+        assert m._maybe_push_agent_profile() is True
+        assert [c[2]["ts"] for c in calls if c[0] == "POST"] == [1, 2]
+        assert [c[2]["workers"][W1]["label"] for c in calls if c[0] == "PUT"] == [
+            "reviewer", "restored"]
+
+        rec = _record(3)
+        rec["profile_workers"][W1]["label"] = "again"
+        p = _advertise(m, rec)
+        os.utime(p, (first_mtime, first_mtime))
+        assert m._maybe_push_workers_snapshot() is True, "equal mtime, new content"
+        assert m._maybe_push_agent_profile() is True
+        assert calls[-2][2]["ts"] == 3 and calls[-1][2]["workers"][W1]["label"] == "again"
+        print("PASS test_a_restore_at_or_below_the_prior_mtime_repushes_both")
 
 
 def test_a_server_error_takes_the_short_retry_not_the_hour():
@@ -406,7 +445,8 @@ if __name__ == "__main__":
     test_a_parser_failure_of_any_kind_is_unavailable_not_a_stalled_poll()
     test_an_oversized_record_is_unavailable_before_it_is_parsed()
     test_a_later_mtime_repushes_both()
-    test_mtime_alone_repushes_the_card()
+    test_a_bumped_mtime_with_unchanged_content_repushes_neither()
+    test_a_restore_at_or_below_the_prior_mtime_repushes_both()
     test_a_server_error_takes_the_short_retry_not_the_hour()
     test_an_auth_error_takes_the_short_retry_not_the_hour()
     test_only_an_unsupported_endpoint_earns_the_hour_backoff()

--- a/packages/ag2-sparrow/tests/test_pool_advertisement_push.py
+++ b/packages/ag2-sparrow/tests/test_pool_advertisement_push.py
@@ -204,6 +204,81 @@ def test_a_non_dict_workers_value_is_ignored():
         print("PASS test_a_non_dict_workers_value_is_ignored")
 
 
+class _ReadRaises:
+    """A stand-in for the advertisement path whose read fails the way a
+    parser does: the exception the loop must survive is not an OSError."""
+    name = "pool-advertisement.json"
+
+    def __init__(self, exc):
+        self._exc = exc
+
+    def stat(self):
+        return os.stat_result((0o100644, 0, 0, 1, 0, 0, 64, 0, 0, 0))
+
+    def read_text(self):
+        raise self._exc
+
+
+def test_a_parser_failure_of_any_kind_is_unavailable_not_a_stalled_poll():
+    """The reviewer's input: a record carrying both maps plus an unknown
+    1,000-deep array. Older json decoders raise RecursionError on it, and the
+    read runs in the loop BEFORE the task poll, where an escaping exception
+    backs off and retries the same file forever. Whether or not this
+    interpreter's decoder is the recursive one, the read must not raise and
+    the unknown key must change nothing; the injected RecursionError then pins
+    the UNAVAILABLE path on every interpreter."""
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        calls = _capture(m)
+        rec = _record(1)
+        deep = json.dumps(rec)[:-1] + ', "junk": ' + "[" * 1000 + "]" * 1000 + "}"
+        _write_raw(m, deep)
+        _, ad = m._read_pool_advertisement()  # must not raise
+        pushed = m._maybe_push_workers_snapshot()
+        assert m._maybe_push_agent_profile() is pushed
+        if ad is None:
+            assert calls == [], "UNAVAILABLE pushes nothing"
+        else:
+            assert calls[0][2] == rec["workers"], "the unknown key ships nothing"
+        n = len(calls)
+
+        real_path = m._POOL_ADVERTISEMENT_FILE
+        m._POOL_ADVERTISEMENT_FILE = _ReadRaises(RecursionError("maximum recursion depth exceeded"))
+        assert m._read_pool_advertisement() == (0.0, None), "the UNAVAILABLE sentinel"
+        assert m._maybe_push_workers_snapshot() is False
+        assert m._maybe_push_agent_profile() is False
+        assert len(calls) == n, "a parser failure issues no request"
+
+        m._POOL_ADVERTISEMENT_FILE = real_path
+        rec = _record(2)
+        rec["profile_workers"][W1]["label"] = "after"
+        _advertise(m, rec, age=5)
+        assert m._maybe_push_workers_snapshot() is True, "positive control"
+        assert m._maybe_push_agent_profile() is True
+        assert calls[-1][2]["workers"][W1]["label"] == "after"
+        print("PASS test_a_parser_failure_of_any_kind_is_unavailable_not_a_stalled_poll")
+
+
+def test_an_oversized_record_is_unavailable_before_it_is_parsed():
+    """The record is bounded by size before the parse: a runaway file is
+    UNAVAILABLE at the stat, not a full read-and-decode on every loop pass."""
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        calls = _capture(m)
+        rec = _record(1)
+        rec["pad"] = "x" * m._POOL_ADVERTISEMENT_MAX_BYTES
+        _advertise(m, rec)
+        assert m._read_pool_advertisement() == (0.0, None)
+        assert m._maybe_push_workers_snapshot() is False
+        assert m._maybe_push_agent_profile() is False
+        assert calls == [], "an oversized record pushes nothing"
+
+        _advertise(m, _record(2), age=5)
+        assert m._maybe_push_workers_snapshot() is True, "positive control"
+        assert m._maybe_push_agent_profile() is True
+        print("PASS test_an_oversized_record_is_unavailable_before_it_is_parsed")
+
+
 def test_a_later_mtime_repushes_both():
     with tempfile.TemporaryDirectory() as d:
         m = _load(pathlib.Path(d))
@@ -328,6 +403,8 @@ if __name__ == "__main__":
     test_a_valid_empty_map_is_an_intentional_clear_and_ships()
     test_a_file_without_the_keys_pushes_nothing_extra()
     test_a_non_dict_workers_value_is_ignored()
+    test_a_parser_failure_of_any_kind_is_unavailable_not_a_stalled_poll()
+    test_an_oversized_record_is_unavailable_before_it_is_parsed()
     test_a_later_mtime_repushes_both()
     test_mtime_alone_repushes_the_card()
     test_a_server_error_takes_the_short_retry_not_the_hour()


### PR DESCRIPTION
## What

The gateway bridge learns to advertise the worker pool: it reads `state/pool-advertisement.json` (written by the pool side from the roster, #4119) and POSTs its `workers` body to `/v1/workers` on boot and on every change, and it carries the file's `profile_workers` map on the agent profile card it PUTs. The broker replaces the profile document, so a card without `workers` erases the map the worker picker draws from — that is what happened on production on 2026-09-10 after a core restart, when the rescue-line bridge re-sent a snapshot frozen since 09-08 and a workers-less card, and the owner's binding vanished from both clients.

Stacked on #4115 (`feat/create-worker-command`), per the owner: `#4106 → #4107 → #4109 → #4108 → {#4110, #4115 → this}`. Replaces #4161, which fixed the same defect on the rescue branch; that PR closes with this one open.

## This PR is the READER. The producer lands with #4119.

`src/pool_advertise.py` — the thing that writes `pool-advertisement.json` — lives on `feat/advertise-pool-to-broker` (#4119), a sibling branch whose merge-base with this one is this PR's own base `c73f8e97`. It is **not** an ancestor here, and `git grep pool-advertisement` at this head finds only this reader and its tests. That is deliberate, and after @keweichen's review it is also **explicit and enforced**:

> **The advertisement file is read-if-present. Absence pushes NOTHING** — not a workers snapshot, and not an identity-only profile card. `main` has no profile PUT at all, so an installation with no producer behaves exactly as it does today; it is a no-op, never a regression, and never a destructive replacement.

`test_a_missing_file_pushes_nothing_at_all` pins that contract without the producer present.

**Open sequencing question for the owner — I am not deciding it.** This PR can stay based on #4115 and be read-only tolerant of the producer's absence (current state), **or** its base can be changed to #4119 so the producer is an ancestor and the stack ships end to end. There is a third option: land as-is and put the boot/upgrade backfill of an existing `state/roster.json` on #4119, where the writer already is. @keweichen @john-the-dev — which do you want?

## Review fixes (head `6c667d2f4`, on top of the reviewed `f3b1fa452`)

**[P1] An unavailable advertisement no longer changes anything.** Availability is a tri-state; `None` is the only "cannot read it" value. Both halves are validated from one read, so a one-sided record is *unavailable*, not half-available. A valid record whose maps are empty stays AVAILABLE and ships — "the pool is empty" is a fact the picker must be told. Unavailable skips both pushes, logs once per edge, and leaves the broker holding the last state we sent. `_build_agent_profile` now takes the map as an argument, so it cannot be reached with a map nobody validated.

@keweichen's own capture, parent `f3b1fa452` → HEAD `6c667d2f4`:

```
                   parent f3b1fa452                     HEAD 6c667d2f4
valid              put=True  ['display','host','workers']  put=True  ['display','host','workers']
unchanged-control  put=False                               put=False
corrupt            put=True  ['display','host']            put=False
restored           put=True  ['display','host','workers']  put=True  ['display','host','workers']
missing            put=True  ['display','host']            put=False
put-workers-presence  [True, False, True, False]           [True, True]

one-sided record   [('POST','/v1/workers',False),          []
                    ('PUT','…/profile',False)]
```

**[P2] Only an unsupported endpoint earns the hour.** 404/405/501 is the broker saying the route does not exist here; every other status is a live endpoint failing and takes the 5m retry. The log line says which.

```
code               parent   HEAD
404                 3600s    3600s
500                 3600s     300s
503                 3600s     300s
401                 3600s     300s
URLError control     300s     300s
```

**@john-the-dev's ordering note.** The two 15 s pushes now sit behind `_retry_pending_publications()` — a best-effort relay must not sit between a pending result and its next delivery attempt.

## Evidence

`/usr/bin/python3 -m pytest tests/test_pool_advertisement_push.py -q` in `packages/ag2-sparrow`:

```
...............                                                          [100%]
15 passed in 0.19s
```

Controls — the same 15 tests against older code:

```
vs the reviewed head f3b1fa452:  9 failed, 6 passed
  test_a_missing_file_pushes_nothing_at_all
  test_malformed_json_pushes_nothing_and_keeps_the_prior_snapshot
  test_a_deleted_file_after_a_good_push_changes_nothing
  test_a_one_sided_record_pushes_neither_half
  test_a_file_without_the_keys_pushes_nothing_extra
  test_a_non_dict_workers_value_is_ignored
  test_a_server_error_takes_the_short_retry_not_the_hour
  test_an_auth_error_takes_the_short_retry_not_the_hour
  test_the_unavailable_edge_logs_once_not_every_pass
vs the base c73f8e97c:          15 failed   (no advertisement reader exists there)
```

Whole package suite: `/usr/bin/python3 -m pytest tests -q` → `130 passed in 7.17s`. `tools/test_no_drift.py` → `PASS — package in sync with src/`. Repo gate on the cumulative diff vs the base (`git diff c73f8e97c > /tmp/f4162.diff && bash scripts/review-checks.sh --diff /tmp/f4162.diff`) → `review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)`. `git diff --check c73f8e97c` clean.

Pre-existing on the base, not touched here: `tests/remote-gateway-bridge.test.py` fails 5 proactive-send retry cases identically without this diff.

**Live-path witness still outstanding.** The post-restart round trip on the production lane at *this* head has not been run — it needs the owner's go, and is reported in this thread when it is. The picker observation in the earlier version of this body came from the rescue-line commit and is not a witness for this head; treat it as absent.

`.github/workflows/ci.yml` gains one line because the package tests are listed explicitly, not globbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
