### PR TITLE
test(health-check): the pool-watchers suite reads fabricated pids, never the host

### DIFF
--- a/tests/health-check-pool-watchers-all-tracked.test.py
+++ b/tests/health-check-pool-watchers-all-tracked.test.py
@@ -31,14 +31,34 @@ except SystemExit:
 
 WATCHER_ARGV = "bash src/watch-tasks-stream.sh"
 
+# Every pid below is fabricated, so the argv reader must be fabricated too: left
+# at production `_is_watcher_argv` reads THIS host, where pid 300 may be anything.
+_HOST_ARGV_VECTOR = hc._proc_argv_vector
+
+
+def _fabricated_argv_vector(vectors=None):
+    """`_proc_argv_vector` over a pid -> argv-list map; any other pid is unreadable,
+    which is what the injected flat `argv` is then decided from."""
+    table = {str(pid): vec for pid, vec in (vectors or {}).items()}
+    return lambda pid, _t=table: _t.get(str(pid))
+
+
+def setUpModule():
+    hc._proc_argv_vector = _fabricated_argv_vector()
+
+
+def tearDownModule():
+    hc._proc_argv_vector = _HOST_ARGV_VECTOR
+
 
 def run(sentinels: dict, trees: dict, argv=WATCHER_ARGV, core_alive=True,
         parent="1", pid_instance=None, pid_actor="", targets=None, verdicts=None,
-        ps="") -> dict:
+        ps="", argv_vectors=None) -> dict:
     """`sentinels` maps filename -> contents; `trees` maps root pid -> members.
 
     `pid_instance` is what the WATCHER's own environment yields: a string names
-    its instance, "" is the default, and None means unreadable.
+    its instance, "" is the default, and None means unreadable. `argv_vectors`
+    maps pid -> argv list, the OS-authoritative half of the same fabrication.
     """
     with tempfile.TemporaryDirectory() as td:
         ws = Path(td)
@@ -50,10 +70,11 @@ def run(sentinels: dict, trees: dict, argv=WATCHER_ARGV, core_alive=True,
         saved = (hc.WORKSPACE_DIR, hc._proc_argv, hc._watcher_trees,
                  hc._ps_snapshot, hc._pid_parent, hc._fresh_local_core_record,
                  hc._pid_instance_id, hc._pid_actor_id, hc._watcher_sentinel_target,
-                 hc._is_watcher_argv)
+                 hc._is_watcher_argv, hc._proc_argv_vector)
         try:
             hc.WORKSPACE_DIR = ws
             hc._proc_argv = (argv if callable(argv) else (lambda pid: argv))
+            hc._proc_argv_vector = _fabricated_argv_vector(argv_vectors)
             if verdicts is not None:
                 # None is the tri-state "cannot prove", which no argv string
                 # reliably produces; force it so that branch is reachable.
@@ -77,7 +98,8 @@ def run(sentinels: dict, trees: dict, argv=WATCHER_ARGV, core_alive=True,
             (hc.WORKSPACE_DIR, hc._proc_argv, hc._watcher_trees,
              hc._ps_snapshot, hc._pid_parent, hc._fresh_local_core_record,
              hc._pid_instance_id, hc._pid_actor_id,
-             hc._watcher_sentinel_target, hc._is_watcher_argv) = saved
+             hc._watcher_sentinel_target, hc._is_watcher_argv,
+             hc._proc_argv_vector) = saved
 
 
 class PoolHost(unittest.TestCase):
@@ -94,6 +116,15 @@ class PoolHost(unittest.TestCase):
         self.assertEqual(r["status"], "ok", r["detail"])
         for pid in ("100", "200", "300"):
             self.assertIn(pid, r["detail"])
+
+    def test_an_OS_vector_that_denies_the_script_is_PID_reuse(self):
+        """The same host shape CI kept hitting by accident, now stated: the pid in
+        the sentinel is authoritatively some other program, so it is not a watcher."""
+        r = run({"watch-tasks-stream-worker-2.pid": "300\n"}, {},
+                argv_vectors={300: ["/usr/bin/python3", "-u", "/opt/app/worker.py"]})
+        self.assertEqual(r["status"], "warn", r["detail"])
+        self.assertIn("300", r["detail"])
+        self.assertIn("PID reuse", r["detail"])
 
     def test_a_genuinely_untracked_watcher_is_still_reported(self):
         """The union must not swallow the defect the probe exists to find."""
@@ -521,7 +552,8 @@ class TheDarwinArgvParseIsExercisedOnAnyPlatform(unittest.TestCase):
                 + b"\0".join(argv) + b"\0")
         with patch.object(Path, "read_bytes", side_effect=OSError("not linux")), \
              patch.object(ctypes, "CDLL", return_value=self._fake_libc(blob)):
-            return hc._proc_argv_vector(4242)
+            # The real reader is the subject here, not the module-wide fabrication.
+            return _HOST_ARGV_VECTOR(4242)
 
     def test_the_exec_path_is_skipped_and_argv_returned(self):
         self.assertEqual(
@@ -556,7 +588,7 @@ class TheDarwinArgvParseIsExercisedOnAnyPlatform(unittest.TestCase):
 
         with patch.object(Path, "read_bytes", side_effect=OSError("not linux")), \
              patch.object(ctypes, "CDLL", return_value=_Fail()):
-            self.assertIsNone(hc._proc_argv_vector(4242))
+            self.assertIsNone(_HOST_ARGV_VECTOR(4242))
 
 
 class TheWatcherPredicateIsAShapeNotAFieldCount(unittest.TestCase):


### PR DESCRIPTION
## The defect

`tests/health-check-pool-watchers-all-tracked.test.py` fabricates watcher pids (100/200/300, 4242, 888/901/902…) and injects a fake `_proc_argv` for them — but it left `_is_watcher_argv` at production, and that function prefers the **OS-authoritative** reader:

```python
def _is_watcher_argv(argv: str, pid: "int | None" = None) -> "bool | None":
    vec = _proc_argv_vector(pid) if pid is not None else None   # reads THIS host
    if vec is not None and len(vec) >= 2:
        ...
```

`_proc_argv_vector` reads `/proc/<pid>/cmdline`. On macOS those fabricated pids don't exist, so it returns `None` and the injected flat argv decides — which is why the suite is green locally. On a Linux CI runner pid 300 is frequently a real process, and a real non-watcher argv beats the injected one.

### Before — the actual CI failure (PR #4162, Coverage Gate run 34578517595 **attempt 1**, job 103196437366, `diff coverage >= 95% (python)`)

```
coverage-gate: running Python suite under instrumentation...
✖ test failed under instrumentation: tests/health-check-pool-watchers-all-tracked.test.py
======================================================================
FAIL: test_every_instance_watcher_is_tracked (__main__.PoolHost.test_every_instance_watcher_is_tracked)
THE case: three sentinels, three live watchers, nothing untracked.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/tmp.wq31BZ2xU6/4/tests/health-check-pool-watchers-all-tracked.test.py", line 94, in test_every_instance_watcher_is_tracked
    self.assertEqual(r["status"], "ok", r["detail"])
AssertionError: 'warn' != 'ok'
- warn
+ ok
 : PID reuse: watch-tasks-stream-worker-2.pid (pid 300 is bash src/watch-tasks-stream.sh). …
Ran 90 tests in 0.178s
FAILED (failures=1)
```

The message is itself the proof: the detail prints the **injected** argv (`bash src/watch-tasks-stream.sh`) while the verdict says "not the watcher" — the two disagree precisely because the verdict came from the host, not from the fixture. Attempt 2 of the same run passed with no code change; #4165 hit it earlier the same night. It depends on which pids happen to exist on the runner.

## The fix (test-only; the seam already existed)

`_proc_argv_vector` is already a module-level function that two classes in this same file patch. Nothing in `src/` changes.

- `setUpModule` installs a fabricated `_proc_argv_vector` for the whole module, so no direct `_watcher_trees(...)` / `_is_watcher_argv(argv, pid)` call can reach the host either; `tearDownModule` restores production.
- `run()` now injects the argv reader the way it already injects the ps snapshot: a new `argv_vectors` kwarg (pid -> argv list) saved/restored alongside the other probes. Default = no pid has an authoritative vector, i.e. exactly the macOS behaviour the suite was written against, now stated instead of inherited from the platform.
- `TheDarwinArgvParseIsExercisedOnAnyPlatform` is the unit test **of** the real reader, so it calls the production function captured at import (`_HOST_ARGV_VECTOR`) rather than the module-wide fabrication. Same code object, same assertions.
- One new test consumes the seam: `test_an_OS_vector_that_denies_the_script_is_PID_reuse` states the exact host shape CI kept hitting by accident, so the PID-reuse branch is now covered deliberately and hermetically.

## The control that pins hermeticity

`hermetic_control.py` (not committed — a throwaway harness, quoted below) simulates a Linux runner on which **every** fabricated pid is a real, running, non-watcher process. It deliberately does **not** patch `_proc_argv_vector` (the seam the suite injects) — it patches the OS read that function performs, `Path.read_bytes` on `/proc/<pid>/cmdline`. So it can only change a verdict if the suite still reaches the host. (The KERN_PROCARGS2 class re-patches `Path.read_bytes` inside its own `with`, so it is unaffected either way.)

```python
_NONWATCHER = b"/usr/bin/python3\x00-u\x00/opt/app/unrelated-worker.py\x00"
_real_read_bytes = Path.read_bytes

def _fake_read_bytes(self, *a, **k):
    if re.fullmatch(r"/proc/\d+/cmdline", str(self)):
        return _NONWATCHER
    return _real_read_bytes(self, *a, **k)
...
Path.read_bytes = _fake_read_bytes
res = unittest.main(module=mod, argv=["control"], exit=False, verbosity=1).result
```

**At the parent (origin/main, 5a8b84633)** — the fake host changes 20 verdicts, `test_every_instance_watcher_is_tracked` among them:

```
FAIL: test_every_instance_watcher_is_tracked (PoolHost.test_every_instance_watcher_is_tracked)
FAIL: test_a_clean_pool_is_still_ok (PoolHost.test_a_clean_pool_is_still_ok)
FAIL: test_only_the_untracked_root_is_named (PoolHost.test_only_the_untracked_root_is_named)
FAIL: test_ok (SingleInstanceUnchanged.test_ok)
FAIL: test_a_production_shaped_duplicate_is_counted_as_a_second_tree (TheWatcherPredicateIsAShapeNotAFieldCount...)
 … 15 more …
Ran 90 tests in 0.253s
FAILED (failures=20)
CONTROL: ran=90 failures=20 errors=0
```

**At HEAD** — the same control changes nothing, because nothing reads the host any more:

```
Ran 91 tests in 0.131s
OK
CONTROL: ran=91 failures=0 errors=0
```

And the plain suite at HEAD:

```
Ran 91 tests in 0.182s
OK
```

## Neighbours + gate

Every test file that imports these helpers (`grep -ln '_is_watcher_argv\|_proc_argv_vector\|_watcher_trees\|check_task_watcher\|watcher_sentinel_path' tests/*.py`) run at HEAD:

```
tests/agent-availability.test.py                        Ran 35 tests   OK
tests/health-check-codex-task-notifier.test.py          Ran 18 tests   OK
tests/health-check-probe-names-its-subject.test.py      Ran 11 tests   OK
tests/health-check-supervised-watcher-not-orphan.test.py   PASS — supervised watcher is not reported as an orphan
tests/health-check-task-watcher.test.py                    Task-watcher liveness invariants hold.
tests/watcher-sentinel-naming.test.py                   Ran 30 tests   OK
```

Repo gate on the cumulative diff:

```
$ git diff origin/main > /tmp/h.diff && bash scripts/review-checks.sh --diff /tmp/h.diff
prose-cap: PASS (comment blocks within cap 2, exts .py)
review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
```

## Not in this PR (verified, worth a follow-up)

`tests/health-check-task-watcher.test.py` has the same exposure — its `run_check`/`supervised_watcher` fixtures patch `_proc_argv` and `_watcher_trees` but not `_proc_argv_vector`, and their fabricated pids are 4242 and 7100. Under the same fake host it reports 22 failures; 9 of those (cases e/j/k/n/s/u/w) are genuine host-dependence, the other 3 rows (`aa)`) are a control artifact from the one case that legitimately spawns real processes. Left out to keep this PR to a single concern; happy to file it or fix it in a follow-up if you'd rather it land together.

— Sudoo-the-sutando-core (qingyun's Sutando)
