### PR TITLE
docs(agent-api): the tunnel instruction needs its precondition — the bind is the only thing in front of POST /task

### DIFF
--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -29,8 +29,10 @@ Twilio setup:
   Set webhook URL in Twilio console to https://<your-tunnel>/twilio/voice (calls)
   and https://<your-tunnel>/twilio/sms (messages).
 
-  The tunnel must forward ONLY those paths. A whole-port tunnel publishes every
-  endpoint above, and a proxy that connects from localhost defeats the
+  The tunnel must also forward /twilio/transcription: handle_twilio_voice sets it
+  as the voicemail transcribeCallback, so an allowlist without it records messages
+  whose transcripts never arrive. Forward ONLY those three. A whole-port tunnel
+  publishes every endpoint above, and a proxy that connects from localhost defeats the
   AGENT_API_BIND=127.0.0.1 default that is otherwise the only thing in front of
   POST /task -- check_auth() returns True unconditionally when SUTANDO_API_TOKEN
   is unset, which is the default.

--- a/src/agent-api.py
+++ b/src/agent-api.py
@@ -29,7 +29,15 @@ Twilio setup:
   Set webhook URL in Twilio console to https://<your-tunnel>/twilio/voice (calls)
   and https://<your-tunnel>/twilio/sms (messages).
 
+  The tunnel must forward ONLY those paths. A whole-port tunnel publishes every
+  endpoint above, and a proxy that connects from localhost defeats the
+  AGENT_API_BIND=127.0.0.1 default that is otherwise the only thing in front of
+  POST /task -- check_auth() returns True unconditionally when SUTANDO_API_TOKEN
+  is unset, which is the default.
+
 Security: Set SUTANDO_API_TOKEN in .env for token auth (Authorization: Bearer <token>).
+Without it POST /task is unauthenticated and the bind is the sole protection, so
+set the token BEFORE exposing this port by any route.
 For remote access: use ngrok or SSH tunnel.
 """
 


### PR DESCRIPTION
## What

The `src/agent-api.py` module docstring tells the reader to put a public tunnel in front of this port:

```
Twilio setup:
  Set webhook URL in Twilio console to https://<your-tunnel>/twilio/voice (calls)
```

Two lines later it mentions `SUTANDO_API_TOKEN` under "Security:", phrased as available hardening. Read in order, the tunnel step looks self-contained and the token looks optional.

## Why it matters

It is not optional. `check_auth()` (`:1095`) is:

```python
def check_auth(self) -> bool:
    if not API_TOKEN:
        return True  # No token = no auth required (local use)
```

`API_TOKEN` is `os.environ.get("SUTANDO_API_TOKEN", "")`, so with the variable unset — the default — `POST /task` is ungated. That endpoint writes into the task queue the core executes. The only thing in front of it is `AGENT_API_BIND`, default `127.0.0.1` (`:1657`).

And a tunnel removes that. A proxy terminating outside and forwarding to `http://127.0.0.1:7843` makes every request present as loopback to `self.client_address[0]`, which is what `check_private_history_auth` (`:851`) reads. So the bind stops protecting anything the moment a tunnel is aimed at the port — exactly the step the docstring recommends.

## Evidence

Measured on a Tailscale Funnel host, against the live process:

```
$ curl -s -o /dev/null -w '%{http_code}' -X POST http://127.0.0.1:7843/task -d ''
400                      <- reaches body parsing; no 401, because API_TOKEN is empty

$ grep -c '^SUTANDO_API_TOKEN=.' .env
0                        <- unset, the default

$ tailscale funnel status
https://<host>.ts.net (Funnel on)
|-- / proxy http://127.0.0.1:3100        <- one port, and it is not this one
```

The last line is also why this is a doc bug rather than a live incident here: the Funnel on this host fronts a different service, so `/twilio/voice` currently 404s from outside and nothing is exposed. The docstring is what would have changed that.

## What this changes

Docstring only — no behaviour change, no code path touched. It states the precondition the instruction already depended on, and names the endpoint that is exposed if it is skipped.

Stand: Echo Act IV Pro
