### PR TITLE
fix(x-twitter): a garbage grace must fall back to the default, not to zero

### DIFF
--- a/skills/x-twitter/profile-lock-wait.mjs
+++ b/skills/x-twitter/profile-lock-wait.mjs
@@ -5,6 +5,9 @@
 // fixed 1s timer forces the jar whether or not the flush happened, which drops every
 // cookie set since the last write — i.e. exactly the auth cookies from a fresh sign-in.
 
+/** Used when the caller supplies a non-finite or negative grace. */
+export const DEFAULT_GRACE_MS = 10000;
+
 /**
  * SIGTERM has been sent; wait for the holders to go, then report what outlived the grace.
  *
@@ -19,7 +22,9 @@ export function waitForProfileExit(probe, graceMs, sleep, now = Date.now) {
   const start = now();
   // A non-finite grace makes every `now() >= start + graceMs` false and the loop
   // never exits — `Number('abc')` is NaN, and an env var is the usual source.
-  const grace = Number.isFinite(graceMs) && graceMs >= 0 ? graceMs : 0;
+  // Garbage must fall back to the DEFAULT, not to 0: a 0 grace kills on the first
+  // check, which is the un-flushed SIGKILL this module exists to prevent.
+  const grace = Number.isFinite(graceMs) && graceMs >= 0 ? graceMs : DEFAULT_GRACE_MS;
   const deadline = start + grace;
   for (;;) {
     const p = probe();

--- a/tests/x-profile-lock-wait.test.mjs
+++ b/tests/x-profile-lock-wait.test.mjs
@@ -91,6 +91,13 @@ function holder(afterMs, c, known = true) {
   const nan  = (() => { const c = clock(); return waitForProfileExit(stuck, Number('abc'), c.sleep, c.now); })();
   const neg  = (() => { const c = clock(); return waitForProfileExit(stuck, -5, c.sleep, c.now); })();
   ck('a NaN grace waits the DEFAULT, not zero', nan.waitedMs === DEFAULT_GRACE_MS);
+  // `10s` is the realistic typo for a *_MS var — `abc` is not what anyone writes.
+  // `Infinity` is non-finite the other way and must fall back too, or it hangs.
+  for (const raw of ['10s', 'Infinity']) {
+    const c2 = clock();
+    const r2 = waitForProfileExit(stuck, Number(raw), c2.sleep, c2.now);
+    ck(`X_PROFILE_GRACE_MS=${raw} falls back to the DEFAULT`, r2.waitedMs === DEFAULT_GRACE_MS);
+  }
   ck('a negative grace waits the DEFAULT too', neg.waitedMs === DEFAULT_GRACE_MS);
   ck('garbage is indistinguishable from a sane default, not from 0',
      nan.waitedMs === sane.waitedMs);

--- a/tests/x-profile-lock-wait.test.mjs
+++ b/tests/x-profile-lock-wait.test.mjs
@@ -93,10 +93,20 @@ function holder(afterMs, c, known = true) {
   ck('a NaN grace waits the DEFAULT, not zero', nan.waitedMs === DEFAULT_GRACE_MS);
   // `10s` is the realistic typo for a *_MS var — `abc` is not what anyone writes.
   // `Infinity` is non-finite the other way and must fall back too, or it hangs.
-  for (const raw of ['10s', 'Infinity']) {
+  for (const raw of ['10s', 'Infinity', '1e999']) {
     const c2 = clock();
-    const r2 = waitForProfileExit(stuck, Number(raw), c2.sleep, c2.now);
-    ck(`X_PROFILE_GRACE_MS=${raw} falls back to the DEFAULT`, r2.waitedMs === DEFAULT_GRACE_MS);
+    // Bounded probe, not `stuck`: with the isFinite half removed, an Infinity
+    // grace spins forever and a bare arm HANGS CI instead of failing it.
+    let n = 0;
+    const bounded = () => {
+      if (++n > 1000) throw new Error(`did not terminate for ${raw}`);
+      return { known: true, pids: ['4242'] };
+    };
+    let caught = null, r2 = null;
+    try { r2 = waitForProfileExit(bounded, Number(raw), c2.sleep, c2.now); } catch (e) { caught = e; }
+    ck(`X_PROFILE_GRACE_MS=${raw} terminates`, caught === null);
+    ck(`X_PROFILE_GRACE_MS=${raw} falls back to the DEFAULT`,
+       r2 !== null && r2.waitedMs === DEFAULT_GRACE_MS);
   }
   ck('a negative grace waits the DEFAULT too', neg.waitedMs === DEFAULT_GRACE_MS);
   ck('garbage is indistinguishable from a sane default, not from 0',

--- a/tests/x-profile-lock-wait.test.mjs
+++ b/tests/x-profile-lock-wait.test.mjs
@@ -3,7 +3,7 @@
 // sign-in's auth cookies are the newest thing in that jar, so they are what is lost.
 //
 // Run: node tests/x-profile-lock-wait.test.mjs
-import { waitForProfileExit } from '../skills/x-twitter/profile-lock-wait.mjs';
+import { waitForProfileExit, DEFAULT_GRACE_MS } from '../skills/x-twitter/profile-lock-wait.mjs';
 
 let fails = 0;
 const ck = (name, cond) => { console.log((cond ? '  ok   ' : '  FAIL ') + name); if (!cond) fails++; };
@@ -66,7 +66,10 @@ function holder(afterMs, c, known = true) {
   let threw = null;
   try { waitForProfileExit(counting, Number('abc'), c.sleep, c.now); } catch (e) { threw = e; }
   ck('a NaN grace terminates instead of spinning', threw === null);
-  ck('and it does not silently wait forever', iters <= 2);
+  // `iters <= 2` used to stand here. It passed only because NaN collapsed to a 0
+  // grace and exited on the first check — it pinned the defect's side effect, not
+  // termination. The bound is now grace/sleep (10000/250 = 40) plus slack.
+  ck('and it terminates within the grace, not after it', iters > 0 && iters <= 50);
 }
 // 7. exitedCleanly and remaining DISAGREE under an unknown probe — that disagreement
 //    is the flag's whole purpose, so anything recomputing it from `remaining` is wrong.
@@ -77,6 +80,28 @@ function holder(afterMs, c, known = true) {
   ck('unknown probe: exitedCleanly is FALSE despite that', r.exitedCleanly === false);
   ck('so remaining.length===0 is NOT a substitute for exitedCleanly',
      (r.remaining.length === 0) !== r.exitedCleanly);
+}
+
+// 8. A non-finite grace must fall back to the DEFAULT, not to 0. Falling back to 0
+//    makes the first deadline check true, so holders are SIGKILLed with no flush —
+//    the un-flushed kill this whole module exists to prevent, restored silently.
+{
+  const stuck = () => ({ known: true, pids: ['4242'] });
+  const sane = (() => { const c = clock(); return waitForProfileExit(stuck, 10000, c.sleep, c.now); })();
+  const nan  = (() => { const c = clock(); return waitForProfileExit(stuck, Number('abc'), c.sleep, c.now); })();
+  const neg  = (() => { const c = clock(); return waitForProfileExit(stuck, -5, c.sleep, c.now); })();
+  ck('a NaN grace waits the DEFAULT, not zero', nan.waitedMs === DEFAULT_GRACE_MS);
+  ck('a negative grace waits the DEFAULT too', neg.waitedMs === DEFAULT_GRACE_MS);
+  ck('garbage is indistinguishable from a sane default, not from 0',
+     nan.waitedMs === sane.waitedMs);
+}
+// 9. An EXPLICIT 0 is a real choice and must survive. It is the one input that
+//    should kill immediately, and conflating it with garbage loses that.
+{
+  const c = clock();
+  const r = waitForProfileExit(() => ({ known: true, pids: ['7'] }), 0, c.sleep, c.now);
+  ck('an explicit 0 still means kill immediately', r.waitedMs === 0);
+  ck('so 0 and garbage are NOT the same output', r.waitedMs !== DEFAULT_GRACE_MS);
 }
 
 console.log(fails === 0 ? '\nall ok' : `\n${fails} FAILED`);


### PR DESCRIPTION
## The hole #4166 opened while closing a worse one

#4166 guarded a NaN hang by clamping a non-finite grace to `0`. That closed the hang and opened a quieter failure: `deadline = start + 0` makes the first deadline check true, so every holder comes back as `remaining` and is SIGKILLed with no flush — **the un-flushed kill #4166 exists to prevent, restored silently.**

Traced against a live holder, on merged `main`:

```
X_PROFILE_GRACE_MS=abc   ->  waited 0ms, SIGKILL     the original cookie-loss defect
X_PROFILE_GRACE_MS=0     ->  waited 0ms, SIGKILL     a deliberate choice
```

Two opposite intents, one output. `Number.isFinite` already separated them; only the fallback value was wrong.

## The change

Garbage takes `DEFAULT_GRACE_MS` (10000). An explicit `0` still means kill immediately, because that is a real choice and conflating it with garbage loses it.

```
sane 10000   -> 10000ms      NaN -> 10000ms      negative -> 10000ms      explicit 0 -> 0ms
```

**Empty values are handled upstream — verified, not assumed.** `manifest-config.mjs:56` treats an empty env var as unset (`fromEnv !== ''`), so `X_PROFILE_GRACE_MS=` falls through to the manifest's `10000` and never reaches this unit as `0`. I checked because `Number('') === 0`, not NaN, so the unit alone could not have told them apart.

## One existing assertion changed, and why it is not a relaxation

Arm 6 asserted `iters <= 2`. It passed **only because** NaN collapsed to a 0 grace and exited on the first check — it pinned the defect's side effect, not termination. It now bounds iterations by grace/sleep, so it still catches a hang and no longer certifies the bug.

That is the same shape as the defect itself: an assertion whose green depended on the thing being broken.

## Control

Revert the fallback to `0`, nothing else:

```
FAIL a NaN grace waits the DEFAULT, not zero
FAIL a negative grace waits the DEFAULT too
FAIL garbage is indistinguishable from a sane default, not from 0
4 arms fail, rc=1
```

Suites at this head: wait 16 ok, log-line 7 ok, manifest-config ok.

## Credit

Found by review on the merged PR rather than by me. I shipped the clamp and did not ask what the fallback value did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
