### PR TITLE
fix(pool): a mis-shaped bindings file is refused, and a roster compile cannot silently drop bindings

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -137,6 +137,7 @@ One entry per agent-facing module. 5 without a usable header comment.
 - **`quota_projection.py`** — Quota usage history + even-pace projection series for the dashboard chart.
 - **`reachability-endpoints.ts`** — Direct-reachability endpoint detection (US-10, Tier 2b) — "call your agent from another device and still reach YOUR core, directly, without routing through the cloud."
 - **`read_discord_channel.py`** — Gated Discord channel reader — compatibility wrapper over the shared reader and the shared contextNotFrom policy.
+- **`record_lock.py`** — One writer at a time for a shared record, via a sidecar lock file.
 - **`recording-state.ts`** — Shared recording state — used by both browser-tools.ts (describeScreenTool) and recording-tools.ts (scrollAndDescribeTool, screenRecordTool, etc.)
 - **`recording-tools.ts`** — Recording, video playback, and scroll-and-describe tools.
 - **`remote-gateway-bridge.py`** — remote-gateway-bridge.py — sutando loader for the canonical ag2-sparrow client.

--- a/src/pool_roster.py
+++ b/src/pool_roster.py
@@ -132,7 +132,7 @@ def unknown_targets(roster: dict, targets) -> list:
     return [t for t in targets if t not in known]
 
 
-def compile_roster(workspace, workers: dict, bindings=None, version=None,
+def compile_roster(workspace, workers: dict, bindings=None,
                    allow_unbind=None, expect_version=None) -> dict:
     """Build the roster the router reads. Refuses declarations it cannot honour
     rather than emitting a roster that routes somewhere unintended.
@@ -146,7 +146,9 @@ def compile_roster(workspace, workers: dict, bindings=None, version=None,
 
     A caller decides what to pass from a roster it read BEFORE calling; it names
     that version as `expect_version` and is refused if the roster moved since,
-    instead of overwriting the writer that moved it.
+    instead of overwriting the writer that moved it. That check is only as
+    good as the token, so the writer alone allocates it: every publication
+    advances the version, and no caller can publish under a reused one.
     """
     bindings = dict(bindings if bindings is not None else load_bindings(workspace))
     for wid, row in (workers or {}).items():
@@ -187,7 +189,7 @@ def compile_roster(workspace, workers: dict, bindings=None, version=None,
                 f"compile would drop {len(dropped)} binding(s) {dropped} — those sources "
                 "would silently re-aim at the core; name them in allow_unbind to release them")
 
-        roster = {"version": version if version is not None else current + 1,
+        roster = {"version": current + 1,
                   "compiled_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
                   "workers": dict(workers or {}), "bindings": bindings}
         _write_atomic(roster_path(workspace), roster)

--- a/src/pool_roster.py
+++ b/src/pool_roster.py
@@ -26,6 +26,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+from record_lock import record_lock  # noqa: E402
 from workspace_default import resolve_workspace  # noqa: E402
 
 WORKER_ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,31}$")
@@ -132,12 +133,20 @@ def unknown_targets(roster: dict, targets) -> list:
 
 
 def compile_roster(workspace, workers: dict, bindings=None, version=None,
-                   allow_unbind=None) -> dict:
+                   allow_unbind=None, expect_version=None) -> dict:
     """Build the roster the router reads. Refuses declarations it cannot honour
     rather than emitting a roster that routes somewhere unintended.
 
     A source that loses its binding is re-aimed at the core, so a compile whose
     bindings SHRINK is refused unless `allow_unbind` names the sources released.
+
+    That refusal is only worth anything if it is still true when the roster is
+    published, so the predecessor read, the shrink check, the version and the
+    publication are ONE critical section under `<roster>.lock`.
+
+    A caller decides what to pass from a roster it read BEFORE calling; it names
+    that version as `expect_version` and is refused if the roster moved since,
+    instead of overwriting the writer that moved it.
     """
     bindings = dict(bindings if bindings is not None else load_bindings(workspace))
     for wid, row in (workers or {}).items():
@@ -163,15 +172,23 @@ def compile_roster(workspace, workers: dict, bindings=None, version=None,
                 f"binding {source!r} names {missing} which are not workers — "
                 "a binding to a nonexistent target fails every task from that source")
 
-    prev = load_roster(workspace) or {}
-    dropped = sorted(set(prev.get("bindings") or {}) - set(bindings) - set(allow_unbind or ()))
-    if dropped:
-        raise RosterError(
-            f"compile would drop {len(dropped)} binding(s) {dropped} — those sources "
-            "would silently re-aim at the core; name them in allow_unbind to release them")
+    with record_lock(roster_path(workspace)):
+        prev = load_roster(workspace) or {}
+        current = int(prev.get("version") or 0)
+        if expect_version is not None and current != expect_version:
+            raise RosterError(
+                f"roster moved to version {current} since this compile read version "
+                f"{expect_version} — publishing would erase that writer's roster; "
+                "re-read it and recompile")
 
-    roster = {"version": version if version is not None else int(prev.get("version", 0)) + 1,
-              "compiled_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-              "workers": dict(workers or {}), "bindings": bindings}
-    _write_atomic(roster_path(workspace), roster)
+        dropped = sorted(set(prev.get("bindings") or {}) - set(bindings) - set(allow_unbind or ()))
+        if dropped:
+            raise RosterError(
+                f"compile would drop {len(dropped)} binding(s) {dropped} — those sources "
+                "would silently re-aim at the core; name them in allow_unbind to release them")
+
+        roster = {"version": version if version is not None else current + 1,
+                  "compiled_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                  "workers": dict(workers or {}), "bindings": bindings}
+        _write_atomic(roster_path(workspace), roster)
     return roster

--- a/src/pool_roster.py
+++ b/src/pool_roster.py
@@ -77,7 +77,10 @@ def load_bindings(workspace) -> dict:
         raw = json.loads(p.read_text(encoding="utf-8"))
     except (OSError, ValueError) as e:
         raise RosterError(f"bindings unreadable, keeping the last roster: {p}: {e}")
-    bindings = raw.get("bindings", {}) if isinstance(raw, dict) else None
+    # A bare {source: worker} map carries no 'bindings' key; `.get(..., {})` read
+    # it as an empty declaration and re-aimed every bound source at the core.
+    has_key = isinstance(raw, dict) and "bindings" in raw
+    bindings = raw["bindings"] if has_key else None
     if not isinstance(bindings, dict):
         raise RosterError(f"bindings must be an object under 'bindings': {p}")
     return bindings
@@ -128,9 +131,14 @@ def unknown_targets(roster: dict, targets) -> list:
     return [t for t in targets if t not in known]
 
 
-def compile_roster(workspace, workers: dict, bindings=None, version=None) -> dict:
+def compile_roster(workspace, workers: dict, bindings=None, version=None,
+                   allow_unbind=None) -> dict:
     """Build the roster the router reads. Refuses declarations it cannot honour
-    rather than emitting a roster that routes somewhere unintended."""
+    rather than emitting a roster that routes somewhere unintended.
+
+    A source that loses its binding is re-aimed at the core, so a compile whose
+    bindings SHRINK is refused unless `allow_unbind` names the sources released.
+    """
     bindings = dict(bindings if bindings is not None else load_bindings(workspace))
     for wid, row in (workers or {}).items():
         if wid != CORE and not WORKER_ID_RE.match(wid):
@@ -156,6 +164,12 @@ def compile_roster(workspace, workers: dict, bindings=None, version=None) -> dic
                 "a binding to a nonexistent target fails every task from that source")
 
     prev = load_roster(workspace) or {}
+    dropped = sorted(set(prev.get("bindings") or {}) - set(bindings) - set(allow_unbind or ()))
+    if dropped:
+        raise RosterError(
+            f"compile would drop {len(dropped)} binding(s) {dropped} — those sources "
+            "would silently re-aim at the core; name them in allow_unbind to release them")
+
     roster = {"version": version if version is not None else int(prev.get("version", 0)) + 1,
               "compiled_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
               "workers": dict(workers or {}), "bindings": bindings}

--- a/src/record_lock.py
+++ b/src/record_lock.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""One writer at a time for a shared record, via a sidecar lock file.
+
+`os.replace` makes a publication atomic FOR THE READER: nobody sees a truncated
+file. It does nothing for two WRITERS that each read the record, decide against
+what they read, and then publish — both decisions were valid against the same
+predecessor and the second publication erases the first. Serialising the whole
+read-decide-write section is what makes such a decision still true when it is
+acted on; a compare-and-swap on what was read is what makes a writer that loaded
+before the section notice it is stale.
+
+The lock is a sidecar (`<record>.lock`), never the record itself: locking the
+record would mean holding a descriptor on the inode `os.replace` is about to
+swap away, so the next writer would lock a file nobody else can see.
+"""
+from __future__ import annotations
+
+import contextlib
+import fcntl
+from pathlib import Path
+
+LOCK_SUFFIX = ".lock"
+
+
+def lock_path(path) -> Path:
+    """The sidecar guarding `path`. Exposed so a record's own listings can
+    exclude it — it is a guard, not one of the records it protects."""
+    p = Path(path)
+    return p.with_name(p.name + LOCK_SUFFIX)
+
+
+@contextlib.contextmanager
+def record_lock(path):
+    """Hold an exclusive lock on `<path>.lock` for the critical section.
+
+    The sidecar is created once and never unlinked: deleting it would let the
+    next writer lock a new inode while a current holder still owns the old one.
+    """
+    lock = lock_path(path)
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    with open(lock, "a+") as fh:
+        fcntl.flock(fh, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(fh, fcntl.LOCK_UN)

--- a/src/worker_identity.py
+++ b/src/worker_identity.py
@@ -22,8 +22,6 @@ is recorded at start or it is lost.
 """
 from __future__ import annotations
 
-import contextlib
-import fcntl
 import json
 import os
 import re
@@ -34,6 +32,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+from record_lock import record_lock  # noqa: E402
 from workspace_default import resolve_workspace  # noqa: E402
 
 RELATION_NEW = "new"
@@ -95,21 +94,15 @@ def _write(path: Path, payload) -> None:
     os.replace(tmp, path)
 
 
-@contextlib.contextmanager
 def _appending(path: Path):
     """Read-modify-write under an exclusive lock, so no row is lost.
 
     `_write` alone protects the reader; it does not serialise two writers, and a
-    lost lineage row is unrecoverable — it is recorded at start or never.
+    lost lineage row is unrecoverable — it is recorded at start or never. The
+    lock itself is `record_lock`: every record with a read-decide-write section
+    takes the same sidecar, so there is one implementation to reason about.
     """
-    path.parent.mkdir(parents=True, exist_ok=True)
-    lock = path.with_name(path.name + ".lock")
-    with open(lock, "a+") as fh:
-        fcntl.flock(fh, fcntl.LOCK_EX)
-        try:
-            yield
-        finally:
-            fcntl.flock(fh, fcntl.LOCK_UN)
+    return record_lock(path)
 
 
 def sessions_path(workspace, worker_id): return worker_dir(workspace, worker_id) / "sessions.json"

--- a/tests/pool-bindings-roster.test.py
+++ b/tests/pool-bindings-roster.test.py
@@ -386,6 +386,44 @@ class TestConcurrentCompiles(Base):
                                 expect_version=read["version"])
         self.assertEqual(got["version"], read["version"] + 1)
 
+    def test_a_publication_cannot_keep_the_version_a_stale_compile_will_cite(self):
+        """kewei's repro on this PR: an intervening publication that reused
+        version 1 let a compile citing expect_version=1 erase it. Only the
+        writer allocates the token now, so no publication leaves it in place."""
+        read = pr.compile_roster(self.ws, live(W1), {"!base:ag2.space": W1})
+        with self.assertRaises(TypeError):
+            pr.compile_roster(self.ws, live(W1, W2), {"!base:ag2.space": W2},
+                              version=read["version"])
+        between = pr.compile_roster(self.ws, live(W1, W2), {"!base:ag2.space": W2})
+        self.assertEqual(between["version"], read["version"] + 1)
+        with self.assertRaises(pr.RosterError) as e:
+            pr.compile_roster(self.ws, live(W1), {"!base:ag2.space": W1},
+                              expect_version=read["version"])
+        self.assertIn("version", str(e.exception))
+        kept = pr.load_roster(self.ws)
+        self.assertEqual(kept["version"], between["version"])
+        self.assertEqual(pr.targets_for(kept, "!base:ag2.space"), [W2])
+        self.assertEqual(sorted(kept["workers"]), sorted([W1, W2]))
+
+    def test_every_publication_advances_the_version_strictly(self):
+        """Whatever shape a compile takes, the stored version moves past the
+        one it read; two publications never share a token."""
+        seen = []
+        for i in range(8):
+            before = (pr.load_roster(self.ws) or {}).get("version", 0)
+            if i % 3 == 0:
+                got = pr.compile_roster(self.ws, live(W1, W2), {"!base:ag2.space": W1})
+            elif i % 3 == 1:
+                got = pr.compile_roster(self.ws, live(W1, W2), {"!base:ag2.space": W2},
+                                        expect_version=before)
+            else:
+                got = pr.compile_roster(self.ws, live(W1, W2), {},
+                                        allow_unbind=["!base:ag2.space"])
+            self.assertGreater(got["version"], before)
+            self.assertEqual(pr.load_roster(self.ws)["version"], got["version"])
+            seen.append(got["version"])
+        self.assertEqual(seen, list(range(1, 9)))
+
     def test_the_lock_sidecar_is_not_a_roster_record(self):
         """The guard lives beside the record it guards, so it must not read as
         one to anything listing state, and must survive the publication."""

--- a/tests/pool-bindings-roster.test.py
+++ b/tests/pool-bindings-roster.test.py
@@ -17,8 +17,10 @@ Run: python3 tests/pool-bindings-roster.test.py
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 import tempfile
+import threading
 import unittest
 from pathlib import Path
 
@@ -262,6 +264,137 @@ class TestBindingLoss(Base):
         pr.compile_roster(self.ws, live(W1, W2), {"!x:ag2.space": W1})
         got = pr.compile_roster(self.ws, live(W1, W2), {"!x:ag2.space": W2})
         self.assertEqual(pr.targets_for(got, "!x:ag2.space"), [W2])
+
+
+# Each child loads the roster inside the production compile and waits at a
+# barrier for its peer, so both read one predecessor and publish in a fixed order.
+CONCURRENT_WRITER = """
+import json, os, sys, time
+sys.path.insert(0, {src!r})
+import pool_roster as pr
+
+ws, room, mine, peer, wrote_first, order = sys.argv[1:7]
+real_load = pr.load_roster
+
+
+def wait_for(path, seconds):
+    deadline = time.time() + seconds
+    while time.time() < deadline and not os.path.exists(path):
+        time.sleep(0.01)
+
+
+def barriered(workspace):
+    got = real_load(workspace)
+    open(mine, "w").close()
+    # Bounded: under a lock the peer cannot arrive, so this must time out
+    # rather than deadlock the serialised head.
+    wait_for(peer, 3.0)
+    if order == "second":
+        wait_for(wrote_first, 5.0)
+    return got
+
+
+pr.load_roster = barriered
+if order == "second":
+    wait_for(peer, 5.0)   # the first writer is inside compile before this starts
+try:
+    got = pr.compile_roster(ws, {workers!r}, {{"!base:ag2.space": {w1!r}, room: {w1!r}}})
+    print(json.dumps(["OK", got["version"], None]))
+except pr.RosterError as e:
+    print(json.dumps(["RosterError", None, str(e)]))
+if order == "first":
+    open(wrote_first, "w").close()
+"""
+
+
+class TestConcurrentCompiles(Base):
+    """A shared mutable record has ONE writer contract, and a concurrency test
+    calls the production writer. `os.replace` is atomic for the READER; it does
+    not stop two writers validating a shrink against the same predecessor and
+    both publishing, which re-aims the first writer's room at the core — the
+    exact loss this module refuses sequentially. Found in review of this PR."""
+
+    def _run_pair(self):
+        """kewei's repro: both compiles read version 1, then publish left-first."""
+        pr.compile_roster(self.ws, live(W1), {"!base:ag2.space": W1})
+        prog = CONCURRENT_WRITER.format(src=str(REPO / "src"), workers=live(W1), w1=W1)
+        script = self.ws / "writer.py"
+        script.write_text(prog, encoding="utf-8")
+        first_wrote = self.ws / "wrote-first"
+        procs = []
+        for room, name, peer, order in (
+                ("!left:ag2.space", "ready-l", "ready-r", "first"),
+                ("!right:ag2.space", "ready-r", "ready-l", "second")):
+            procs.append(subprocess.Popen(
+                [sys.executable, str(script), str(self.ws), room,
+                 str(self.ws / name), str(self.ws / peer), str(first_wrote), order],
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True))
+        return [json.loads(p.communicate()[0].strip() or '["CRASH",null,null]') for p in procs]
+
+    def test_a_stale_concurrent_compile_is_refused_not_silently_applied(self):
+        left, right = self._run_pair()
+        outcomes = sorted(o[0] for o in (left, right))
+        self.assertEqual(outcomes, ["OK", "RosterError"],
+                         f"both writers succeeded: {left} {right}")
+        final = pr.load_roster(self.ws)
+        self.assertEqual(pr.targets_for(final, "!left:ag2.space"), [W1],
+                         "the published room was silently re-aimed at the core")
+        self.assertEqual(final["version"], 2)
+        loser = left if left[0] == "RosterError" else right
+        self.assertIn("!left:ag2.space", loser[2])
+        self.assertEqual(pr.targets_for(final, "!right:ag2.space"), [pr.CORE])
+
+    def test_concurrent_compiles_allocate_distinct_versions(self):
+        """Two writers reading one predecessor otherwise allocate one version."""
+        pr.compile_roster(self.ws, live(W1), {"!base:ag2.space": W1})
+        seen, errors = [], []
+
+        def compile_once():
+            try:
+                seen.append(pr.compile_roster(self.ws, live(W1),
+                                              {"!base:ag2.space": W1})["version"])
+            except Exception as exc:  # noqa: BLE001 — a lost race surfaces here
+                errors.append(f"{type(exc).__name__}: {exc}")
+
+        threads = [threading.Thread(target=compile_once) for _ in range(12)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        self.assertEqual(errors, [])
+        self.assertEqual(sorted(seen), list(range(2, 14)))
+        self.assertEqual(pr.load_roster(self.ws)["version"], 13)
+
+    def test_a_compile_from_a_superseded_version_is_refused(self):
+        """The caller reads, decides, then compiles; the roster moved between."""
+        read = pr.compile_roster(self.ws, live(W1), {"!base:ag2.space": W1})
+        pr.compile_roster(self.ws, live(W1, W2),
+                          {"!base:ag2.space": W1, "!other:ag2.space": W2})
+        with self.assertRaises(pr.RosterError) as e:
+            pr.compile_roster(self.ws, live(W1),
+                              {"!base:ag2.space": W1, "!mine:ag2.space": W1},
+                              expect_version=read["version"])
+        self.assertIn("version", str(e.exception))
+        kept = pr.load_roster(self.ws)
+        self.assertEqual(kept["version"], 2)
+        self.assertEqual(pr.targets_for(kept, "!other:ag2.space"), [W2])
+        self.assertEqual(pr.targets_for(kept, "!mine:ag2.space"), [pr.CORE])
+
+    def test_a_compile_on_the_version_it_read_is_accepted(self):
+        read = pr.compile_roster(self.ws, live(W1), {"!base:ag2.space": W1})
+        got = pr.compile_roster(self.ws, live(W1), {"!base:ag2.space": W1},
+                                expect_version=read["version"])
+        self.assertEqual(got["version"], read["version"] + 1)
+
+    def test_the_lock_sidecar_is_not_a_roster_record(self):
+        """The guard lives beside the record it guards, so it must not read as
+        one to anything listing state, and must survive the publication."""
+        pr.compile_roster(self.ws, live(W1), {"!base:ag2.space": W1})
+        state = self.ws / "state"
+        self.assertEqual(sorted(p.name for p in state.glob("*.json")), ["roster.json"])
+        self.assertTrue((state / "roster.json.lock").exists())
+        self.assertEqual(pr.load_roster(self.ws)["version"], 1)
+        self.assertEqual(list(state.glob("*.tmp")), [])
 
 
 if __name__ == "__main__":

--- a/tests/pool-bindings-roster.test.py
+++ b/tests/pool-bindings-roster.test.py
@@ -210,6 +210,59 @@ class TestCorruptDeclarations(Base):
             with self.assertRaises(pr.RosterError, msg=bad):
                 pr.load_bindings(self.ws)
 
+    def test_a_bare_map_without_the_bindings_key_is_refused(self):
+        """Measured 2026-09-11: a hand-written {source: worker} map loaded as {}
+        and the next compile emitted 1 binding where the owner had declared 6."""
+        self.declare(json.dumps({"!x:ag2.space": W1, "!y:ag2.space": W1}))
+        with self.assertRaises(pr.RosterError):
+            pr.load_bindings(self.ws)
+        with self.assertRaises(pr.RosterError):
+            pr.compile_roster(self.ws, live(W1))
+
+    def test_the_bindings_key_is_what_is_missing_not_the_file(self):
+        """The refusal must not swallow the still-valid empty declarations."""
+        self.assertEqual(pr.load_bindings(self.ws), {})
+        self.declare(json.dumps({"bindings": {}}))
+        self.assertEqual(pr.load_bindings(self.ws), {})
+
+
+class TestBindingLoss(Base):
+    """A source whose binding vanishes is re-aimed at the core with no error,
+    which is the same silent misroute a corrupt declaration produced."""
+
+    def test_a_shrink_without_allow_unbind_is_refused_by_name(self):
+        pr.compile_roster(self.ws, live(W1), {"!x:ag2.space": W1, "!y:ag2.space": W1})
+        with self.assertRaises(pr.RosterError) as e:
+            pr.compile_roster(self.ws, live(W1), {"!x:ag2.space": W1})
+        self.assertIn("!y:ag2.space", str(e.exception))
+        self.assertNotIn("!x:ag2.space", str(e.exception))
+
+    def test_a_refused_shrink_leaves_the_previous_roster_intact(self):
+        first = pr.compile_roster(self.ws, live(W1), {"!y:ag2.space": W1})
+        with self.assertRaises(pr.RosterError):
+            pr.compile_roster(self.ws, live(W1), {})
+        kept = pr.load_roster(self.ws)
+        self.assertEqual(kept["version"], first["version"])
+        self.assertEqual(pr.targets_for(kept, "!y:ag2.space"), [W1])
+
+    def test_a_shrink_the_caller_names_compiles(self):
+        pr.compile_roster(self.ws, live(W1), {"!x:ag2.space": W1, "!y:ag2.space": W1})
+        got = pr.compile_roster(self.ws, live(W1), {"!x:ag2.space": W1},
+                                allow_unbind=["!y:ag2.space"])
+        self.assertEqual(got["bindings"], {"!x:ag2.space": W1})
+        self.assertEqual(pr.targets_for(got, "!y:ag2.space"), [pr.CORE])
+
+    def test_growth_needs_no_permission(self):
+        pr.compile_roster(self.ws, live(W1), {"!x:ag2.space": W1})
+        got = pr.compile_roster(self.ws, live(W1, W2),
+                                {"!x:ag2.space": W1, "!y:ag2.space": W2})
+        self.assertEqual(pr.targets_for(got, "!y:ag2.space"), [W2])
+
+    def test_retargeting_a_source_is_not_a_shrink(self):
+        pr.compile_roster(self.ws, live(W1, W2), {"!x:ag2.space": W1})
+        got = pr.compile_roster(self.ws, live(W1, W2), {"!x:ag2.space": W2})
+        self.assertEqual(pr.targets_for(got, "!x:ag2.space"), [W2])
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=0)


### PR DESCRIPTION
## The defect (measured 2026-09-11 02:31, pool host)

`load_bindings()` promises in its own docstring: *"Unreadable or mis-shaped is refused: read as
empty, a corrupt file compiles into a roster that sends every bound task to the core."* It does not
keep that promise for one shape. A top-level dict **without** the `bindings` key was read by
`raw.get("bindings", {})` — a default that turns a mis-shaped file into a *valid empty declaration*.

A hand-written bare `{room: worker}` map (six rooms) loaded as `{}`, and the next `compile_roster`
emitted a roster with **1 binding instead of 6** — no error, version bumped, every one of those six
rooms silently re-aimed at the core.

A peer's point, same failure class: `compile_roster` would also write a roster with **fewer**
bindings than the live one without saying so. Whatever the cause — a drifted file, a caller that
rebuilt the map from a partial read — the rooms that vanish are re-aimed at the core silently.

## Two guards

1. **`load_bindings`**: a top-level dict lacking the `bindings` key raises `RosterError`. Unchanged:
   a missing file is a valid empty declaration; `{"bindings": {}}` is a valid empty declaration; a
   non-dict `bindings` is still refused.
2. **`compile_roster`**: a compile whose bindings set SHRINKS relative to the current roster's
   bindings raises `RosterError` **naming the sources that would vanish**, unless the caller passes
   `allow_unbind=[...]` naming the rooms being released. Shaped after the retire path, which also
   makes the caller state the release rather than inferring it. Retargeting a source is not a shrink;
   growth needs no permission.

## Evidence — parent vs head

Repro (six rooms in a bare map, then `create-worker`'s load-then-add shape):

**Parent `f71f1aaee`:**
```
declared rooms in bindings.json: 6
load_bindings -> 0 binding(s)
compiled roster bindings: 1
targets for !room3:ag2.space -> ['core']
```

**Head `0fb3450ad`:**
```
declared rooms in bindings.json: 6
load_bindings -> RosterError: bindings must be an object under 'bindings': /var/.../state/bindings.json
```

Suite `tests/pool-bindings-roster.test.py` — **new tests against parent source** (controls):
```
ERROR: test_a_shrink_the_caller_names_compiles
  TypeError: compile_roster() got an unexpected keyword argument 'allow_unbind'
FAIL: test_a_refused_shrink_leaves_the_previous_roster_intact
  AssertionError: RosterError not raised
FAIL: test_a_shrink_without_allow_unbind_is_refused_by_name
  AssertionError: RosterError not raised
FAIL: test_a_bare_map_without_the_bindings_key_is_refused
  AssertionError: RosterError not raised
Ran 36 tests in 0.033s
FAILED (failures=3, errors=1)
```

**At head:**
```
Ran 36 tests in 0.038s
OK
```

(`test_growth_needs_no_permission` and `test_retargeting_a_source_is_not_a_shrink` pass at both —
they pin that the guard does not over-refuse.)

Sibling suite `tests/pool-delivery.test.py`: `Ran 60 tests ... OK` at head.
No `tests/pool-route*.test.py` exists on `main`.

Repo gate on the cumulative diff:
```
$ git diff origin/main > /tmp/rg.diff && bash scripts/review-checks.sh --diff /tmp/rg.diff
prose-cap: PASS (comment blocks within cap 2, exts .py)
review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
```
`ruff check src/pool_roster.py tests/pool-bindings-roster.test.py` → `All checks passed!`

## Callers

Grepped `compile_roster` / `load_bindings` across the repo and across the staged pool-stack branches.
**No branch is modified by this PR — this is a report only.**

| Caller | Where | Needs `allow_unbind`? |
|---|---|---|
| `tests/pool-bindings-roster.test.py` | `main` | No — the only caller on `main`; updated here |
| `compile_with()` → `scripts/create-worker.py:82-85` | `feat/create-worker-command` (#4115), inherited unchanged by `feat/worker-picker-commands` (#4120) and `feat/picker-structured-command` (#4121) | **Conditionally.** It is additive (`bindings = dict(pr.load_bindings(ws))`, then `bindings[room] = worker_id`), so it never shrinks on its own. But it seeds from the *file* while the shrink check compares against the *roster*: if the owner has removed a room from `bindings.json` since the last compile, this call now refuses and the flow must pass `allow_unbind` (or re-declare). Guard 1 closes the mis-shaped-file route into that same state. |
| `tests/create-worker-command.test.py:133-165` | `feat/create-worker-command` (#4115) and the two branches above | No — stubs/one-shot compiles, no shrink |
| `spawn_worker` / `src/pool_spawn*` | `feat/spawn-worker-launcher` (#4108) | No — no `compile_roster` or `load_bindings` call on that branch |
| `feat/pool-router-pass` (#4110) | — | No — router reads the roster, never compiles it |

---

## Round 2 — @keweichen's blocker: the guard did not survive concurrency

Code at `0eb41cfb0`; head `b31babf38` adds only the `docs/src-map.md` regeneration the new module requires.

**The ask.** `compile_roster` loaded the previous roster, computed `dropped`, and published later
with `_write_atomic()`. `os.replace` prevents a torn read; it does not stop two writers validating
against the same predecessor. Kewei barriered two forked processes after each production
`load_roster()` and ordered the writes: both reported OK, both allocated version 2, and the first
writer's room was silently re-aimed at the core — the exact loss this PR claims to refuse.

**The fix.** Two mechanisms, both required:

1. **One critical section.** The predecessor read, the shrink check, the version allocation and the
   publication now run under an exclusive `fcntl.flock` on a sidecar `<roster>.lock`. A decision is
   therefore still true when it is acted on.
2. **Compare-and-swap on the predecessor.** A caller that read the roster *before* calling — it
   decides which workers and bindings to pass from what it read — names that version as
   `expect_version`. If the roster moved since, the compile raises `RosterError` and the successful
   writer's roster is left untouched. Default `None` keeps every existing caller's behaviour.

The lock is `src/record_lock.py`. `src/worker_identity.py`'s `_appending` — the production-writer
lock this repo already exercises at `tests/worker-identity-records.test.py:250-294`, which Kewei
cited — now **delegates** to it rather than this PR adding a second copy of the same sidecar, so a
record with a read-decide-write section has one implementation (AGENTS.md/CLAUDE.md: "centralize
only semantically identical writers"; "do not add a copy").

### Tail — Kewei's repro, driven against both trees

Same barriered-fork harness, the only wrap being the scheduling hook on `load_roster`; the
production `compile_roster()` is the function called.

**Parent `0fb3450ad` (this PR before round 2):**
```
sequential second compile: RosterError compile would drop 1 binding(s) ['!right:ag2.space'] — those sources would silently re-aim at the core; name them in allow_unbind to release them
concurrent compile outcomes: [('!left:ag2.space', 'OK', 2), ('!right:ag2.space', 'OK', 2)]
final bindings: ['!base:ag2.space', '!right:ag2.space'] version: 2
lost source target: !left:ag2.space -> ['core']
```

**Head `0eb41cfb0`:**
```
sequential second compile: RosterError compile would drop 1 binding(s) ['!right:ag2.space'] — those sources would silently re-aim at the core; name them in allow_unbind to release them
concurrent compile outcomes: [('!left:ag2.space', 'OK', 2), ('!right:ag2.space', 'RosterError', None)]
   refusal: compile would drop 1 binding(s) ['!left:ag2.space'] — those sources would silently re-aim at the core; name them in allow_unbind to release them
final bindings: ['!base:ag2.space', '!left:ag2.space'] version: 2
lost source target: !left:ag2.space -> ['a3f91c2d4e5b6a7c8d9e0f1a2b3c4d5e']
```

Exactly one writer publishes; the loser is **refused by name** and the winner's room stays bound.
The sequential control refuses identically at both commits, so the repro is measuring the race and
not the shrink guard.

### Tail — the five new tests, run against this PR's own parent as the control

`TestConcurrentCompiles` calls the production `compile_roster()` in every case.

```
$ python3 tests/pool-bindings-roster.test.py TestConcurrentCompiles     # src/ = 0fb3450ad
FAIL test_a_stale_concurrent_compile_is_refused_not_silently_applied
     AssertionError: ['OK', 'OK'] != ['OK', 'RosterError'] : both writers succeeded: ['OK', 2, None] ['OK', 2, None]
FAIL test_concurrent_compiles_allocate_distinct_versions
     FileNotFoundError: ... '/state/.roster.json.72876.tmp' -> '/state/roster.json'   (x9)
FAIL test_the_lock_sidecar_is_not_a_roster_record
ERROR test_a_compile_from_a_superseded_version_is_refused        (expect_version absent — wrong-reason control)
ERROR test_a_compile_on_the_version_it_read_is_accepted          (expect_version absent — wrong-reason control)
Ran 5 tests — FAILED (failures=3, errors=2)
```

The three FAILs carry the comparison; the two ERRORs are absent-kwarg, not behavioural. The
thread FAIL is worth naming: without the lock, twelve threads that share a pid also collide on
`_write_atomic`'s per-pid temp name, so the loser of that race raises rather than merely
overwriting. Under the lock they serialise and allocate versions 2..13 with no repeats.

**At head, whole suites:**
```
tests/pool-bindings-roster.test.py        Ran 41 tests   OK     (36 existing + 5 new)
tests/pool-delivery.test.py               Ran 60 tests   OK
tests/worker-identity-records.test.py     Ran 33 tests   OK     (the delegated lock)
tests/state-paths-adoption.test.py        all state-paths adoption tests passed
tests/shepherd-github-durability.test.py  PASS: 120 assertions, control verified
tests/shepherd-github-integrity.test.py   integrity: 0 failure(s)
ruff check src/record_lock.py src/pool_roster.py src/worker_identity.py tests/pool-bindings-roster.test.py
                                          All checks passed!
```

`test_the_lock_sidecar_is_not_a_roster_record` covers Kewei's implied question about the new file in
`state/`: `state/*.json` still lists exactly `roster.json`, the sidecar is not unlinked (deleting it
would let the next writer lock a different inode), and no `.tmp` survives the publication.

**Repo gate, cumulative diff, run alone:**
```
$ git diff $(git merge-base origin/main HEAD) > /tmp/f4176.diff
$ bash scripts/review-checks.sh --diff /tmp/f4176.diff   ; echo rc=$?
prose-cap: PASS (comment blocks within cap 2, exts .py)
review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
rc=0
```
Positive control (the same diff plus `CACHE = "/Users/reviewer/private-cache"` in `src/record_lock.py`):
`review-checks: FAIL — hardcoded-paths … rc=1`. Python-only diff, so the shell comment-block count is n/a.

### #4115 must call the new contract — measured, not asserted

`scripts/create-worker.py:compile_with()` on `feat/create-worker-command` (`a729f7c3`) reads the
roster (`existing_workers` → `pr.load_roster`), adds its worker, reads `bindings.json`, adds its
room, then compiles. **This PR does not modify that branch.** After this change:

- Its *bindings* loss is now covered: two concurrent runs serialise, and the second sees the first's
  room in the roster it loads under the lock, so it is refused by name instead of dropping it.
- Its *workers* loss is **not**, and cannot be — there is no shrink guard on the workers table
  (retiring a worker is legitimate), so a run started with `--room` omitted publishes a workers table
  that silently lacks the worker another run just created. Measured on this head:

```
no expect_version -> workers in roster: ['b4e0…5d6e']   (A lost)
expect_version    -> RosterError: roster moved to version 2 since this compile read version 1 —
                     publishing would erase that writer's roster; re-read it and recompile
final workers:       ['a3f9…4d5e']
```

So the caller fix is one argument: `compile_with` should carry the version it read in
`existing_workers()` and pass it as `expect_version=`, then retry on refusal. Raised on #4115 rather
than patched here — it is that PR's branch and that PR's review.

## Scope (cumulative)

`src/pool_roster.py`, `src/worker_identity.py`, new `src/record_lock.py`,
`tests/pool-bindings-roster.test.py`. No prompt or tool behavior changed.

---
Signed: Sutando core (qingyun-001)

