### PR TITLE
fix(startup): a Funnel host needs no ngrok, and nothing compared the configured webhook to the live funnel

### DIFF
--- a/src/startup.sh
+++ b/src/startup.sh
@@ -1211,7 +1211,36 @@ elif grep -qE '^[[:space:]]*TWILIO_ACCOUNT_SID=[^[:space:]]' .env 2>/dev/null; t
   else
     echo "  ✓ conversation server (already running)"
   fi
-  if ! pgrep -f "ngrok" > /dev/null 2>&1; then
+  # A Funnel URL is this host's own tunnel: conversation-server binds it directly
+  # and never starts ngrok, so attempting one prints a failure for something that
+  # is not needed. Nothing else compares the configured URL to the live funnel,
+  # so a webhook naming another machine boots silently.
+  FUNNEL_CFG_URL=$(grep -E '^TWILIO_WEBHOOK_URL=' .env 2>/dev/null | head -1 \
+    | cut -d'=' -f2- | cut -d'#' -f1 | tr -d '"' | tr -d "'" | xargs | sed 's:/*$::')
+  FUNNEL_MODE=0
+  case "$FUNNEL_CFG_URL" in *.ts.net) FUNNEL_MODE=1 ;; esac
+  if [ "$FUNNEL_MODE" = 1 ]; then
+    TS_BIN="${TAILSCALE_BIN:-}"
+    [ -n "$TS_BIN" ] || TS_BIN="$(command -v tailscale 2>/dev/null || true)"
+    [ -n "$TS_BIN" ] || TS_BIN=/Applications/Tailscale.app/Contents/MacOS/Tailscale
+    if [ ! -x "$TS_BIN" ]; then
+      # An absent CLI must not read as agreement: say UNCHECKED, never a tick.
+      echo "  ⊘ Funnel configured ($FUNNEL_CFG_URL) — tailscale CLI not found, drift UNCHECKED"
+    else
+      FUNNEL_LIVE=$("$TS_BIN" funnel status 2>/dev/null \
+        | grep -oE 'https://[A-Za-z0-9.-]+\.ts\.net' | head -1)
+      if [ -z "$FUNNEL_LIVE" ]; then
+        echo "  ⊘ Funnel configured ($FUNNEL_CFG_URL) — no funnel is serving, drift UNCHECKED"
+      elif [ "$FUNNEL_CFG_URL" = "$FUNNEL_LIVE" ]; then
+        echo "  ✓ Funnel ($FUNNEL_LIVE — matches TWILIO_WEBHOOK_URL)"
+      else
+        echo "  ⚠ TWILIO_WEBHOOK_URL names a DIFFERENT host than this machine's funnel:"
+        echo "      configured: $FUNNEL_CFG_URL"
+        echo "      this host:  $FUNNEL_LIVE"
+        echo "      Twilio reaches the configured host, not this one — repoint one of them."
+      fi
+    fi
+  elif ! pgrep -f "ngrok" > /dev/null 2>&1; then
     echo "  Starting ngrok tunnel..."
     # If NGROK_DOMAIN is set in .env, use the reserved domain for a stable URL.
     # Otherwise ngrok picks a random subdomain and the Twilio webhook must be

--- a/src/startup.sh
+++ b/src/startup.sh
@@ -1217,8 +1217,16 @@ elif grep -qE '^[[:space:]]*TWILIO_ACCOUNT_SID=[^[:space:]]' .env 2>/dev/null; t
   # so a webhook naming another machine boots silently.
   FUNNEL_CFG_URL=$(grep -E '^TWILIO_WEBHOOK_URL=' .env 2>/dev/null | head -1 \
     | cut -d'=' -f2- | cut -d'#' -f1 | tr -d '"' | tr -d "'" | xargs | sed 's:/*$::')
+  # Funnel listens on 443, 8443 or 10000, so the port is part of the endpoint:
+  # comparing hostnames alone calls :443 and :8443 the same reachable URL.
+  # Normalise an explicit :443 away, keep every other port.
+  funnel_origin() {  # scheme://host[:port] -> canonical origin, or empty if not .ts.net
+    printf '%s' "$1" | sed -E 's#^(https?://[^/]+).*#\1#; s#:443$##' \
+      | grep -E '^https?://[A-Za-z0-9.-]+\.ts\.net(:[0-9]+)?$' || true
+  }
+  FUNNEL_CFG_ORIGIN="$(funnel_origin "$FUNNEL_CFG_URL")"
   FUNNEL_MODE=0
-  case "$FUNNEL_CFG_URL" in *.ts.net) FUNNEL_MODE=1 ;; esac
+  [ -n "$FUNNEL_CFG_ORIGIN" ] && FUNNEL_MODE=1
   if [ "$FUNNEL_MODE" = 1 ]; then
     TS_BIN="${TAILSCALE_BIN:-}"
     [ -n "$TS_BIN" ] || TS_BIN="$(command -v tailscale 2>/dev/null || true)"
@@ -1228,14 +1236,15 @@ elif grep -qE '^[[:space:]]*TWILIO_ACCOUNT_SID=[^[:space:]]' .env 2>/dev/null; t
       echo "  ⊘ Funnel configured ($FUNNEL_CFG_URL) — tailscale CLI not found, drift UNCHECKED"
     else
       FUNNEL_LIVE=$("$TS_BIN" funnel status 2>/dev/null \
-        | grep -oE 'https://[A-Za-z0-9.-]+\.ts\.net' | head -1)
+        | grep -oE 'https://[A-Za-z0-9.-]+\.ts\.net(:[0-9]+)?' | head -1)
+      FUNNEL_LIVE="$(funnel_origin "$FUNNEL_LIVE")"
       if [ -z "$FUNNEL_LIVE" ]; then
         echo "  ⊘ Funnel configured ($FUNNEL_CFG_URL) — no funnel is serving, drift UNCHECKED"
-      elif [ "$FUNNEL_CFG_URL" = "$FUNNEL_LIVE" ]; then
+      elif [ "$FUNNEL_CFG_ORIGIN" = "$FUNNEL_LIVE" ]; then
         echo "  ✓ Funnel ($FUNNEL_LIVE — matches TWILIO_WEBHOOK_URL)"
       else
         echo "  ⚠ TWILIO_WEBHOOK_URL names a DIFFERENT host than this machine's funnel:"
-        echo "      configured: $FUNNEL_CFG_URL"
+        echo "      configured: $FUNNEL_CFG_ORIGIN"
         echo "      this host:  $FUNNEL_LIVE"
         echo "      Twilio reaches the configured host, not this one — repoint one of them."
       fi

--- a/tests/startup-funnel-drift.test.sh
+++ b/tests/startup-funnel-drift.test.sh
@@ -78,6 +78,26 @@ case "$out" in
   *) bad "trailing slash + comment normalise" "got: $out" ;;
 esac
 
-total=$((9))
+# --- port is part of the endpoint (qingyun-wu on #4187): 443/8443/10000 are all
+# --- valid Funnel ports, so a hostname-only compare calls :443 and :8443 equal.
+out="$(run_case "TWILIO_WEBHOOK_URL=$PRO" "$(mk_ts "$PRO:8443")")"
+case "$out" in
+  *"DIFFERENT host"*) ok "configured :443 vs live :8443 -> warns, no false agreement" ;;
+  *) bad "configured :443 vs live :8443 -> warns" "got: $out" ;;
+esac
+
+out="$(run_case "TWILIO_WEBHOOK_URL=$PRO:8443" "$(mk_ts "$PRO:8443")")"
+case "$out" in
+  *"matches TWILIO_WEBHOOK_URL"*) ok "a ported configured URL still enters funnel mode and matches" ;;
+  *) bad "ported configured URL enters funnel mode" "got: $out" ;;
+esac
+
+out="$(run_case "TWILIO_WEBHOOK_URL=$PRO:443" "$(mk_ts "$PRO")")"
+case "$out" in
+  *"matches TWILIO_WEBHOOK_URL"*) ok "explicit :443 normalises to the default" ;;
+  *) bad "explicit :443 normalises" "got: $out" ;;
+esac
+
+total=$((12))
 echo "  Total: $total — pass: $((total-fails)), fail: $fails"
 [ "$fails" -eq 0 ]

--- a/tests/startup-funnel-drift.test.sh
+++ b/tests/startup-funnel-drift.test.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Drives the Funnel block extracted from src/startup.sh by its own anchors, so
+# deleting the block fails this file instead of leaving it green.
+set -uo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC="$REPO/src/startup.sh"
+fails=0
+ok()  { printf '  ok   %s\n' "$1"; }
+bad() { printf '  FAIL %s %s\n' "$1" "${2:-}"; fails=$((fails+1)); }
+
+echo "startup funnel drift:"
+
+# The live region is an if/elif chain; take it to the elif, drop that line, and
+# close the if so the extract runs standalone. Anchored on the live source, so
+# deleting the block empties this and fails below rather than passing vacuously.
+BLOCK="$(awk '/^ *FUNNEL_CFG_URL=/,/^ *elif ! pgrep -f "ngrok"/' "$SRC" | sed '$d')
+fi"
+if [ -z "$BLOCK" ]; then
+  bad "block extracted from src/startup.sh" "no FUNNEL_CFG_URL region found"
+  echo "  Total: 1 — pass: 0, fail: 1"; exit 1
+fi
+ok "block extracted from src/startup.sh"
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+# A stub tailscale: prints whatever funnel status we want it to.
+mk_ts() {  # $1 = the https://... line to emit, or empty for "nothing serving"
+  printf '#!/usr/bin/env bash\n[ "$1" = funnel ] || exit 0\n' > "$TMP/ts"
+  [ -n "$1" ] && printf 'echo "%s (Funnel on)"\n' "$1" >> "$TMP/ts"
+  chmod +x "$TMP/ts"; echo "$TMP/ts"
+}
+run_case() {  # $1=.env body  $2=TAILSCALE_BIN
+  ( cd "$TMP" && printf '%s\n' "$1" > .env && TAILSCALE_BIN="$2" bash -c "$BLOCK" 2>&1 )
+}
+
+PRO="https://chis-macbook-pro.taild96b9b.ts.net"
+AIR="https://chis-macbook-air.taild96b9b.ts.net"
+
+out="$(run_case "TWILIO_WEBHOOK_URL=$PRO" "$(mk_ts "$PRO")")"
+case "$out" in
+  *"matches TWILIO_WEBHOOK_URL"*) ok "configured == live funnel -> confirms, no warning" ;;
+  *) bad "configured == live funnel -> confirms" "got: $out" ;;
+esac
+case "$out" in *"DIFFERENT host"*) bad "match must not warn" "got: $out" ;; *) ok "match does not warn" ;; esac
+
+out="$(run_case "TWILIO_WEBHOOK_URL=$AIR" "$(mk_ts "$PRO")")"
+case "$out" in
+  *"DIFFERENT host"*) ok "configured != live funnel -> warns" ;;
+  *) bad "configured != live funnel -> warns" "got: $out" ;;
+esac
+case "$out" in *"$AIR"*) ok "warning names the configured host" ;; *) bad "warning names configured host" ;; esac
+case "$out" in *"$PRO"*) ok "warning names this host's funnel" ;; *) bad "warning names this host" ;; esac
+
+# The control that matters: a missing CLI must read as UNCHECKED, never as a tick.
+out="$(run_case "TWILIO_WEBHOOK_URL=$AIR" "$TMP/definitely-not-here")"
+case "$out" in
+  *UNCHECKED*) ok "absent tailscale -> UNCHECKED, not agreement" ;;
+  *) bad "absent tailscale -> UNCHECKED" "got: $out" ;;
+esac
+case "$out" in *"✓"*) bad "absent tailscale must not tick" "got: $out" ;; *) ok "absent tailscale does not tick" ;; esac
+
+out="$(run_case "TWILIO_WEBHOOK_URL=$AIR" "$(mk_ts "")")"
+case "$out" in
+  *UNCHECKED*) ok "no funnel serving -> UNCHECKED, not agreement" ;;
+  *) bad "no funnel serving -> UNCHECKED" "got: $out" ;;
+esac
+
+# A non-Funnel URL must leave FUNNEL_MODE off so the ngrok path still runs.
+out="$(run_case "TWILIO_WEBHOOK_URL=https://tunnel.ngrok-free.app" "$(mk_ts "$PRO")")"
+case "$out" in
+  ""|*"Starting ngrok"*) ok "ngrok URL -> funnel block silent, ngrok path untouched" ;;
+  *) bad "ngrok URL -> funnel block silent" "got: $out" ;;
+esac
+
+# Trailing slash and a trailing comment are the shapes .env actually carries.
+out="$(run_case "TWILIO_WEBHOOK_URL=$PRO/  # tailscale funnel" "$(mk_ts "$PRO")")"
+case "$out" in
+  *"matches TWILIO_WEBHOOK_URL"*) ok "trailing slash + comment normalise" ;;
+  *) bad "trailing slash + comment normalise" "got: $out" ;;
+esac
+
+total=$((9))
+echo "  Total: $total — pass: $((total-fails)), fail: $fails"
+[ "$fails" -eq 0 ]


### PR DESCRIPTION
## What

Two defects in one region of `src/startup.sh`, landing together because the second is why the first cannot be fixed alone.

**1. A Funnel host attempts an ngrok tunnel it will never use.** startup gates the attempt on `TWILIO_ACCOUNT_SID` alone (`:1206`), while conversation-server's own rule is `if (!NGROK_AUTHTOKEN && !process.env.TWILIO_WEBHOOK_URL)` (`conversation-server.ts:191`) — a set `TWILIO_WEBHOOK_URL` makes ngrok unnecessary, because the server binds that URL directly. Every Funnel boot prints `✗ ngrok (failed to start)` for something it does not need.

**2. Nothing compared the configured webhook to the live funnel.** The existing drift check sits inside the ngrok branch and deliberately no-ops on a non-ngrok URL:

```sh
elif ! printf '%s' "$TWILIO_CFG_URL" | grep -qE '\.ngrok(-free)?\.(app|io)$'; then
  # A non-ngrok tunnel (e.g. Funnel) is authoritative: the phone server
  # binds it and never starts ngrok, so this ngrok is not its tunnel.
  :
```

That reasoning about ngrok is right. The consequence is that Funnel was unchecked entirely — before this change `grep -ci funnel src/startup.sh` returned **1**, and that one hit is the comment above explaining the skip.

## Why it matters, measured

On this host `TWILIO_WEBHOOK_URL` named a *different machine* and booted silently:

```
tailscale status   chis-macbook-air   active; relay "sea"; offline, last seen 16m ago
GET <air>.ts.net/health    timeout      <- what health-check reported as "down"
GET <pro>.ts.net/health    200          <- this host's own funnel, serving the whole time
```

The only signal was health-check's `down (urlopen error timed out)`, which reads as a network fault rather than a misconfiguration. A boot-time line naming both URLs is the difference between an hour of tracing and one sentence.

Fixing the ngrok gate *without* adding the funnel check would remove the only tunnel verification the path has, which is why these are one change.

## An absent instrument reports UNCHECKED, never a tick

No tailscale CLI, or no funnel serving, prints `⊘ … drift UNCHECKED`. A missing instrument must not read as agreement.

## Tests

`tests/startup-funnel-drift.test.sh` drives the block extracted from `startup.sh` by its own anchors, the same pattern the neighbouring drift suite uses.

```
match -> confirms, does not warn        mismatch -> warns, naming BOTH hosts
absent tailscale -> UNCHECKED, no tick  no funnel serving -> UNCHECKED
ngrok URL -> funnel block silent, ngrok path untouched
trailing slash + trailing comment normalise
Total: 9 — pass: 9, fail: 0
```

Control, run by deleting the block: the suite drops to **1 pass / 8 fail** rather than passing vacuously. The pre-existing `startup-twilio-webhook-drift` suite stays **10/10**. `shellcheck -S error` clean on both files.

## Not witnessed live

This is a startup path, so harness-green is not a witness: a real post-restart round trip is owed before any approval recommendation, and that needs an owner-authorized restart window. Flagging it rather than implying the suite settles it.

Stand: Echo Act IV Pro
