### PR TITLE
fix(x-twitter): wait for Chrome to exit before SIGKILL, so the cookie jar flushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,7 +253,12 @@ jobs:
               echo "$output"
               failed=1
             else
-              echo "$output" | grep -E 'FAIL|^all ok' || true
+              # Every suite must contribute a visible verdict. With a narrower
+              # pattern four of seven printed nothing, so a step that ran
+              # everything looked like a loop that matched no files — a green
+              # indistinguishable from absence. `tail -1` is the backstop for a
+              # suite whose closing line matches none of these.
+              echo "$output" | grep -E 'FAIL|^all ok|^all passed|^PASS' || echo "$output" | tail -1
             fi
           done < <(find tests -name '*.test.mjs' -not -path '*/node_modules/*' | sort)
           exit "$failed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,27 @@ jobs:
           done < <(find tests -name '*.test.sh' -not -path '*/node_modules/*' | sort)
           exit "$failed"
 
+      # Run standalone ESM tests (*.test.mjs). Same gap as #1934, one extension
+      # later: these suites existed and CI discovered none of them, so a .mjs
+      # suite could fail at HEAD while the run reported green.
+      - name: Run ESM standalone tests
+        run: |
+          failed=0
+          while IFS= read -r f; do
+            echo "→ $f"
+            # Same `if ! output=$(...)` form as the shell step: a bare assignment
+            # would abort the whole step under `bash -e` on the first failure and
+            # mask every later suite.
+            if ! output=$(timeout -k 5 300 node "$f" 2>&1); then
+              echo "✖ esm test failed: $f"
+              echo "$output"
+              failed=1
+            else
+              echo "$output" | grep -E 'FAIL|^all ok' || true
+            fi
+          done < <(find tests -name '*.test.mjs' -not -path '*/node_modules/*' | sort)
+          exit "$failed"
+
   python-standalone-tests:
     name: python standalone tests
     runs-on: ubuntu-latest

--- a/skills/x-twitter/manifest.json
+++ b/skills/x-twitter/manifest.json
@@ -15,7 +15,8 @@
   "config": {
     "X_BROWSER_PROFILE": "",
     "X_LOGIN_DONE_SENTINEL": "/tmp/x-login-done",
-    "X_LOGIN_TIMEOUT_ITERS": "120"
+    "X_LOGIN_TIMEOUT_ITERS": "120",
+    "X_PROFILE_GRACE_MS": "10000"
   },
   "provenance": {
     "source_repo": "https://github.com/sonichi/sutando"

--- a/skills/x-twitter/profile-lock-wait.mjs
+++ b/skills/x-twitter/profile-lock-wait.mjs
@@ -17,7 +17,10 @@
  */
 export function waitForProfileExit(probe, graceMs, sleep, now = Date.now) {
   const start = now();
-  const deadline = start + graceMs;
+  // A non-finite grace makes every `now() >= start + graceMs` false and the loop
+  // never exits — `Number('abc')` is NaN, and an env var is the usual source.
+  const grace = Number.isFinite(graceMs) && graceMs >= 0 ? graceMs : 0;
+  const deadline = start + grace;
   for (;;) {
     const p = probe();
     const remaining = p.known ? p.pids : [];

--- a/skills/x-twitter/profile-lock-wait.mjs
+++ b/skills/x-twitter/profile-lock-wait.mjs
@@ -1,0 +1,33 @@
+// The wait between SIGTERM and SIGKILL, extracted so a test can drive it with a
+// fake probe — the same reason readLanding lives outside x-post-browser.mjs.
+//
+// Chrome writes its cookie jar lazily and flushes on clean shutdown. Killing on a
+// fixed 1s timer forces the jar whether or not the flush happened, which drops every
+// cookie set since the last write — i.e. exactly the auth cookies from a fresh sign-in.
+
+/**
+ * SIGTERM has been sent; wait for the holders to go, then report what outlived the grace.
+ *
+ * @param probe    () => {known: boolean, pids: string[]} — an UNKNOWN probe never
+ *                 reports "free", so a broken lsof cannot authorise a kill.
+ * @param graceMs  how long a holder gets to flush and exit.
+ * @param sleep    (ms) => void, injected so a test does not spend real time.
+ * @param now      () => epoch ms, injected for the same reason.
+ * @returns {{remaining: string[], exitedCleanly: boolean, waitedMs: number}}
+ */
+export function waitForProfileExit(probe, graceMs, sleep, now = Date.now) {
+  const start = now();
+  const deadline = start + graceMs;
+  for (;;) {
+    const p = probe();
+    const remaining = p.known ? p.pids : [];
+    // known && empty is the only state that means "gone"; an unknown probe is not it.
+    if (p.known && remaining.length === 0) {
+      return { remaining: [], exitedCleanly: true, waitedMs: now() - start };
+    }
+    if (now() >= deadline) {
+      return { remaining, exitedCleanly: false, waitedMs: now() - start };
+    }
+    sleep(250);
+  }
+}

--- a/skills/x-twitter/x-post-browser.mjs
+++ b/skills/x-twitter/x-post-browser.mjs
@@ -236,7 +236,7 @@ function releaseProfileLock() {
   // that flush drops every cookie set since the last write — which is exactly the
   // auth cookies from a sign-in that just happened.
   const graceMs = Number(process.env.X_PROFILE_GRACE_MS || 10000);
-  const { remaining, waitedMs } = waitForProfileExit(
+  const { remaining, waitedMs, exitedCleanly } = waitForProfileExit(
     pidsForProfile,
     graceMs,
     (ms) => { try { execFileSync('sleep', [String(ms / 1000)]); } catch {} },
@@ -246,7 +246,7 @@ function releaseProfileLock() {
   // they exited on their own, and how long it took.
   console.error(
     `profile-lock: SIGTERM->[${signalled.join(',') || 'none'}] ` +
-    `exited_cleanly=${remaining.length === 0} waited_ms=${waitedMs} ` +
+    `exited_cleanly=${exitedCleanly} waited_ms=${waitedMs} ` +
     `sigkilled=[${remaining.join(',') || 'none'}]`,
   );
   try {

--- a/skills/x-twitter/x-post-browser.mjs
+++ b/skills/x-twitter/x-post-browser.mjs
@@ -45,6 +45,7 @@ import { fileURLToPath } from 'node:url';
 import { execFileSync } from 'node:child_process';
 import { normalizeComposerText, composerMatches } from './composer-text.mjs';
 import { gcftPids, classifyLsofProbe, execTimedOut } from './profile-match.mjs';
+import { waitForProfileExit } from './profile-lock-wait.mjs';
 import { readLanding, landingExit } from './landing-check.mjs';
 import { resolveProfileDir } from './profile-dir.mjs';
 import { readManifestConfig, resolveSetting } from './manifest-config.mjs';
@@ -229,9 +230,18 @@ function releaseProfileLock() {
       try { process.kill(parseInt(pid, 10), 'SIGTERM'); } catch {}
     }
   } catch {}
-  try { execFileSync('sleep', ['1']); } catch {}
+  // WAIT for the SIGTERM to be honoured instead of killing on a fixed 1s. Chrome
+  // writes its cookie jar lazily and flushes on clean shutdown; a SIGKILL before
+  // that flush drops every cookie set since the last write — which is exactly the
+  // auth cookies from a sign-in that just happened.
+  const graceMs = Number(process.env.X_PROFILE_GRACE_MS || 10000);
+  const { remaining } = waitForProfileExit(
+    pidsForProfile,
+    graceMs,
+    (ms) => { try { execFileSync('sleep', [String(ms / 1000)]); } catch {} },
+  );
   try {
-    for (const pid of pidsForProfile().pids) {
+    for (const pid of remaining) {
       try { process.kill(parseInt(pid, 10), 'SIGKILL'); } catch {}
     }
   } catch {}

--- a/skills/x-twitter/x-post-browser.mjs
+++ b/skills/x-twitter/x-post-browser.mjs
@@ -225,9 +225,10 @@ function pidsForProfile() {
 /** Kill any GCfT holding THIS profile and clear the SingletonLock, so the next
  *  launch (open or Playwright) doesn't collide on the single-instance lock. */
 function releaseProfileLock() {
+  const signalled = [];
   try {
     for (const pid of pidsForProfile().pids) {
-      try { process.kill(parseInt(pid, 10), 'SIGTERM'); } catch {}
+      try { process.kill(parseInt(pid, 10), 'SIGTERM'); signalled.push(pid); } catch {}
     }
   } catch {}
   // WAIT for the SIGTERM to be honoured instead of killing on a fixed 1s. Chrome
@@ -235,10 +236,18 @@ function releaseProfileLock() {
   // that flush drops every cookie set since the last write — which is exactly the
   // auth cookies from a sign-in that just happened.
   const graceMs = Number(process.env.X_PROFILE_GRACE_MS || 10000);
-  const { remaining } = waitForProfileExit(
+  const { remaining, waitedMs } = waitForProfileExit(
     pidsForProfile,
     graceMs,
     (ms) => { try { execFileSync('sleep', [String(ms / 1000)]); } catch {} },
+  );
+  // Say what happened, so a surviving session is evidence the grace ENGAGED rather
+  // than an absence anyone can read either way: which pids were signalled, whether
+  // they exited on their own, and how long it took.
+  console.error(
+    `profile-lock: SIGTERM->[${signalled.join(',') || 'none'}] ` +
+    `exited_cleanly=${remaining.length === 0} waited_ms=${waitedMs} ` +
+    `sigkilled=[${remaining.join(',') || 'none'}]`,
   );
   try {
     for (const pid of remaining) {

--- a/skills/x-twitter/x-post-browser.mjs
+++ b/skills/x-twitter/x-post-browser.mjs
@@ -235,7 +235,7 @@ function releaseProfileLock() {
   // writes its cookie jar lazily and flushes on clean shutdown; a SIGKILL before
   // that flush drops every cookie set since the last write — which is exactly the
   // auth cookies from a sign-in that just happened.
-  const graceMs = Number(process.env.X_PROFILE_GRACE_MS || 10000);
+  const graceMs = Number(setting('X_PROFILE_GRACE_MS', '10000'));
   const { remaining, waitedMs, exitedCleanly } = waitForProfileExit(
     pidsForProfile,
     graceMs,

--- a/tests/x-profile-lock-log-line.test.mjs
+++ b/tests/x-profile-lock-log-line.test.mjs
@@ -1,0 +1,38 @@
+// The CALLER's log line, not the unit. `waitForProfileExit` returns
+// `exitedCleanly` and `remaining` that DISAGREE under an unknown probe; an
+// earlier version of the log recomputed cleanliness from `remaining`, so an
+// unreadable probe printed exited_cleanly=true.
+//
+// tests/x-profile-lock-wait.test.mjs pins the unit's disagreement, which is why
+// reverting the caller's destructure left THAT suite 12/12 — the claim that the
+// substitution cannot come back was about a line no test read. This reads it.
+//
+// Run: node tests/x-profile-lock-log-line.test.mjs
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const REPO = dirname(dirname(fileURLToPath(import.meta.url)));
+const SRC = readFileSync(join(REPO, 'skills/x-twitter/x-post-browser.mjs'), 'utf8');
+let fails = 0;
+const ck = (n, c) => { console.log((c ? '  ok   ' : '  FAIL ') + n); if (!c) fails++; };
+
+// Isolate the emitting statement rather than scanning the whole file, so an
+// unrelated `remaining.length` elsewhere cannot satisfy or break this.
+const m = SRC.match(/console\.error\(\s*`profile-lock:[\s\S]*?\);/);
+ck('the profile-lock log statement exists', !!m);
+const stmt = m ? m[0] : '';
+
+ck('it prints the exitedCleanly the unit returned', /exited_cleanly=\$\{exitedCleanly\}/.test(stmt));
+ck('it does NOT recompute cleanliness from remaining',
+   !/exited_cleanly=\$\{[^}]*remaining[^}]*\}/.test(stmt));
+ck('the caller actually destructures exitedCleanly',
+   /const\s*\{[^}]*\bexitedCleanly\b[^}]*\}\s*=\s*waitForProfileExit/.test(SRC));
+
+// The three observations a surviving session needs to mean anything.
+ck('it names which pids were signalled', /SIGTERM->\[\$\{signalled/.test(stmt));
+ck('it reports the wait duration', /waited_ms=\$\{waitedMs\}/.test(stmt));
+ck('it reports what was force-killed', /sigkilled=\[\$\{remaining/.test(stmt));
+
+console.log(fails === 0 ? '\nall ok' : `\n${fails} FAILED`);
+process.exit(fails === 0 ? 0 : 1);

--- a/tests/x-profile-lock-wait.test.mjs
+++ b/tests/x-profile-lock-wait.test.mjs
@@ -1,0 +1,61 @@
+// The defect: releaseProfileLock() SIGTERMed, slept a fixed 1s, then SIGKILLed every
+// holder — forcing Chrome down whether or not it had flushed its cookie jar. A
+// sign-in's auth cookies are the newest thing in that jar, so they are what is lost.
+//
+// Run: node tests/x-profile-lock-wait.test.mjs
+import { waitForProfileExit } from '../skills/x-twitter/profile-lock-wait.mjs';
+
+let fails = 0;
+const ck = (name, cond) => { console.log((cond ? '  ok   ' : '  FAIL ') + name); if (!cond) fails++; };
+
+// A fake clock: sleep advances it, so grace is measured without spending time.
+function clock() {
+  let t = 0;
+  return { now: () => t, sleep: (ms) => { t += ms; } };
+}
+/** A holder that exits after `afterMs` of grace. */
+function holder(afterMs, c, known = true) {
+  return () => ({ known, pids: c.now() >= afterMs ? [] : ['4242'] });
+}
+
+// 1. A well-behaved Chrome exits on SIGTERM and must NOT be killed — the whole point.
+{
+  const c = clock();
+  const r = waitForProfileExit(holder(500, c), 10000, c.sleep, c.now);
+  ck('a holder that exits during grace is NOT force-killed', r.remaining.length === 0 && r.exitedCleanly);
+  ck('it returns as soon as the holder is gone, not at the deadline', r.waitedMs < 1000);
+}
+// 2. The old behaviour must be impossible: at 1s a slow-but-honest Chrome still had it.
+{
+  const c = clock();
+  const r = waitForProfileExit(holder(3000, c), 10000, c.sleep, c.now);
+  ck('a holder needing 3s (the old 1s timer killed it) now survives', r.exitedCleanly);
+}
+// 3. A genuinely stuck holder is still forced — the lock must not regress into a hang.
+{
+  const c = clock();
+  const r = waitForProfileExit(() => ({ known: true, pids: ['99'] }), 2000, c.sleep, c.now);
+  ck('a holder that ignores SIGTERM IS reported for SIGKILL', !r.exitedCleanly && r.remaining[0] === '99');
+  ck('and only after the full grace period', r.waitedMs >= 2000);
+}
+// 4. An UNKNOWN probe must never read as "free" — that is what would let a second
+//    Chrome launch against a live profile (the corruption this lock exists to prevent).
+{
+  const c = clock();
+  const r = waitForProfileExit(() => ({ known: false, pids: [] }), 1000, c.sleep, c.now);
+  ck('an unknown probe never reports a clean exit', r.exitedCleanly === false);
+}
+// 5. CONTROL — the old implementation must FAIL these. Fixed 1s, then kill regardless.
+{
+  const c = clock();
+  const oldImpl = (probe, _grace, sleep, now) => {
+    sleep(1000);
+    const p = probe();
+    return { remaining: p.known ? p.pids : [], exitedCleanly: false, waitedMs: now() - 0 };
+  };
+  const r = oldImpl(holder(3000, c), 10000, c.sleep, c.now);
+  ck('CONTROL: the old fixed-1s path kills the 3s holder', r.remaining.length === 1 && !r.exitedCleanly);
+}
+
+console.log(fails === 0 ? '\nall ok' : `\n${fails} FAILED`);
+process.exit(fails === 0 ? 0 : 1);

--- a/tests/x-profile-lock-wait.test.mjs
+++ b/tests/x-profile-lock-wait.test.mjs
@@ -57,5 +57,27 @@ function holder(afterMs, c, known = true) {
   ck('CONTROL: the old fixed-1s path kills the 3s holder', r.remaining.length === 1 && !r.exitedCleanly);
 }
 
+// 6. A non-finite grace must not hang. `Number('abc')` is NaN and an env var is
+//    the usual source; `now() >= start + NaN` is never true, so the loop runs forever.
+{
+  const c = clock();
+  let iters = 0;
+  const counting = () => { iters++; if (iters > 1000) throw new Error('did not terminate'); return { known: true, pids: ['7'] }; };
+  let threw = null;
+  try { waitForProfileExit(counting, Number('abc'), c.sleep, c.now); } catch (e) { threw = e; }
+  ck('a NaN grace terminates instead of spinning', threw === null);
+  ck('and it does not silently wait forever', iters <= 2);
+}
+// 7. exitedCleanly and remaining DISAGREE under an unknown probe — that disagreement
+//    is the flag's whole purpose, so anything recomputing it from `remaining` is wrong.
+{
+  const c = clock();
+  const r = waitForProfileExit(() => ({ known: false, pids: [] }), 1000, c.sleep, c.now);
+  ck('unknown probe: remaining is empty', r.remaining.length === 0);
+  ck('unknown probe: exitedCleanly is FALSE despite that', r.exitedCleanly === false);
+  ck('so remaining.length===0 is NOT a substitute for exitedCleanly',
+     (r.remaining.length === 0) !== r.exitedCleanly);
+}
+
 console.log(fails === 0 ? '\nall ok' : `\n${fails} FAILED`);
 process.exit(fails === 0 ? 0 : 1);


### PR DESCRIPTION
## The defect

`releaseProfileLock()` sent SIGTERM, slept a fixed **1 second**, then SIGKILLed every remaining holder of the X browser profile:

```js
for (const pid of pidsForProfile().pids) process.kill(pid, 'SIGTERM');
try { execFileSync('sleep', ['1']); } catch {}
for (const pid of pidsForProfile().pids) process.kill(pid, 'SIGKILL');
```

Chrome writes its cookie jar lazily and flushes on clean shutdown. A SIGKILL before that flush drops every cookie set since the last write — which is exactly the auth cookies of a sign-in that just happened.

`gcftPids()` makes it sharper rather than safer: it drops anything whose argv carries `--type=`, so renderers and the GPU helper are excluded and **only the browser process is signalled**. That is the one process that owns the jar and performs the flush. And the `login` branch launches `Google Chrome for Testing.app` itself, so a user's sign-in window is in that set by construction.

## The change

SIGTERM, then wait for the holders to actually go (10s, `X_PROFILE_GRACE_MS`), and force only what outlives the grace. A holder that honours SIGTERM is never killed.

The wait is extracted to `profile-lock-wait.mjs` so a test can drive it with a fake probe and a fake clock — the same reason `readLanding()` lives outside this script. `x-post-browser.mjs` calls that unit instead of keeping its own copy of the loop, so the test covers the shipped path.

## Evidence

```
$ node tests/x-profile-lock-wait.test.mjs          # at HEAD
  ok   a holder that exits during grace is NOT force-killed
  ok   it returns as soon as the holder is gone, not at the deadline
  ok   a holder needing 3s (the old 1s timer killed it) now survives
  ok   a holder that ignores SIGTERM IS reported for SIGKILL
  ok   and only after the full grace period
  ok   an unknown probe never reports a clean exit
  ok   CONTROL: the old fixed-1s path kills the 3s holder
all ok                                              rc=0
```

Perturbation — `waitForProfileExit` reverted to the old fixed-1s-then-kill semantics, nothing else changed:

```
  FAIL a holder that exits during grace is NOT force-killed
  FAIL it returns as soon as the holder is gone, not at the deadline
  FAIL a holder needing 3s (the old 1s timer killed it) now survives
  FAIL and only after the full grace period
4 FAILED                                            rc=1
```

The suite also carries the old implementation as an in-file control, so the test states the defect rather than only the fix.

## Safety property preserved

The lock exists so a second Chrome cannot launch against a live profile (#2133 P1). That rests on an **unknown** probe never reading as "free", and it is pinned: `an unknown probe never reports a clean exit`. The singleton-file clearing still gates on a post-kill probe, unchanged by this PR.

## What this does NOT claim

That this caused the sign-outs seen on one host. It makes a falsifiable prediction — a login window that honours SIGTERM should survive a subsequent `check` — and only a real sign-in settles it. Filed because the kill-before-flush is a defect on its own terms either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
