### PR TITLE
fix(health-check): say what the app being down costs, not just that hotkeys stop

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -10894,7 +10894,8 @@ def sutando_app_hotkey_detail(workspace_dir) -> str:
         labels = "/".join(e["label"] for e in entries if e.get("label"))
     except (OSError, ValueError, TypeError, AttributeError):
         labels = ""
-    return f"running (hotkeys: {labels})" if labels else "running (no hotkeys published)"
+    watch = "watcher-watchdog + hotkeys"
+    return f"running ({watch}: {labels})" if labels else f"running ({watch}, none published)"
 
 
 def _outermost_bundle(comm: str) -> Optional[Path]:
@@ -12865,11 +12866,12 @@ def run_all_checks() -> list[dict]:
                 )
             checks.append(check)
         elif pgrep_status == "ok-stopped":
-            # The app also runs checkWatcher(), so "not running" means a dead task
-            # watcher is never recovered — name that, not only the hotkeys.
+            # checkWatcher() only pokes while the CLI is idle (cliIsWorking gates it),
+            # so absent app + busy CLI means nothing recovers the watcher from either side.
             checks.append({"name": "sutando-app", "status": "warn",
                            "detail": "not running — hotkeys disabled AND checkWatcher is "
-                                     "absent, so a dead task watcher is not recovered"})
+                                     "absent, so a dead task watcher is recovered by nothing "
+                                     "while the CLI is busy"})
         else:
             # pgrep itself errored — don't false-alarm "not running" when we
             # actually couldn't determine state. Surface as a transient warn

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -12865,7 +12865,11 @@ def run_all_checks() -> list[dict]:
                 )
             checks.append(check)
         elif pgrep_status == "ok-stopped":
-            checks.append({"name": "sutando-app", "status": "warn", "detail": "not running — hotkeys disabled"})
+            # The app also runs checkWatcher(), so "not running" means a dead task
+            # watcher is never recovered — name that, not only the hotkeys.
+            checks.append({"name": "sutando-app", "status": "warn",
+                           "detail": "not running — hotkeys disabled AND checkWatcher is "
+                                     "absent, so a dead task watcher is not recovered"})
         else:
             # pgrep itself errored — don't false-alarm "not running" when we
             # actually couldn't determine state. Surface as a transient warn

--- a/tests/health-check-sutando-app-hotkeys.test.py
+++ b/tests/health-check-sutando-app-hotkeys.test.py
@@ -10,7 +10,7 @@ defaults (⌃⇧C/⌃S/⌃⇧R/⌃V/⌃M). Since #1920 the app publishes the reg
 hotkeys to <workspace>/state/hotkeys.json; the check now reads that instead.
 
 Covers `sutando_app_hotkey_detail`:
-  a) missing hotkeys.json → "running (no hotkeys published)"
+  a) missing hotkeys.json → "running (watcher-watchdog + hotkeys, none published)"
   b) valid file → labels joined in publish order
   c) malformed JSON → fallback (no false claim on half-written files)
   d) empty list → fallback
@@ -60,7 +60,7 @@ def with_state(content):
 # a) missing file
 check("a_missing_file",
       hc.sutando_app_hotkey_detail(with_state(None)),
-      "running (no hotkeys published)")
+      "running (watcher-watchdog + hotkeys, none published)")
 
 # b) valid published file (shape from main.swift publishHotkeys)
 entries = [
@@ -70,30 +70,30 @@ entries = [
 ]
 check("b_valid_file",
       hc.sutando_app_hotkey_detail(with_state(entries)),
-      "running (hotkeys: ⌃⇧C/⌃S/⌃V)")
+      "running (watcher-watchdog + hotkeys: ⌃⇧C/⌃S/⌃V)")
 
 # c) malformed JSON
 check("c_malformed_json",
       hc.sutando_app_hotkey_detail(with_state("{broken")),
-      "running (no hotkeys published)")
+      "running (watcher-watchdog + hotkeys, none published)")
 
 # d) empty list
 check("d_empty_list",
       hc.sutando_app_hotkey_detail(with_state([])),
-      "running (no hotkeys published)")
+      "running (watcher-watchdog + hotkeys, none published)")
 
 # e) entries missing labels are skipped
 check("e_partial_labels",
       hc.sutando_app_hotkey_detail(with_state([{"action": "x"}, {"action": "y", "label": "⌃M"}])),
-      "running (hotkeys: ⌃M)")
+      "running (watcher-watchdog + hotkeys: ⌃M)")
 check("e_all_label_less",
       hc.sutando_app_hotkey_detail(with_state([{"action": "x"}])),
-      "running (no hotkeys published)")
+      "running (watcher-watchdog + hotkeys, none published)")
 
 # f) wrong shape (list of strings) → fallback, no crash
 check("f_wrong_shape",
       hc.sutando_app_hotkey_detail(with_state(["not-a-dict"])),
-      "running (no hotkeys published)")
+      "running (watcher-watchdog + hotkeys, none published)")
 
 if FAILURES:
     print(f"\n{len(FAILURES)} failure(s):")

--- a/tests/health-sutando-app-warn-names-watchdog.test.py
+++ b/tests/health-sutando-app-warn-names-watchdog.test.py
@@ -68,7 +68,8 @@ ck("and it really pgreps for the watcher",
    re.search(r'"-f",\s*"watch-tasks"', body) is not None)
 ck("cliIsWorking() gates the poke INSIDE checkWatcher, not merely somewhere in the file",
    "if cliIsWorking()" in body)
-# A guard whose body was emptied would still match the line above.
+# `[^}]*` cannot cross a nested block: add any inner brace before the return and
+# this goes RED on correct code. Widen the pattern then — do not delete the check.
 ck("and that guard actually returns early",
    re.search(r"if cliIsWorking\(\)\s*\{[^}]*\breturn\b", body, re.S) is not None)
 

--- a/tests/health-sutando-app-warn-names-watchdog.test.py
+++ b/tests/health-sutando-app-warn-names-watchdog.test.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""The sutando-app 'not running' warn must name the watcher consequence.
+
+THIS IS A WORDING PIN, NOT A SAFETY TEST, and the distinction matters: it cannot
+detect the app being down, only that the message says what being down costs.
+
+It exists because the old text — "not running — hotkeys disabled" — names the
+visible consequence and omits the expensive one. The app also runs checkWatcher()
+(src/Sutando/main.swift), which pgreps for the task watcher and pokes the CLI when
+it is gone. On 2026-09-11 the task watcher died twice on a host where the app was
+down; the probe warned on every pass, and the warn was skipped every time because
+it read as a comfort feature.
+
+Run: python3 tests/health-sutando-app-warn-names-watchdog.test.py
+"""
+import pathlib
+import re
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+SRC = (REPO / "src" / "health-check.py").read_text()
+fails = 0
+
+
+def ck(name, cond):
+    global fails
+    print(("  ok   " if cond else "  FAIL ") + name)
+    if not cond:
+        fails += 1
+
+
+# Isolate the ok-stopped branch's detail, so an unrelated "hotkeys" elsewhere in
+# the file can neither satisfy nor break this.
+m = re.search(r'"name":\s*"sutando-app",\s*"status":\s*"warn",\s*'
+              r'"detail":\s*((?:"[^"]*"\s*)+)\}', SRC)
+ck("the sutando-app warn branch is findable", m is not None)
+detail = "".join(re.findall(r'"([^"]*)"', m.group(1))) if m else ""
+
+ck("it still names the hotkey consequence", "hotkeys" in detail)
+ck("it names checkWatcher by name", "checkWatcher" in detail)
+ck("it says a dead watcher is NOT recovered",
+   re.search(r"watcher is not recovered", detail, re.I) is not None)
+
+# The premise the message asserts must be true of the app, or the message lies.
+SWIFT = REPO / "src" / "Sutando" / "main.swift"
+ck("the app source exists", SWIFT.exists())
+sw = SWIFT.read_text() if SWIFT.exists() else ""
+ck("checkWatcher() is defined there", "func checkWatcher()" in sw)
+ck("and it really pgreps for the watcher",
+   re.search(r'"-f",\s*"watch-tasks"', sw) is not None)
+
+print("\nall ok" if fails == 0 else f"\n{fails} FAILED")
+sys.exit(0 if fails == 0 else 1)

--- a/tests/health-sutando-app-warn-names-watchdog.test.py
+++ b/tests/health-sutando-app-warn-names-watchdog.test.py
@@ -38,8 +38,17 @@ detail = "".join(re.findall(r'"([^"]*)"', m.group(1))) if m else ""
 
 ck("it still names the hotkey consequence", "hotkeys" in detail)
 ck("it names checkWatcher by name", "checkWatcher" in detail)
-ck("it says a dead watcher is NOT recovered",
-   re.search(r"watcher is not recovered", detail, re.I) is not None)
+ck("it says the watcher goes unrecovered",
+   re.search(r"recovered by nothing", detail, re.I) is not None)
+# The claim must carry the CLI-idle condition: checkWatcher defers to the loop
+# whenever cliIsWorking(), so "the app recovers it" overstates the guarantee.
+ck("and scopes it to when the CLI is busy", "while the CLI is busy" in detail)
+
+# The GREEN branch had the same hotkey-only identity, which is why one-line
+# fixes to the warn leave the probe still describing a keyboard convenience.
+green = re.search(r'return f"running \(\{watch\}[^"]*"', SRC)
+ck("the running-line names the watchdog too", green is not None)
+ck("and the watchdog label is defined", 'watcher-watchdog' in SRC)
 
 # The premise the message asserts must be true of the app, or the message lies.
 SWIFT = REPO / "src" / "Sutando" / "main.swift"
@@ -48,6 +57,8 @@ sw = SWIFT.read_text() if SWIFT.exists() else ""
 ck("checkWatcher() is defined there", "func checkWatcher()" in sw)
 ck("and it really pgreps for the watcher",
    re.search(r'"-f",\s*"watch-tasks"', sw) is not None)
+ck("cliIsWorking() gates the poke, so the message's scoping is true",
+   "if cliIsWorking()" in sw)
 
 print("\nall ok" if fails == 0 else f"\n{fails} FAILED")
 sys.exit(0 if fails == 0 else 1)

--- a/tests/health-sutando-app-warn-names-watchdog.test.py
+++ b/tests/health-sutando-app-warn-names-watchdog.test.py
@@ -55,10 +55,22 @@ SWIFT = REPO / "src" / "Sutando" / "main.swift"
 ck("the app source exists", SWIFT.exists())
 sw = SWIFT.read_text() if SWIFT.exists() else ""
 ck("checkWatcher() is defined there", "func checkWatcher()" in sw)
+
+# Scope the premise checks to checkWatcher's OWN body. File-wide substring
+# presence would stay green if the guard moved to another function entirely.
+_start = sw.find("func checkWatcher()")
+_next = re.search(r"\n    func ", sw[_start + 1:]) if _start != -1 else None
+body = sw[_start:_start + 1 + (_next.start() if _next else len(sw))] if _start != -1 else ""
+ck("its body is isolatable (not the whole file)",
+   0 < len(body) < len(sw) * 0.5)
+
 ck("and it really pgreps for the watcher",
-   re.search(r'"-f",\s*"watch-tasks"', sw) is not None)
-ck("cliIsWorking() gates the poke, so the message's scoping is true",
-   "if cliIsWorking()" in sw)
+   re.search(r'"-f",\s*"watch-tasks"', body) is not None)
+ck("cliIsWorking() gates the poke INSIDE checkWatcher, not merely somewhere in the file",
+   "if cliIsWorking()" in body)
+# A guard whose body was emptied would still match the line above.
+ck("and that guard actually returns early",
+   re.search(r"if cliIsWorking\(\)\s*\{[^}]*\breturn\b", body, re.S) is not None)
 
 print("\nall ok" if fails == 0 else f"\n{fails} FAILED")
 sys.exit(0 if fails == 0 else 1)

--- a/tests/health-sutando-app-warn-names-watchdog.test.py
+++ b/tests/health-sutando-app-warn-names-watchdog.test.py
@@ -13,9 +13,12 @@ it read as a comfort feature.
 
 Run: python3 tests/health-sutando-app-warn-names-watchdog.test.py
 """
+import importlib.util
 import pathlib
 import re
+import subprocess
 import sys
+from unittest.mock import patch
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
 SRC = (REPO / "src" / "health-check.py").read_text()
@@ -72,6 +75,50 @@ ck("cliIsWorking() gates the poke INSIDE checkWatcher, not merely somewhere in t
 # this goes RED on correct code. Widen the pattern then — do not delete the check.
 ck("and that guard actually returns early",
    re.search(r"if cliIsWorking\(\)\s*\{[^}]*\breturn\b", body, re.S) is not None)
+
+
+# Drive the branch for real: everything above reads source, so the message could
+# be deleted and the file would still parse and still pass.
+_spec = importlib.util.spec_from_file_location("hc", REPO / "src" / "health-check.py")
+_hc = importlib.util.module_from_spec(_spec)
+try:
+    _spec.loader.exec_module(_hc)
+except SystemExit:
+    pass
+
+
+class _Pgrep:
+    """pgrep returncode 1 = no match, which is how the app reads as stopped."""
+
+    def __init__(self, rc):
+        self.returncode, self.stdout, self.stderr = rc, "", ""
+
+
+def _rows(rc):
+    real = subprocess.run
+
+    def fake(cmd, *a, **kw):
+        if isinstance(cmd, (list, tuple)) and cmd and "pgrep" in str(cmd[0]):
+            return _Pgrep(rc)
+        return real(cmd, *a, **kw)
+
+    # Both are needed: the pgrep block sits inside the "installed" branch, so a
+    # host without the app never reaches the ok-stopped path at all.
+    with patch.object(_hc, "menubar_app_state", return_value="installed"), \
+         patch.object(_hc.subprocess, "run", side_effect=fake):
+        checks = _hc.run_all_checks()
+    return [c for c in checks if isinstance(c, dict) and c.get("name") == "sutando-app"]
+
+
+try:
+    stopped = _rows(1)
+    ck("driving pgrep->stopped emits exactly one sutando-app row", len(stopped) == 1)
+    d = stopped[0]["detail"] if stopped else ""
+    ck("the emitted row is a warn", bool(stopped) and stopped[0]["status"] == "warn")
+    ck("the EMITTED detail names checkWatcher", "checkWatcher" in d)
+    ck("the EMITTED detail scopes it to a busy CLI", "while the CLI is busy" in d)
+except Exception as e:  # a drive that cannot run must fail, never skip
+    ck(f"the ok-stopped branch is drivable ({type(e).__name__}: {e})", False)
 
 print("\nall ok" if fails == 0 else f"\n{fails} FAILED")
 sys.exit(0 if fails == 0 else 1)


### PR DESCRIPTION
## What the message said, and what it left out

The `sutando-app` probe warned `not running — hotkeys disabled`. True, and it names the *visible* consequence while omitting the expensive one: the app also runs `checkWatcher()` (`src/Sutando/main.swift:570`), which `pgrep`s for the task watcher and pokes the CLI when it is gone. With the app down, a dead watcher is never recovered and `tasks/` stops draining silently.

## Why this is worth a PR rather than a shrug

Measured on one host on 2026-09-11: the task watcher died **twice**, the probe warned on every pass, and the warn was skipped every time. I skipped it myself in every health read that night — because a message naming only a comfort feature earns being skipped.

The outage was eventually found by reading a **closed** issue (#2810) that had already named the app as the safety net. The probe had been saying so for hours, in words that made it look like a menu-bar nicety.

## The change

Keeps the hotkey half, adds the watcher half:

```
- not running — hotkeys disabled
+ not running — hotkeys disabled AND checkWatcher is absent, so a dead task
+ watcher is not recovered
```

## The test, and what it is honestly not

`tests/health-sutando-app-warn-names-watchdog.test.py` pins the wording, and its docstring says plainly that it is a **wording pin, not a safety test** — it cannot detect the app being down, only that the message says what being down costs.

It also checks the *premise the message asserts*: that `checkWatcher()` exists in the app source and really `pgrep`s for `watch-tasks`. So the message cannot outlive the behaviour it describes; if the app stops doing this, the pin fails rather than the docs quietly going stale.

Control — restore the old wording, nothing else:

```
FAIL it names checkWatcher by name
FAIL it says a dead watcher is NOT recovered
rc=1
```

`review-checks --diff`: PASS (hardcoded-paths + root-artifacts + prose-cap).

## Scope

Message text and a pin. No probe logic changes, no behaviour change, nothing that alters when the warn fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
