### PR TITLE
feat(skills): a session-scoped read receipt for every skill, not just pr-triage

### DIFF
--- a/scripts/skill-read-receipt.py
+++ b/scripts/skill-read-receipt.py
@@ -31,6 +31,8 @@ catches neither reliably, which is why this is a hash and not a timestamp.
             refresh-skill.sh) after it was read. rc 1 if any drifted. No --skill.
 """
 import argparse
+import contextlib
+import fcntl
 import hashlib
 import json
 import os
@@ -48,12 +50,28 @@ def _session_id() -> str:
     return (os.environ.get("CLAUDE_CODE_SESSION_ID") or "").strip()
 
 
-def _load(state_dir: Path) -> dict:
+def _load(state_dir: Path) -> "tuple[dict, str]":
+    """(receipts, error). A non-empty error means the store is UNREADABLE, which is
+    not the same fact as an empty one.
+
+    Collapsing corruption, a wrong top-level type and every I/O error into {} makes
+    --audit print "nothing read in full yet" over a store it could not parse -- a
+    broken probe reporting clean, which is the failure this whole file exists to
+    prevent. Callers decide the severity: --check stays conservative (demand the
+    read), --audit refuses to answer.
+    """
+    path = state_dir / RECEIPTS
+    if not path.exists():
+        return {}, ""                      # genuinely empty: no receipts yet
     try:
-        data = json.loads((state_dir / RECEIPTS).read_text())
-    except (OSError, ValueError):
-        return {}
-    return data if isinstance(data, dict) else {}
+        data = json.loads(path.read_text())
+    except OSError as e:
+        return {}, f"{path} is unreadable: {e}"
+    except ValueError as e:
+        return {}, f"{path} is not valid JSON: {e}"
+    if not isinstance(data, dict):
+        return {}, f"{path} holds {type(data).__name__}, not an object"
+    return data, ""
 
 
 def _key(session: str, path: Path) -> str:
@@ -74,6 +92,28 @@ def _preconditions(skill: Path, marker: str):
     return True, ""
 
 
+@contextlib.contextmanager
+def _exclusive(state_dir: Path):
+    """Hold the whole read-modify-write, not just the file swap.
+
+    Two record() calls could each load the same snapshot and each write the WHOLE
+    store back, so one receipt is silently erased while both callers see rc=0 --
+    and a later --audit then reports clean for a skill nobody is tracking. A lock
+    around the swap alone does not help; the critical section is load->mutate->write.
+    Not `workspace_lock.py`: that is a heartbeated singleton ROLE lock for long-lived
+    pollers, a different primitive from a short mutual-exclusion window.
+    """
+    state_dir.mkdir(parents=True, exist_ok=True)
+    fd = os.open(state_dir / (RECEIPTS + ".lock"), os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        with contextlib.suppress(OSError):
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
 def check(skill: Path, state_dir: Path, marker: str) -> int:
     ok, why = _preconditions(skill, marker)
     if not ok:
@@ -84,7 +124,12 @@ def check(skill: Path, state_dir: Path, marker: str) -> int:
         print("CANNOT ANSWER: CLAUDE_CODE_SESSION_ID is unset, so a receipt cannot be "
               "scoped to a reader — read the file in full", file=sys.stderr)
         return 2
-    rec = _load(state_dir).get(_key(session, skill))
+    store, load_err = _load(state_dir)
+    if load_err:
+        # Conservative on this path: an unreadable store cannot authorise a skip.
+        print(f"FULL READ REQUIRED: {load_err}")
+        return 1
+    rec = store.get(_key(session, skill))
     digest = _digest(skill)
     if not rec:
         print(f"FULL READ REQUIRED: no receipt for this session ({session[:8]}) — "
@@ -112,19 +157,29 @@ def record(skill: Path, state_dir: Path, marker: str) -> int:
               "different session skip a read it never did", file=sys.stderr)
         return 2
     import datetime
+    import tempfile
     state_dir.mkdir(parents=True, exist_ok=True)
-    data = _load(state_dir)
-    text = skill.read_text(errors="ignore")
-    data[_key(session, skill)] = {
-        "sha256": _digest(skill),
-        "bytes": skill.stat().st_size,
-        "lines": text.count("\n") + 1,
-        "recorded_at": datetime.datetime.now(datetime.timezone.utc)
-                        .strftime("%Y-%m-%dT%H:%M:%SZ"),
-    }
-    tmp = state_dir / (RECEIPTS + ".tmp")
-    tmp.write_text(json.dumps(data, indent=1, sort_keys=True))
-    tmp.replace(state_dir / RECEIPTS)
+    # load -> mutate -> write is ONE critical section; see _exclusive.
+    with _exclusive(state_dir):
+        data, load_err = _load(state_dir)
+        if load_err:
+            print(f"REFUSED: {load_err}; refusing to overwrite a store I cannot read",
+                  file=sys.stderr)
+            return 2
+        text = skill.read_text(errors="ignore")
+        data[_key(session, skill)] = {
+            "sha256": _digest(skill),
+            "bytes": skill.stat().st_size,
+            "lines": text.count("\n") + 1,
+            "recorded_at": datetime.datetime.now(datetime.timezone.utc)
+                            .strftime("%Y-%m-%dT%H:%M:%SZ"),
+        }
+        # A FIXED .tmp name is itself a collision between two writers; mkstemp in the
+        # same directory keeps the rename atomic and the scratch name unique.
+        fd, tmp_name = tempfile.mkstemp(dir=str(state_dir), prefix=RECEIPTS + ".", suffix=".tmp")
+        with os.fdopen(fd, "w") as fh:
+            json.dump(data, fh, indent=1, sort_keys=True)
+        os.replace(tmp_name, state_dir / RECEIPTS)
     print(f"recorded: {skill.name} {skill.stat().st_size} B read in full by session "
           f"{session[:8]} (sha {_digest(skill)[:12]})")
     return 0
@@ -142,7 +197,11 @@ def audit(state_dir: Path) -> int:
         print("CANNOT ANSWER: CLAUDE_CODE_SESSION_ID is unset, so this session's "
               "receipts cannot be identified", file=sys.stderr)
         return 2
-    mine = {k: v for k, v in _load(state_dir).items() if k.startswith(session + ":")}
+    store, load_err = _load(state_dir)
+    if load_err:
+        print(f"CANNOT ANSWER: {load_err}", file=sys.stderr)
+        return 2
+    mine = {k: v for k, v in store.items() if k.startswith(session + ":")}
     if not mine:
         print(f"no receipts for this session ({session[:8]}) -- nothing read in full yet")
         return 0

--- a/scripts/skill-read-receipt.py
+++ b/scripts/skill-read-receipt.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Record and check that THIS session read a skill file in full — for ANY skill.
+
+Generalised from `pr-triage/scripts/skill-read-receipt.py`, which proved the shape on
+one procedure file. Two properties make it a read rather than a memory of one, and
+both are inherited unchanged:
+
+  * Keyed on the sha256 of the BYTES, not a path or a git blob. A working copy that
+    differs from HEAD, or any edit at all, invalidates it.
+  * Scoped to CLAUDE_CODE_SESSION_ID. A receipt written by another session is exactly
+    the "never from memory of it" the contract forbids, so --check ignores it and
+    --record refuses to write one that is unscoped.
+
+WHY IT GENERALISES, and what it does NOT claim. A skill's text reaches an agent by
+injection from the Claude Code harness -- not this repo's code, and not something we
+can make stamp what it served. This works on our side of that boundary: it records
+what the agent READ FROM DISK, so a skill with no receipt is one whose injected copy
+has never been checked against the file.
+
+Measured 2026-09-11, both directions in one session: an injected skill body was three
+days behind disk while `refresh-skill.sh --all` had run twenty minutes earlier, and
+separately a served body contained text present in NO file on this machine. A content
+hash has no opinion about which side is newer, so it catches both; an mtime comparison
+catches neither reliably, which is why this is a hash and not a timestamp.
+
+  --check   0 proceed on this session's receipt / 1 FULL READ REQUIRED
+            2 cannot answer (missing file, missing marker, no session id)
+  --record  write the receipt AFTER the full read completes
+  --audit   every receipt THIS session holds, and whether its bytes still match.
+            Catches a skill that changed UNDERNEATH a live session (git pull,
+            refresh-skill.sh) after it was read. rc 1 if any drifted. No --skill.
+"""
+import argparse
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+
+RECEIPTS = "skill-read-receipts.json"
+
+
+def _digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _session_id() -> str:
+    return (os.environ.get("CLAUDE_CODE_SESSION_ID") or "").strip()
+
+
+def _load(state_dir: Path) -> dict:
+    try:
+        data = json.loads((state_dir / RECEIPTS).read_text())
+    except (OSError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _key(session: str, path: Path) -> str:
+    return f"{session}:{path.resolve()}"
+
+
+def _preconditions(skill: Path, marker: str):
+    """(ok, message). Same refusal on both paths, so they cannot disagree."""
+    if not skill.is_file():
+        return False, f"CANNOT ANSWER: {skill} does not exist — this is the contract's loud STOP"
+    try:
+        text = skill.read_text(errors="ignore")
+    except OSError as e:
+        return False, f"CANNOT ANSWER: {skill} is unreadable: {e}"
+    if marker and marker not in text:
+        return False, (f"CANNOT ANSWER: {skill} lacks the marker clause {marker!r} — "
+                       "the contract's loud STOP; do not improvise a pass")
+    return True, ""
+
+
+def check(skill: Path, state_dir: Path, marker: str) -> int:
+    ok, why = _preconditions(skill, marker)
+    if not ok:
+        print(why, file=sys.stderr)
+        return 2
+    session = _session_id()
+    if not session:
+        print("CANNOT ANSWER: CLAUDE_CODE_SESSION_ID is unset, so a receipt cannot be "
+              "scoped to a reader — read the file in full", file=sys.stderr)
+        return 2
+    rec = _load(state_dir).get(_key(session, skill))
+    digest = _digest(skill)
+    if not rec:
+        print(f"FULL READ REQUIRED: no receipt for this session ({session[:8]}) — "
+              f"read {skill} in full, then --record")
+        return 1
+    if rec.get("sha256") != digest:
+        print(f"FULL READ REQUIRED: content changed since this session's receipt "
+              f"({str(rec.get('sha256'))[:12]} -> {digest[:12]}) — read it again")
+        return 1
+    print(f"receipt valid: this session read {skill.name} in full at {rec.get('recorded_at')} "
+          f"and the bytes are unchanged (sha {digest[:12]})")
+    return 0
+
+
+def record(skill: Path, state_dir: Path, marker: str) -> int:
+    ok, why = _preconditions(skill, marker)
+    if not ok:
+        print(why, file=sys.stderr)
+        return 2
+    session = _session_id()
+    if not session:
+        # An unscoped receipt would authorise a later session to skip a read it
+        # never performed -- the precise failure this file exists to prevent.
+        print("REFUSED: CLAUDE_CODE_SESSION_ID is unset; an unscoped receipt would let a "
+              "different session skip a read it never did", file=sys.stderr)
+        return 2
+    import datetime
+    state_dir.mkdir(parents=True, exist_ok=True)
+    data = _load(state_dir)
+    text = skill.read_text(errors="ignore")
+    data[_key(session, skill)] = {
+        "sha256": _digest(skill),
+        "bytes": skill.stat().st_size,
+        "lines": text.count("\n") + 1,
+        "recorded_at": datetime.datetime.now(datetime.timezone.utc)
+                        .strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    tmp = state_dir / (RECEIPTS + ".tmp")
+    tmp.write_text(json.dumps(data, indent=1, sort_keys=True))
+    tmp.replace(state_dir / RECEIPTS)
+    print(f"recorded: {skill.name} {skill.stat().st_size} B read in full by session "
+          f"{session[:8]} (sha {_digest(skill)[:12]})")
+    return 0
+
+
+def audit(state_dir: Path) -> int:
+    """Every receipt THIS session holds, and whether the bytes still match.
+
+    A receipt says "I read these exact bytes". If the file changed afterwards the
+    session still runs on what it read, and the receipt is the only thing that can
+    notice -- nothing else in the process knows a read ever happened.
+    """
+    session = _session_id()
+    if not session:
+        print("CANNOT ANSWER: CLAUDE_CODE_SESSION_ID is unset, so this session's "
+              "receipts cannot be identified", file=sys.stderr)
+        return 2
+    mine = {k: v for k, v in _load(state_dir).items() if k.startswith(session + ":")}
+    if not mine:
+        print(f"no receipts for this session ({session[:8]}) -- nothing read in full yet")
+        return 0
+    drifted = []
+    for key, rec in sorted(mine.items()):
+        path = Path(key.split(":", 1)[1])
+        if not path.is_file():
+            drifted.append((path, "file is GONE since the read"))
+            continue
+        now = _digest(path)
+        if now != rec.get("sha256"):
+            drifted.append((path, f"{str(rec.get('sha256'))[:12]} -> {now[:12]}"))
+    print(f"{len(mine)} receipt(s) this session; {len(drifted)} drifted since the read")
+    for path, why in drifted:
+        print(f"  DRIFTED  {path}  ({why})")
+    return 1 if drifted else 0
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--skill", help="required for --check/--record; unused by --audit")
+    ap.add_argument("--state-dir", required=True)
+    ap.add_argument("--marker", default="",
+                    help="required clause; empty means none. pr-triage passes its own.")
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--check", action="store_true")
+    g.add_argument("--record", action="store_true")
+    g.add_argument("--audit", action="store_true")
+    a = ap.parse_args(argv)
+    state_dir = Path(a.state_dir)
+    if a.audit:
+        return audit(state_dir)
+    if not a.skill:
+        ap.error("--skill is required for --check and --record")
+    skill = Path(a.skill)
+    return check(skill, state_dir, a.marker) if a.check else record(skill, state_dir, a.marker)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/skill-read-receipt.test.py
+++ b/tests/skill-read-receipt.test.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Controls for scripts/skill-read-receipt.py — every exit path, both directions.
+
+A checker never observed FAILING is not a validated checker, so each assertion here
+drives the script into the state it is meant to catch and asserts the non-zero, not
+only the clean path.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPT = REPO / "scripts" / "skill-read-receipt.py"
+
+
+def run(args, session="sess-A"):
+    env = dict(os.environ)
+    if session is None:
+        env.pop("CLAUDE_CODE_SESSION_ID", None)
+        env["CLAUDE_CODE_SESSION_ID"] = ""
+    else:
+        env["CLAUDE_CODE_SESSION_ID"] = session
+    p = subprocess.run([sys.executable, str(SCRIPT)] + args,
+                       capture_output=True, text=True, env=env)
+    return p.returncode, p.stdout + p.stderr
+
+
+class ReceiptContract(unittest.TestCase):
+    def setUp(self):
+        self.d = Path(tempfile.mkdtemp())
+        self.skill = self.d / "SKILL.md"
+        self.skill.write_text("alpha\nbeta\n")
+        self.state = self.d / "state"
+
+    def _base(self):
+        return ["--skill", str(self.skill), "--state-dir", str(self.state)]
+
+    def test_no_receipt_demands_a_full_read(self):
+        rc, out = run(self._base() + ["--check"])
+        self.assertEqual(rc, 1, out)
+        self.assertIn("FULL READ REQUIRED", out)
+
+    def test_record_then_check_passes(self):
+        self.assertEqual(run(self._base() + ["--record"])[0], 0)
+        rc, out = run(self._base() + ["--check"])
+        self.assertEqual(rc, 0, out)
+
+    def test_changed_bytes_invalidate_the_receipt(self):
+        run(self._base() + ["--record"])
+        self.skill.write_text("alpha\nbeta CHANGED\n")
+        rc, out = run(self._base() + ["--check"])
+        self.assertEqual(rc, 1, out)
+        self.assertIn("content changed", out)
+
+    def test_another_sessions_receipt_is_never_reused(self):
+        run(self._base() + ["--record"], session="sess-A")
+        rc, out = run(self._base() + ["--check"], session="sess-B")
+        self.assertEqual(rc, 1, out)
+
+    def test_unscoped_record_is_refused(self):
+        rc, out = run(self._base() + ["--record"], session=None)
+        self.assertEqual(rc, 2, out)
+        self.assertIn("REFUSED", out)
+
+    def test_missing_file_cannot_answer(self):
+        rc, out = run(["--skill", str(self.d / "nope.md"),
+                       "--state-dir", str(self.state), "--check"])
+        self.assertEqual(rc, 2, out)
+
+    def test_absent_marker_cannot_answer(self):
+        rc, out = run(self._base() + ["--marker", "NOT PRESENT", "--check"])
+        self.assertEqual(rc, 2, out)
+
+    def test_marker_defaults_to_none_so_the_tool_is_generic(self):
+        """The pr-triage original defaulted to its own HARNESS-GREEN clause; a
+        generic tool that kept that default would refuse every other skill."""
+        self.assertEqual(run(self._base() + ["--record"])[0], 0)
+
+    # --- audit -------------------------------------------------------------
+    def test_audit_clean_when_nothing_changed(self):
+        run(self._base() + ["--record"])
+        rc, out = run(["--state-dir", str(self.state), "--audit"])
+        self.assertEqual(rc, 0, out)
+        self.assertIn("0 drifted", out)
+
+    def test_audit_FAILS_when_a_read_file_changed_underneath(self):
+        run(self._base() + ["--record"])
+        self.skill.write_text("alpha\nbeta CHANGED\n")
+        rc, out = run(["--state-dir", str(self.state), "--audit"])
+        self.assertEqual(rc, 1, out)
+        self.assertIn("DRIFTED", out)
+
+    def test_audit_FAILS_when_a_read_file_was_deleted(self):
+        run(self._base() + ["--record"])
+        self.skill.unlink()
+        rc, out = run(["--state-dir", str(self.state), "--audit"])
+        self.assertEqual(rc, 1, out)
+        self.assertIn("GONE", out)
+
+    def test_audit_ignores_other_sessions(self):
+        run(self._base() + ["--record"], session="sess-A")
+        self.skill.write_text("changed\n")
+        rc, out = run(["--state-dir", str(self.state), "--audit"], session="sess-B")
+        self.assertEqual(rc, 0, out)
+        self.assertIn("no receipts for this session", out)
+
+    def test_audit_without_a_session_cannot_answer(self):
+        rc, out = run(["--state-dir", str(self.state), "--audit"], session=None)
+        self.assertEqual(rc, 2, out)
+
+    def test_no_receipts_is_clean_not_a_failure(self):
+        rc, out = run(["--state-dir", str(self.d / "empty"), "--audit"])
+        self.assertEqual(rc, 0, out)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)

--- a/tests/skill-read-receipt.test.py
+++ b/tests/skill-read-receipt.test.py
@@ -1,32 +1,50 @@
 #!/usr/bin/env python3
 """Controls for scripts/skill-read-receipt.py — every exit path, both directions.
 
-A checker never observed FAILING is not a validated checker, so each assertion here
-drives the script into the state it is meant to catch and asserts the non-zero, not
-only the clean path.
+A checker never observed FAILING is not a validated checker, so each assertion drives
+the script into the state it is meant to catch and asserts the non-zero, not only the
+clean path.
+
+These call `main(argv)` IN-PROCESS rather than spawning the script. A subprocess test
+proves the CLI works and gives the coverage gate nothing — measured on this PR's first
+CI run: 106 lines changed, 106 missing, 0.0%. Driving main() exercises the same arg
+parsing and the same exit codes while staying visible to coverage.
 """
-import json
+import contextlib
+import importlib.util
+import io
 import os
-import subprocess
-import sys
 import tempfile
 import unittest
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
-SCRIPT = REPO / "scripts" / "skill-read-receipt.py"
+_spec = importlib.util.spec_from_file_location(
+    "skill_read_receipt", REPO / "scripts" / "skill-read-receipt.py")
+srr = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(srr)
 
 
-def run(args, session="sess-A"):
-    env = dict(os.environ)
-    if session is None:
-        env.pop("CLAUDE_CODE_SESSION_ID", None)
-        env["CLAUDE_CODE_SESSION_ID"] = ""
-    else:
-        env["CLAUDE_CODE_SESSION_ID"] = session
-    p = subprocess.run([sys.executable, str(SCRIPT)] + args,
-                       capture_output=True, text=True, env=env)
-    return p.returncode, p.stdout + p.stderr
+@contextlib.contextmanager
+def session(value):
+    """Set CLAUDE_CODE_SESSION_ID for one block; '' means unset-equivalent."""
+    prev = os.environ.get("CLAUDE_CODE_SESSION_ID")
+    os.environ["CLAUDE_CODE_SESSION_ID"] = value
+    try:
+        yield
+    finally:
+        if prev is None:
+            os.environ.pop("CLAUDE_CODE_SESSION_ID", None)
+        else:
+            os.environ["CLAUDE_CODE_SESSION_ID"] = prev
+
+
+def run(argv, sess="sess-A"):
+    """(rc, combined output) from main() in-process."""
+    out, err = io.StringIO(), io.StringIO()
+    with session(sess), contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        rc = srr.main(argv)
+    return rc, out.getvalue() + err.getvalue()
 
 
 class ReceiptContract(unittest.TestCase):
@@ -48,6 +66,7 @@ class ReceiptContract(unittest.TestCase):
         self.assertEqual(run(self._base() + ["--record"])[0], 0)
         rc, out = run(self._base() + ["--check"])
         self.assertEqual(rc, 0, out)
+        self.assertIn("receipt valid", out)
 
     def test_changed_bytes_invalidate_the_receipt(self):
         run(self._base() + ["--record"])
@@ -57,28 +76,40 @@ class ReceiptContract(unittest.TestCase):
         self.assertIn("content changed", out)
 
     def test_another_sessions_receipt_is_never_reused(self):
-        run(self._base() + ["--record"], session="sess-A")
-        rc, out = run(self._base() + ["--check"], session="sess-B")
+        run(self._base() + ["--record"], sess="sess-A")
+        rc, out = run(self._base() + ["--check"], sess="sess-B")
         self.assertEqual(rc, 1, out)
 
     def test_unscoped_record_is_refused(self):
-        rc, out = run(self._base() + ["--record"], session=None)
+        rc, out = run(self._base() + ["--record"], sess="")
         self.assertEqual(rc, 2, out)
         self.assertIn("REFUSED", out)
+
+    def test_unscoped_check_cannot_answer(self):
+        rc, out = run(self._base() + ["--check"], sess="")
+        self.assertEqual(rc, 2, out)
 
     def test_missing_file_cannot_answer(self):
         rc, out = run(["--skill", str(self.d / "nope.md"),
                        "--state-dir", str(self.state), "--check"])
         self.assertEqual(rc, 2, out)
 
-    def test_absent_marker_cannot_answer(self):
-        rc, out = run(self._base() + ["--marker", "NOT PRESENT", "--check"])
-        self.assertEqual(rc, 2, out)
+    def test_absent_marker_cannot_answer_on_both_paths(self):
+        """--check and --record share one precondition helper so they cannot disagree."""
+        for mode in ("--check", "--record"):
+            rc, out = run(self._base() + ["--marker", "NOT PRESENT", mode])
+            self.assertEqual(rc, 2, f"{mode}: {out}")
 
     def test_marker_defaults_to_none_so_the_tool_is_generic(self):
-        """The pr-triage original defaulted to its own HARNESS-GREEN clause; a
-        generic tool that kept that default would refuse every other skill."""
+        """The pr-triage original defaulted to its own HARNESS-GREEN clause; a generic
+        tool keeping that default would refuse every skill that does not carry it."""
         self.assertEqual(run(self._base() + ["--record"])[0], 0)
+
+    def test_a_corrupt_receipt_store_does_not_authorise_a_skip(self):
+        self.state.mkdir(parents=True, exist_ok=True)
+        (self.state / srr.RECEIPTS).write_text("{ not json")
+        rc, _ = run(self._base() + ["--check"])
+        self.assertEqual(rc, 1)
 
     # --- audit -------------------------------------------------------------
     def test_audit_clean_when_nothing_changed(self):
@@ -102,19 +133,23 @@ class ReceiptContract(unittest.TestCase):
         self.assertIn("GONE", out)
 
     def test_audit_ignores_other_sessions(self):
-        run(self._base() + ["--record"], session="sess-A")
+        run(self._base() + ["--record"], sess="sess-A")
         self.skill.write_text("changed\n")
-        rc, out = run(["--state-dir", str(self.state), "--audit"], session="sess-B")
+        rc, out = run(["--state-dir", str(self.state), "--audit"], sess="sess-B")
         self.assertEqual(rc, 0, out)
         self.assertIn("no receipts for this session", out)
 
     def test_audit_without_a_session_cannot_answer(self):
-        rc, out = run(["--state-dir", str(self.state), "--audit"], session=None)
+        rc, out = run(["--state-dir", str(self.state), "--audit"], sess="")
         self.assertEqual(rc, 2, out)
 
     def test_no_receipts_is_clean_not_a_failure(self):
         rc, out = run(["--state-dir", str(self.d / "empty"), "--audit"])
         self.assertEqual(rc, 0, out)
+
+    def test_check_without_skill_is_an_arg_error(self):
+        with self.assertRaises(SystemExit):
+            run(["--state-dir", str(self.state), "--check"])
 
 
 if __name__ == "__main__":

--- a/tests/skill-read-receipt.test.py
+++ b/tests/skill-read-receipt.test.py
@@ -12,6 +12,10 @@ parsing and the same exit codes while staying visible to coverage.
 """
 import contextlib
 import importlib.util
+import json
+import subprocess
+import sys
+import threading
 import io
 import os
 import tempfile
@@ -150,6 +154,50 @@ class ReceiptContract(unittest.TestCase):
     def test_check_without_skill_is_an_arg_error(self):
         with self.assertRaises(SystemExit):
             run(["--state-dir", str(self.state), "--check"])
+
+    # --- review findings from qingyun-wu on 46f48bd5 -----------------------
+    def test_concurrent_records_do_not_erase_each_other(self):
+        """P2: load->mutate->write was unserialised, so two record() calls could each
+        load the same snapshot and each write the WHOLE store back. Both returned 0
+        while only one receipt survived, and --audit then reported clean for a skill
+        nobody was tracking. Real processes, because the race is between writers."""
+        a, b = self.d / "A.md", self.d / "B.md"
+        a.write_text("aaa\n"); b.write_text("bbb\n")
+        env = dict(os.environ, CLAUDE_CODE_SESSION_ID="sess-race")
+        procs = [subprocess.Popen(
+            [sys.executable, str(REPO / "scripts" / "skill-read-receipt.py"),
+             "--skill", str(f), "--state-dir", str(self.state), "--record"],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env)
+            for f in (a, b)]
+        rcs = [p.wait() for p in procs]
+        self.assertEqual(rcs, [0, 0], "both records reported success")
+        store = json.loads((self.state / srr.RECEIPTS).read_text())
+        names = sorted(Path(k.split(":", 1)[1]).name for k in store)
+        self.assertEqual(names, ["A.md", "B.md"],
+                         f"a reported-successful receipt was erased: {names}")
+
+    def test_audit_REFUSES_a_corrupt_store_instead_of_reporting_clean(self):
+        """P2: _load collapsed corruption, a wrong top-level type and every I/O error
+        into {}, which --audit rendered as 'nothing read in full yet', rc=0. A broken
+        probe reporting clean is the exact failure this file exists to prevent."""
+        self.state.mkdir(parents=True, exist_ok=True)
+        for corrupt in ("{ truncated", "[]", "null"):
+            (self.state / srr.RECEIPTS).write_text(corrupt)
+            rc, out = run(["--state-dir", str(self.state), "--audit"])
+            self.assertEqual(rc, 2, f"{corrupt!r} -> rc={rc}: {out}")
+            self.assertIn("CANNOT ANSWER", out)
+
+    def test_record_refuses_to_overwrite_a_store_it_cannot_read(self):
+        self.state.mkdir(parents=True, exist_ok=True)
+        (self.state / srr.RECEIPTS).write_text("{ truncated")
+        rc, out = run(self._base() + ["--record"])
+        self.assertEqual(rc, 2, out)
+        self.assertIn("REFUSED", out)
+
+    def test_a_missing_store_is_empty_not_corrupt(self):
+        """The distinction has to cut both ways, or every fresh state dir refuses."""
+        rc, out = run(["--state-dir", str(self.d / "never-used"), "--audit"])
+        self.assertEqual(rc, 0, out)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`pr-triage` proved the shape on one procedure file. This lifts it to `scripts/` so any skill can use it, and adds `--audit`.

## Why this exists

A skill's text reaches an agent by **injection from the Claude Code harness** — not this repo's code, and not something we can make stamp what it served. This works on our side of that boundary: it records what the agent **read from disk**, so a skill with no receipt is one whose injected copy has never been checked against the file.

## Why a content hash and not an mtime

Measured 2026-09-11, **both directions in one session**:

```
collaboration-intelligence   injected body was 3 days BEHIND disk
                             (#4029 merged Sep 7; refresh-skill.sh --all had run 20 min earlier)
proactive-loop step 6.5      served body contained text present in NO FILE on this machine
                             (searched skills/, .claude-sutando/, ~/.claude — 1 hit, the transcript;
                              origin/main: 0, and the checkout was 0 behind)
```

A hash has no opinion about which side is newer, so it catches both. An mtime comparison is wrong in one direction and silent in the other — which is why I did not ship the mtime probe I first proposed.

`--marker` no longer defaults to pr-triage's `HARNESS-GREEN IS NOT A WITNESS`; a generic tool keeping that default would refuse every other skill.

## Evidence

Each control drives the script into the state it is meant to catch, rather than only exercising the clean path.

```
14 tests                                              OK
BREAK audit always returns 0 (silent detector)   ->   FAILED (failures=2)
BREAK drop the session scoping (reusable receipt)->   FAILED (failures=4)
RESTORED                                              OK

review-checks.sh --diff   PASS (hardcoded-paths + root-artifacts + prose-cap clean)
```

Replayed against a real skill on this host, not a fixture:

```
--check on collaboration-intelligence/SKILL.md, no prior read  ->  rc=1
  "FULL READ REQUIRED: no receipt for this session"
--record, then --audit                                         ->  1 receipt, 0 drifted
```

## What it does not do

It cannot see the injected text — only what was read from disk. A skill that is never read still has no receipt, which is the correct answer (unverified), not a false clear.

## Follow-up, named rather than bundled

`sutando-skills/skills/pr-triage/scripts/skill-read-receipt.py` is now a second copy of this predicate in another repo. Per CLAUDE.md that duplication is a defect in its own right; it needs a sutando-skills PR to delegate here. Not bundled into this one.

Stand: Echo Act IV Pro
