### PR TITLE
ci(py39): the 3.9-floor scan follows production python into skills/

### DIFF
--- a/.github/workflows/python39-compat.yml
+++ b/.github/workflows/python39-compat.yml
@@ -11,6 +11,8 @@ on:
   pull_request:
     paths:
       - 'src/**/*.py'
+      # Production python that moved out of src/ into a skill still ships.
+      - 'skills/**/*.py'
       - 'scripts/check-python39-compat.py'
       - 'tests/check-python39-compat.test.py'
       - '.github/workflows/python39-compat.yml'
@@ -18,6 +20,8 @@ on:
     branches: [main]
     paths:
       - 'src/**/*.py'
+      # Production python that moved out of src/ into a skill still ships.
+      - 'skills/**/*.py'
       - 'scripts/check-python39-compat.py'
       - 'tests/check-python39-compat.test.py'
       - '.github/workflows/python39-compat.yml'

--- a/scripts/check-python39-compat.py
+++ b/scripts/check-python39-compat.py
@@ -56,7 +56,9 @@ import sys
 from pathlib import Path
 
 #: Directories scanned. src/ is where the bridge-imported modules live.
-DEFAULT_TARGETS = ("src",)
+# src/ is not the whole product: a module relocated into skills/ runs on the
+# same 3.9.6 interpreter, so the scan follows the code rather than the folder.
+DEFAULT_TARGETS = ("src", "skills")
 
 #: Constructs that MUST fail to parse on 3.9. If any of these compiles, the
 #: interpreter running this script is newer than the floor and the scan below

--- a/tests/python39-guard-follows-skills.test.py
+++ b/tests/python39-guard-follows-skills.test.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""The 3.9 guard must follow production python that moved out of src/.
+
+Run: python3 tests/python39-guard-follows-skills.test.py
+
+python39-compat.yml is the ONLY job validating 3.9.6; its own header says a
+3.10+ regression is otherwise "green everywhere and only fails at bridge
+restart". When a module relocates from src/ into a skill, both the workflow
+TRIGGER and the scanner TARGET have to follow it or the guard silently stops
+covering the code it guards. Neither half was pinned, so reverting either left
+every test green.
+"""
+import re
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+WF = REPO / ".github" / "workflows" / "python39-compat.yml"
+SCANNER = REPO / "scripts" / "check-python39-compat.py"
+
+
+def _triggers_on_skill_python(block: str) -> bool:
+    """True when a `paths:` block has a LIVE entry under skills/ ending in .py."""
+    for ln in block.splitlines():
+        if ln.lstrip().startswith("#"):
+            continue
+        if "skills/" in ln and ln.strip().endswith(".py'"):
+            return True
+    return False
+
+
+class TestPython39GuardFollowsSkills(unittest.TestCase):
+    def test_workflow_triggers_on_skill_python(self):
+        text = WF.read_text()
+        # Both path lists, not just the first; comments are legal inside one and
+        # a run-of-entries regex stops there, reporting a present entry absent.
+        blocks = re.findall(r"paths:\n((?:\s+(?:-\s'[^']+'|#[^\n]*)\n)+)", text)
+        self.assertGreaterEqual(len(blocks), 2,
+                                "expected pull_request AND push path lists in python39-compat.yml")
+        for i, b in enumerate(blocks):
+            self.assertTrue(_triggers_on_skill_python(b),
+                            f"path list #{i+1} does not trigger on any skills/**.py — production "
+                            f"python that moved into a skill would not run this job:\n{b}")
+
+    def test_a_commented_out_skills_path_does_not_count(self):
+        # The block regex admits comments so a comment cannot break the match;
+        # the membership test must then skip them, or a disabled entry reads as live.
+        live = "      - 'src/**/*.py'\n      - 'skills/**/*.py'\n"
+        disabled = "      - 'src/**/*.py'\n      # - 'skills/**/*.py'\n"
+        self.assertTrue(_triggers_on_skill_python(live))
+        self.assertFalse(_triggers_on_skill_python(disabled))
+
+    def test_scanner_default_targets_include_skills(self):
+        text = SCANNER.read_text()
+        m = re.search(r"DEFAULT_TARGETS\s*=\s*\(([^)]*)\)", text)
+        self.assertIsNotNone(m, "DEFAULT_TARGETS not found in check-python39-compat.py")
+        targets = {t.strip().strip('\'"') for t in m.group(1).split(",") if t.strip()}
+        self.assertIn("skills", targets,
+                      f"scanner defaults to {sorted(targets)} — a triggered run would still "
+                      "scan only src/, so the job passes without reading the moved module")
+        self.assertIn("src", targets, "src must remain scanned")
+
+    def test_the_moved_module_is_actually_reachable(self):
+        """The two halves above are necessary; this is the end-to-end claim."""
+        moved = REPO / "skills" / "worker-pool" / "scripts"
+        if not moved.is_dir():
+            self.skipTest("worker-pool scripts not present on this base")
+        pys = list(moved.rglob("*.py"))
+        self.assertTrue(pys, "no .py under the skill's scripts/ — nothing for the guard to reach")
+        m = re.search(r"DEFAULT_TARGETS\s*=\s*\(([^)]*)\)", SCANNER.read_text())
+        targets = {t.strip().strip('\'"') for t in m.group(1).split(",") if t.strip()}
+        self.assertTrue(any(str(p.relative_to(REPO)).startswith(t + "/") for p in pys for t in targets),
+                        f"{pys[0].relative_to(REPO)} is under no scanned target {sorted(targets)}")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
**Rewritten after #4206 merged (owner: "after 4206 is merged, update our PR").** Previous head `e093c142b` carried the module move, a discovery-owner script, consumer widening and their guards. #4206 landed the move with the suites under `tests/skills/worker-pool/`, which every existing recursive `find tests` consumer already reaches, so all of that is superseded and dropped. What survives is the one CI contract the move left uncovered.

## The gap

`python39-compat.yml` is the ONLY job validating the 3.9.6 floor. Both halves were pinned to `src/`:

```
.github/workflows/python39-compat.yml   paths: - 'src/**/*.py'        (pull_request AND push)
scripts/check-python39-compat.py        DEFAULT_TARGETS = ("src",)
```

After #4206, `skills/worker-pool/scripts/*.py` is production python under neither. A 3.10+ construct there is green on every PR job and fails only at bridge restart on a 3.9 host.

## The change (3 files, +84/−1)

- workflow: both path lists gain `skills/**/*.py`
- scanner: `DEFAULT_TARGETS = ("src", "skills")`
- `tests/python39-guard-follows-skills.test.py`: pins the trigger (live entries only, a commented-out one does not count), the scanner target, and the end-to-end claim that the moved modules sit under a scanned target.

## Evidence

```
control — suite against main's scanner + workflow:   FAILED (failures=3)
  test_scanner_default_targets_include_skills / test_the_moved_module_is_actually_reachable / test_workflow_triggers_on_skill_python
at HEAD:                                              Ran 4 · OK
/usr/bin/python3 (3.9.6) scripts/check-python39-compat.py:
  self-test: ok — detector rejects 3.10+ syntax and accepts 3.9 syntax
  python39-compat: 310 file(s) parse cleanly on 3.9.6
review-checks.sh --diff PASS · lint-workspace-resolution clean · ruff clean · ci-covers-every-python-test OK · gen-src-map --check up to date
```

Worst case: none for existing installs — this only widens what one CI job scans and triggers on; a 3.9-incompatible line in `skills/` now fails the job instead of a host.

**Series note:** children (#4108 → #4110 → #4115 → …) were based on this branch's previous layout, including suites at `skills/worker-pool/tests/`. Under the merged layout those must move to `tests/skills/worker-pool/` when they re-home onto `main`; that is a series change, not this PR's.

Sutando core (qingyun-001)
