### PR TITLE
test(health-check): the task-watcher suite reads fabricated pids, never the host

### DIFF
--- a/tests/health-check-task-watcher.test.py
+++ b/tests/health-check-task-watcher.test.py
@@ -15,6 +15,7 @@ Covers:
   b) core alive, sentinel absent → warn
   c) core alive, sentinel holds a dead PID → warn (crashed, sentinel left behind)
   d) core alive, PID alive but argv is not the watcher → warn (PID reuse)
+  d2) ...including when only the OS-authoritative argv vector denies it
   e) core alive, PID alive and argv names the watcher → ok
   f) core alive, sentinel unparseable → warn (not a crash)
   g) the check is registered in run_checks' output
@@ -38,6 +39,11 @@ Covers:
   x) `--fix` actually REACHES the repair (warn never enters `issues`)
   y) under `--json` the repair line stays off stdout, so JSON still parses
   y2) ...and the repair pass's own `_`-prefixed keys stay out of the payload
+
+Hermeticity: every pid below is fabricated, so `_proc_argv_vector` — the
+OS-authoritative reader `_is_watcher_argv` prefers over the injected argv — is
+fabricated module-wide too. Case (aa) spawns real processes and restores the
+real reader for its own duration.
 
 Run: python3 tests/health-check-task-watcher.test.py
 Exit code: 0 on pass, 1 on fail.
@@ -68,6 +74,30 @@ spec.loader.exec_module(hc)
 # Captured before any case swaps it in, so a failing case cannot leak a stub.
 _REAL_PROC_ARGV = hc._proc_argv
 
+# Captured before the module-wide fabrication below: case (aa) spawns real
+# processes, so the real reader is its subject and must stay reachable.
+_HOST_ARGV_VECTOR = hc._proc_argv_vector
+
+_ARGV_VECTORS: "dict[int, list[str]]" = {}
+
+
+def _fabricated_argv_vector(pid: int) -> "list[str] | None":
+    """The OS-authoritative argv reader `_is_watcher_argv` prefers, fabricated
+    for the whole module.
+
+    Every pid these fixtures name is invented, so on a host where one really
+    exists the real reader decides the verdict and the injected argv is ignored.
+    A pid absent from the map has no authoritative vector -- the macOS
+    behaviour this suite was written against, now stated rather than inherited.
+    """
+    try:
+        return _ARGV_VECTORS.get(int(pid))
+    except (TypeError, ValueError):
+        return None
+
+
+hc._proc_argv_vector = _fabricated_argv_vector
+
 
 def make_workspace(td: Path, *, core_alive: bool, pid_text: str | None) -> Path:
     """Build a temp workspace. `core_alive` stamps a fresh heartbeat file;
@@ -90,6 +120,7 @@ def make_workspace(td: Path, *, core_alive: bool, pid_text: str | None) -> Path:
 def run_check(*, core_alive: bool, pid_text: str | None, argv: str | None = None,
               pid_instance: "str | None" = "",
               pid_actor: "str | None" = "",
+              argv_vectors: "dict | None" = None,
               trees: dict | None = None, parents: dict | None = None) -> dict:
     """Call check_task_watcher against a temp WORKSPACE_DIR. `argv` patches
     the _proc_argv probe: None = leave the real one (only used where no PID
@@ -99,13 +130,20 @@ def run_check(*, core_alive: bool, pid_text: str | None, argv: str | None = None
     it has unknown parentage. The parent probes are stubbed unconditionally —
     `trees` invents pids, and an unstubbed probe reads the HOST's process table,
     where a fabricated pid may really exist and carry a real parent.
+    
+    `argv_vectors` maps a fabricated pid to the OS-authoritative argv vector the
+    module-wide fabrication reports for it; a pid absent from it has none, so
+    the injected flat `argv` decides.
     """
     with tempfile.TemporaryDirectory() as td:
         make_workspace(Path(td), core_alive=core_alive, pid_text=pid_text)
         saved = (hc.WORKSPACE_DIR, hc._proc_argv, hc._watcher_trees,
                  hc._ps_snapshot, hc._pid_parent, hc._pid_instance_id,
                  hc._pid_actor_id)
+        saved_vectors = dict(_ARGV_VECTORS)
         try:
+            _ARGV_VECTORS.clear()
+            _ARGV_VECTORS.update({int(p): v for p, v in (argv_vectors or {}).items()})
             hc.WORKSPACE_DIR = Path(td)
             if argv is not None:
                 hc._proc_argv = lambda pid: argv
@@ -118,6 +156,8 @@ def run_check(*, core_alive: bool, pid_text: str | None, argv: str | None = None
             hc._pid_actor_id = lambda pid: pid_actor
             return hc.check_task_watcher()
         finally:
+            _ARGV_VECTORS.clear()
+            _ARGV_VECTORS.update(saved_vectors)
             (hc.WORKSPACE_DIR, hc._proc_argv, hc._watcher_trees,
              hc._ps_snapshot, hc._pid_parent, hc._pid_instance_id,
              hc._pid_actor_id) = saved
@@ -547,6 +587,22 @@ def case_d_pid_reuse_warns() -> list[str]:
     return []
 
 
+def case_d2_an_OS_vector_that_denies_the_script_is_PID_reuse() -> list[str]:
+    """The flattened argv names the watcher and the authoritative vector denies
+    it; the OS wins. This is the exact host shape the fixtures used to inherit
+    by accident — now injected, so the branch is covered on every platform."""
+    r = run_check(core_alive=True, pid_text="4242",
+                  argv="bash src/watch-tasks-stream.sh",
+                  argv_vectors={4242: ["/usr/bin/python3",
+                                       "/opt/app/unrelated-worker.py"]})
+    if r["status"] != "warn":
+        return [f"d2) an OS vector denying the script should warn, got "
+                f"{r['status']} ({r['detail']})"]
+    if "reuse" not in r["detail"]:
+        return [f"d2) detail should name PID reuse, got {r['detail']!r}"]
+    return []
+
+
 def case_e_live_watcher_is_ok() -> list[str]:
     r = run_check(core_alive=True, pid_text="4242", argv="bash src/watch-tasks-stream.sh")
     if r["status"] != "ok":
@@ -781,6 +837,10 @@ def case_aa_argv_classification_binds_to_the_executed_script():
 
     fails = []
     tmp = tempfile.mkdtemp()
+    # The module-wide fabrication would answer for these pids; here the real
+    # reader IS the subject, and the processes it reads are real.
+    saved_vector = hc._proc_argv_vector
+    hc._proc_argv_vector = _HOST_ARGV_VECTOR
 
     def mk(rel):
         path = os.path.join(tmp, rel)
@@ -810,6 +870,7 @@ def case_aa_argv_classification_binds_to_the_executed_script():
                 proc.kill()
                 proc.wait()
     finally:
+        hc._proc_argv_vector = saved_vector
         shutil.rmtree(tmp, ignore_errors=True)
     return fails
 
@@ -837,6 +898,7 @@ def main() -> int:
         ("b", case_b_sentinel_absent_warns),
         ("c", case_c_dead_pid_warns),
         ("d", case_d_pid_reuse_warns),
+        ("d2", case_d2_an_OS_vector_that_denies_the_script_is_PID_reuse),
         ("e", case_e_live_watcher_is_ok),
         ("f", case_f_unparseable_sentinel_warns),
         ("g", case_g_registered_in_run_checks),


### PR DESCRIPTION
## The defect

`tests/health-check-task-watcher.test.py` fabricates the watcher pids 4242 and 7100. Its `run_check` and `supervised_watcher` fixtures inject `_proc_argv`, `_watcher_trees`, `_ps_snapshot`, `_pid_parent` and the identity probes — but not `_proc_argv_vector`, and `_is_watcher_argv` prefers that **OS-authoritative** reader over the injected flat argv:

```python
def _is_watcher_argv(argv: str, pid: "int | None" = None) -> "bool | None":
    vec = _proc_argv_vector(pid) if pid is not None else None   # reads THIS host
    if vec is not None and len(vec) >= 2:
        ...
```

`_proc_argv_vector` reads `/proc/<pid>/cmdline` (Linux) or KERN_PROCARGS2 (darwin). On macOS pids 4242/7100 usually don't exist, it returns `None`, and the injected argv decides — which is why the suite is green locally. On a CI runner where those pids are real processes, a real non-watcher argv beats the fixture and the verdict comes from the host. This is the exposure named as a follow-up in #4172 (same seam, sibling suite); no `src/` change here either.

## The fix (test-only; the seam already existed)

`_proc_argv_vector` is a module-level function, so it is patchable exactly like the probes the fixtures already inject.

- A module-wide fabricated `_proc_argv_vector` is installed at import, reading a `_ARGV_VECTORS` map (pid → argv list). A pid absent from the map has **no** authoritative vector — precisely the macOS behaviour this suite was written against, now stated instead of inherited from the platform.
- `run_check` gains an `argv_vectors` kwarg, saved/restored alongside the other probes, so a case can state the OS's answer for its own pids.
- `case_aa_argv_classification_binds_to_the_executed_script` is the test **of** the real reader — it spawns real processes — so it restores the production function (`_HOST_ARGV_VECTOR`, captured before the fabrication) for its own duration and puts it back in its existing `finally`.
- One new case consumes the seam: `d2` — the flat argv names the watcher, the authoritative vector denies it, the OS wins. That is the exact host shape the fixtures used to hit by accident; it is now covered deliberately and hermetically on every platform.

## The control that pins hermeticity

`hermetic_control2.py` (not committed — a throwaway harness, quoted in full below) simulates a runner on which **every** fabricated pid is a real, running, non-watcher process. It deliberately does **not** patch `_proc_argv_vector` (the seam the suite injects) — it patches the OS read that function performs, `Path.read_bytes` on `/proc/<pid>/cmdline`. So it can only change a verdict if the suite still reaches the host.

```python
_NONWATCHER = b"/usr/bin/python3\x00-u\x00/opt/app/unrelated-worker.py\x00"
_real_read_bytes = Path.read_bytes


def _fake_read_bytes(self, *a, **k):
    if re.fullmatch(r"/proc/\d+/cmdline", str(self)):
        return _NONWATCHER
    return _real_read_bytes(self, *a, **k)


spec = importlib.util.spec_from_file_location("tw_test", TEST)
mod = importlib.util.module_from_spec(spec)
spec.loader.exec_module(mod)

Path.read_bytes = _fake_read_bytes
try:
    rc = mod.main()
finally:
    Path.read_bytes = _real_read_bytes
print(f"CONTROL: rc={rc}")
```

### Before — at the parent (origin/main, `719e1e044`)

The fake host changes **22 verdicts across 14 cases**:

```
$ python3 hermetic_control2.py tests/health-check-task-watcher.test.py | grep '✗'
  ✗ case e
  ✗ case j
  ✗ case k
  ✗ case n
  ✗ case n2
  ✗ case s
  ✗ case t3
  ✗ case u
  ✗ case u2
  ✗ case u3
  ✗ case u4
  ✗ case w
  ✗ case w2
  ✗ case aa

22 failure(s)
CONTROL: rc=1
```

Representative rows — the detail is itself the proof, printing the **injected** argv while the verdict says "not the watcher", because the two came from different sources:

```
  ✗ case s
      s) --fix must write the live watcher's pid, got <ABSENT>
      s) re-run check should be ok, got {'name': 'task-watcher', 'status': 'warn', '_sentinel_restamp_pid': '7100', ...}
  ✗ case u
      u) should say why it declined, got 'pid 7100 is no longer the watcher — not re-stamped'
  ✗ case n
      n) expected 2 trees, got 0: {}
```

### After — at HEAD (`f0d7fe12e`)

The same control changes nothing except case `aa`, which reads the host **by design**:

```
$ python3 hermetic_control2.py tests/health-check-task-watcher.test.py | tail -8
  ✓ case z
  ✗ case aa
      aa) dir ending .sh, real watcher: got False, want True
      aa) path WITH SPACES + tasks: got False, want True
      aa) plain watcher, no args: got False, want True

3 failure(s)
CONTROL: rc=1
```

Those three rows are a **control artifact, not a defect**: `aa` spawns real processes and asserts on the real reader, so a harness that lies about `/proc/<pid>/cmdline` is lying to the subject under test. They are the same three rows #4172's analysis predicted for this file. Every other case is now indifferent to the host.

And the plain suite at HEAD — 38 cases, `d2` new:

```
$ python3 tests/health-check-task-watcher.test.py | tail -6
  ✓ case x
  ✓ case y
  ✓ case y2
  ✓ case z
  ✓ case aa
  ✓ case ab

Task-watcher liveness invariants hold.
```

## Neighbours + gate

Every test file importing these helpers (`grep -ln '_is_watcher_argv\|_proc_argv_vector\|_watcher_trees\|check_task_watcher\|watcher_sentinel_path' tests/*.py`), run at HEAD:

```
tests/agent-availability.test.py                           Ran 35 tests in 0.174s  OK   [rc=0]
tests/health-check-codex-task-notifier.test.py             Ran 18 tests in 0.312s  OK   [rc=0]
tests/health-check-probe-names-its-subject.test.py         Ran 11 tests in 0.077s  OK   [rc=0]
tests/health-check-pool-watchers-all-tracked.test.py       Ran 90 tests in 0.089s  OK   [rc=0]
tests/health-check-supervised-watcher-not-orphan.test.py   PASS — supervised watcher is not reported as an orphan   [rc=0]
tests/watcher-sentinel-naming.test.py                      Ran 30 tests in 0.407s  OK   [rc=0]
```

Repo gate on the cumulative diff:

```
$ git diff origin/main > /tmp/h2.diff && bash scripts/review-checks.sh --diff /tmp/h2.diff
prose-cap: PASS (comment blocks within cap 2, exts .py)
review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
```

## Relationship to #4172

Sibling, not a stack: #4172 does this for `tests/health-check-pool-watchers-all-tracked.test.py`, and its "Not in this PR" section names this file as the remaining exposure. The two touch disjoint files and can land in either order. This PR is branched from `origin/main` with nothing cherry-picked from #4172 — the seam (`_proc_argv_vector` being module-level) already exists on main.

— Sudoo-the-sutando-core (qingyun's Sutando)
