### PR TITLE
feat(telemetry): track recovery issues across retries

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,8 @@ Machine-readable ownership and lifecycle metadata lives in
 
 ## Operations
 
+- [Recovery issue metrics](recovery-issue-metrics.md) — persistent issue IDs and recovery-rate definitions.
+
 - [Release process and migrations](release-process.md)
 - [Workspace sync across machines](workspace-sync.md)
 - [Per-host workspace convention](workspace-hosts-convention.md)

--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -453,6 +453,16 @@
    "status": "canonical",
    "canonical_for": "why each proactive-loop step exists: the measurement, the incident and the reasoning the skill file no longer carries",
    "last_verified": "2026-09-04"
+  },
+  "docs/recovery-issue-metrics.md": {
+   "title": "Recovery issue metrics",
+   "audience": [
+    "contributors",
+    "operators"
+   ],
+   "status": "canonical",
+   "canonical_for": "Recovery issue identity, event lifecycle, and rate query semantics",
+   "last_verified": "2026-09-11"
   }
  }
 }

--- a/docs/recovery-issue-metrics.md
+++ b/docs/recovery-issue-metrics.md
@@ -1,0 +1,63 @@
+# Recovery issue metrics
+
+Attempt metrics cannot identify how many distinct issues eventually recovered.
+The additive issue stream keeps retries attached to a durable random UUID.
+Existing `health_fix_*` and `core_*` events retain their current meanings.
+
+| Event | Meaning |
+| --- | --- |
+| `recovery_issue_detected` | First recovery attempt for this observed issue |
+| `recovery_issue_attempted` | A recovery pass for the issue, including retries |
+| `recovery_issue_recovered` | The issue's recovery was subsequently observed |
+
+Every issue event contains `issue_id` and `issue_type` (`health_check` or `core`).
+Check names, task identities, paths, and details stay local. Each health check has
+its own UUID even though its exported type is the same privacy-safe category.
+A partial batch can therefore recover two checks while a third stays open.
+
+Health issues begin when a non-OK check enters a fix pass. They remain open across
+retries, missing checks, warnings, and process restarts until that check explicitly
+reports OK. A recurrence after OK gets a new UUID. These are observed check
+episodes, not deduplicated underlying root causes across different checks.
+
+Core issues begin at a restart attempt, including a failed launch or exception.
+Dead/wedged transitions and retries share the same UUID. Recovery requires an
+alive core with no queued task, a changed oldest task, or an advanced status
+timestamp relative to the first attempt. A launched process alone is not recovery.
+This observes recovery after intervention; it does not prove which repair caused it.
+
+## Query contract
+
+Group by installation (`distinct_id`) and `issue_id`, never by attempt count.
+For a cohort first detected in a selected period, count unique issues with a
+subsequent recovered event as of the observation cutoff:
+
+`observed recovery percentage = recovered issues / detected issues * 100`
+
+For example, five attempts for issue A followed by recovery count as one detected
+and one recovered issue (100%). Two recovered issues and one still open yield
+66.7%; show the open count alongside the rate. A zero denominator is N/A.
+Follow the cohort beyond the detection window when looking for recovery, and show
+the cutoff date: recent cohorts have had less time to recover.
+
+An unresolved attempt or cooldown/give-up does not close an issue as failed.
+There is no terminal failure signal today; label unmatched issues open or
+"no recovery observed", not failed. A missing detected event is incomplete data,
+not an extra success in the cohort. Historical events without IDs cannot be
+backfilled reliably; retain their attempt charts separately. Dashboard adoption
+is a separate change after clients emit this stream.
+
+## Persistence and delivery
+
+Issue state uses sibling `*-issues.json` files beside the existing health-fix and
+core-recovery state files in the resolved workspace. Writers use an exclusive
+nonblocking lock and atomic replacement; recovered records are removed. Open
+records are retained without a time cutoff. State must survive upgrades/restarts.
+Deleting it loses correlation; corrupt state suppresses issue tracking until
+repaired rather than generating new identities on every tick.
+
+Telemetry remains best effort through the existing capture/opt-out path. State is
+committed before sending; offline delivery or a crash between commit and capture
+can lose an event. UUID grouping removes retry inflation, not telemetry loss.
+No new configuration or dependency is needed. Rollback leaves unused issue-state
+files and does not change recovery behavior or existing dashboard queries.

--- a/docs/recovery-issue-metrics.md
+++ b/docs/recovery-issue-metrics.md
@@ -61,3 +61,9 @@ committed before sending; offline delivery or a crash between commit and capture
 can lose an event. UUID grouping removes retry inflation, not telemetry loss.
 No new configuration or dependency is needed. Rollback leaves unused issue-state
 files and does not change recovery behavior or existing dashboard queries.
+
+Locking is supported on macOS/Linux; without `fcntl` this stream is disabled.
+A contended writer skips that tick rather than delaying repairs. The next explicit
+OK can still close the original issue; an entire episode inside contention may
+be missed. A renamed or removed check stays unmatched until explicitly migrated
+or observed OK; do not treat those orphaned records as confirmed failures.

--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -139,6 +139,7 @@ One entry per agent-facing module. 5 without a usable header comment.
 - **`read_discord_channel.py`** — Gated Discord channel reader — compatibility wrapper over the shared reader and the shared contextNotFrom policy.
 - **`recording-state.ts`** — Shared recording state — used by both browser-tools.ts (describeScreenTool) and recording-tools.ts (scrollAndDescribeTool, screenRecordTool, etc.)
 - **`recording-tools.ts`** — Recording, video playback, and scroll-and-describe tools.
+- **`recovery_issues.py`** — Durable issue identities for recovery telemetry, independent of retry counts.
 - **`remote-gateway-bridge.py`** — remote-gateway-bridge.py — sutando loader for the canonical ag2-sparrow client.
 - **`remote-relay-bridge.py`** — remote-relay-bridge.py — DEPRECATED name; renamed to remote-gateway-bridge.py.
 - **`render_plist_template.py`** — Render a launchd plist: literal __TOKEN__ substitution, XML escaping, parse check.

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -13717,6 +13717,15 @@ def _recovery_metric(event: str, **properties) -> None:
         pass
 
 
+def _track_core_issue(state_file, **observation):
+    try:
+        from recovery_issues import track_core_issue
+        track_core_issue(state_file.with_name(state_file.stem + "-issues.json"),
+                         emit=_recovery_metric, **observation)
+    except Exception:
+        pass
+
+
 def _recovery_duration(seconds: float) -> str:
     for threshold, bucket in ((60, "<1m"), (300, "1-5m"), (1800, "5-30m")):
         if seconds < threshold:
@@ -13873,10 +13882,7 @@ def recover_core_if_wedged(
                   f"UNKNOWN, not dead; suppressing restart and RESETTING the "
                   f"confirmation window", file=sys.stderr)
             return {"action": "probe-failed", "probe": which}
-        from recovery_issues import track_core_issue
-        issue_file = state_file.with_name(state_file.stem + "-issues.json")
-        track_core_issue(issue_file, alive=alive, task=cur_key,
-                         status_ts=status_ts, emit=_recovery_metric)
+        _track_core_issue(state_file, alive=alive, task=cur_key, status_ts=status_ts)
         pending = state.get("recovery_metric_pending")
         if pending and alive and (
             oldest is None or cur_key != pending["task"] or (
@@ -14000,8 +14006,8 @@ def recover_core_if_wedged(
         if not dm_ok:
             print("[recover-core] WARNING: wedge-restart DM failed; restarting anyway", flush=True)
 
-        track_core_issue(issue_file, alive=alive, task=cur_key,
-                         status_ts=status_ts, start=True, emit=_recovery_metric)
+        _track_core_issue(state_file, alive=alive, task=cur_key,
+                          status_ts=status_ts, start=True)
         _recovery_metric("core_recovery_attempted", trigger=cur_mode)
         try:
             restart_ok = restart_fn()

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -13730,6 +13730,9 @@ def track_health_fix(checks: list, *, start: bool = False, state_file=None, now=
         if fcntl is None:
             return
         state_file = state_file or WORKSPACE_DIR / "state" / "health-fix-metrics.json"
+        from recovery_issues import track_health_issues
+        track_health_issues(state_file.with_name(state_file.stem + "-issues.json"),
+                            checks, start=start, emit=_recovery_metric)
         now = time.time() if now is None else now
         state_file.parent.mkdir(parents=True, exist_ok=True)
         with open(state_file.with_name(state_file.name + ".lock"), "a") as lock:
@@ -13870,6 +13873,10 @@ def recover_core_if_wedged(
                   f"UNKNOWN, not dead; suppressing restart and RESETTING the "
                   f"confirmation window", file=sys.stderr)
             return {"action": "probe-failed", "probe": which}
+        from recovery_issues import track_core_issue
+        issue_file = state_file.with_name(state_file.stem + "-issues.json")
+        track_core_issue(issue_file, alive=alive, task=cur_key,
+                         status_ts=status_ts, emit=_recovery_metric)
         pending = state.get("recovery_metric_pending")
         if pending and alive and (
             oldest is None or cur_key != pending["task"] or (
@@ -13993,6 +14000,8 @@ def recover_core_if_wedged(
         if not dm_ok:
             print("[recover-core] WARNING: wedge-restart DM failed; restarting anyway", flush=True)
 
+        track_core_issue(issue_file, alive=alive, task=cur_key,
+                         status_ts=status_ts, start=True, emit=_recovery_metric)
         _recovery_metric("core_recovery_attempted", trigger=cur_mode)
         try:
             restart_ok = restart_fn()

--- a/src/recovery_issues.py
+++ b/src/recovery_issues.py
@@ -1,0 +1,88 @@
+"""Durable issue identities for recovery telemetry, independent of retry counts."""
+
+import json
+import os
+from pathlib import Path
+import tempfile
+import uuid
+
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
+
+
+def _update(path, change, emit):
+    """Serialize observations and publish state before best-effort telemetry."""
+    if fcntl is None:
+        return
+    try:
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path.with_name(path.name + '.lock'), 'a') as lock:
+            fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            state = json.loads(path.read_text()) if path.exists() else {}
+            events = []
+            change(state, events)
+            if not events:
+                return
+            tmp = None
+            try:
+                with tempfile.NamedTemporaryFile(mode='w', dir=path.parent,
+                                                 prefix='.recovery-issues-', delete=False) as out:
+                    tmp = Path(out.name)
+                    json.dump(state, out)
+                os.replace(tmp, path)
+            finally:
+                if tmp is not None:
+                    tmp.unlink(missing_ok=True)
+            for event, properties in events:
+                try:
+                    emit(event, **properties)
+                except Exception:
+                    pass
+    except Exception:
+        # Corrupt/unwritable state must not invent identities or prevent repairs.
+        return
+
+
+def _event(events, action, issue):
+    events.append(('recovery_issue_' + action, {
+        'issue_id': issue['issue_id'], 'issue_type': issue['issue_type'],
+    }))
+
+
+def _begin(state, key, issue_type, events, **local):
+    if key not in state:
+        state[key] = dict(issue_id=str(uuid.uuid4()), issue_type=issue_type, **local)
+        _event(events, 'detected', state[key])
+    _event(events, 'attempted', state[key])
+
+
+def track_health_issues(path, checks, *, start, emit):
+    """One issue per failing check; only an explicit OK closes it."""
+    def change(state, events):
+        for check in checks:
+            key = check['name']
+            if check['status'] == 'ok' and key in state:
+                _event(events, 'recovered', state.pop(key))
+            elif start and check['status'] != 'ok':
+                _begin(state, key, 'health_check', events)
+    _update(path, change, emit)
+
+
+def track_core_issue(path, *, alive, task, status_ts, start=False, emit):
+    """Keep one core issue across retries until observed queue/status progress."""
+    def change(state, events):
+        issue = state.get('core')
+        if issue and alive is True and (
+            task is None or task != issue['task'] or (
+                isinstance(status_ts, (int, float))
+                and isinstance(issue.get('status_ts'), (int, float))
+                and status_ts > issue['status_ts']
+            )
+        ):
+            _event(events, 'recovered', state.pop('core'))
+        if start:
+            _begin(state, 'core', 'core', events, task=task, status_ts=status_ts)
+    _update(path, change, emit)

--- a/src/recovery_issues.py
+++ b/src/recovery_issues.py
@@ -13,7 +13,7 @@ except ImportError:
 
 
 def _update(path, change, emit):
-    """Serialize observations and publish state before best-effort telemetry."""
+    """Publish observations best effort; skip a tick if another writer holds the lock."""
     if fcntl is None:
         return
     try:

--- a/tests/health-check-recovery-telemetry.test.py
+++ b/tests/health-check-recovery-telemetry.test.py
@@ -191,6 +191,13 @@ class RecoveryMetrics(unittest.TestCase):
         self.assertEqual(sorted(detected), sorted(recovered))
         self.assertNotIn('private-', json.dumps(self.issue_events))
 
+    def test_unimportable_issue_tracker_cannot_prevent_core_restart(self):
+        import sys
+        with patch.dict(sys.modules, {'recovery_issues': None}):
+            self.restart()
+        self.assertEqual([e[0] for e in self.events],
+                         ['core_recovery_attempted', 'core_restart_result'])
+
     def test_opt_out_and_short_lived_delivery(self):
         self.mock.stop()
         import telemetry

--- a/tests/health-check-recovery-telemetry.test.py
+++ b/tests/health-check-recovery-telemetry.test.py
@@ -21,7 +21,8 @@ class RecoveryMetrics(unittest.TestCase):
         self.addCleanup(self.tmp.cleanup)
         self.state = Path(self.tmp.name) / 'recovery.json'
         self.events = []
-        self.mock = patch.object(hc, '_recovery_metric', side_effect=lambda event, **props: self.events.append((event, props)))
+        self.issue_events = []
+        self.mock = patch.object(hc, '_recovery_metric', side_effect=lambda event, **props: (self.issue_events if event.startswith('recovery_issue_') else self.events).append((event, props)))
         self.mock.start()
         self.addCleanup(self.mock.stop)
         for name, value in [('RECOVER_WEDGE_SEC', 600), ('RECOVER_CONFIRM_SEC', 120),
@@ -160,11 +161,44 @@ class RecoveryMetrics(unittest.TestCase):
         with patch.object(telemetry, 'capture', side_effect=RuntimeError('offline')):
             self.restart()
 
+    def test_issue_ids_survive_failed_restarts_and_close_once(self):
+        self.run_core(10000)
+        self.run_core(10121, restart=False)
+        self.run_core(10122, restart=False)
+        self.run_core(10123)
+        self.run_core(10130, status_ts=11)
+        self.run_core(10140, status_ts=12)
+        self.assertEqual([e[0] for e in self.issue_events], [
+            'recovery_issue_detected', 'recovery_issue_attempted',
+            'recovery_issue_attempted', 'recovery_issue_attempted',
+            'recovery_issue_recovered'])
+        self.assertEqual(len({e[1]['issue_id'] for e in self.issue_events}), 1)
+        self.assertNotIn('private-task-path', json.dumps(self.issue_events))
+
+    def test_health_issues_close_individually_after_partial_batch(self):
+        checks = [{'name': 'private-one', 'status': 'down'},
+                  {'name': 'private-two', 'status': 'down'}]
+        hc.track_health_fix(checks, start=True, state_file=self.state, now=10)
+        checks[0]['status'] = 'ok'
+        hc.track_health_fix(checks, state_file=self.state, now=20)
+        hc.track_health_fix(checks, start=True, state_file=self.state, now=30)
+        checks[1]['status'] = 'ok'
+        hc.track_health_fix(checks, state_file=self.state, now=40)
+        hc.track_health_fix(checks, state_file=self.state, now=50)
+        detected = [p['issue_id'] for e, p in self.issue_events if e.endswith('_detected')]
+        recovered = [p['issue_id'] for e, p in self.issue_events if e.endswith('_recovered')]
+        self.assertEqual(len(detected), 2)
+        self.assertEqual(sorted(detected), sorted(recovered))
+        self.assertNotIn('private-', json.dumps(self.issue_events))
+
     def test_opt_out_and_short_lived_delivery(self):
         self.mock.stop()
         import telemetry
         with patch.object(telemetry, '_dispatch') as dispatch:
             hc._recovery_metric('core_recovery_attempted', trigger='wedged')
+            hc.track_health_fix([{'name': 'private', 'status': 'down'}],
+                                start=True, state_file=self.state)
+            self.restart()
             dispatch.assert_not_called()
         with patch.object(telemetry, 'capture') as capture:
             hc._recovery_metric('core_recovery_attempted', trigger='wedged')

--- a/tests/recovery-issues-http.test.py
+++ b/tests/recovery-issues-http.test.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Exercise recovery entry points across processes with real local HTTP capture."""
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+CHILD = '''
+import importlib.util, json, sys
+from pathlib import Path
+root, state, kind, raw = sys.argv[1:]
+spec = importlib.util.spec_from_file_location('health_check', Path(root)/'src/health-check.py')
+hc = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hc)
+args = json.loads(raw)
+if kind == 'health':
+    hc.track_health_fix(args['checks'], start=args.get('start', False),
+                        state_file=Path(state)/'health.json', now=args['now'])
+else:
+    result = hc.recover_core_if_wedged(
+        state_file=Path(state)/'core.json', now=args['now'],
+        alive_fn=lambda: True, oldest_task_fn=lambda: ('private-task', 900),
+        status_ts_fn=lambda: args.get('status_ts', 10), just_booted_fn=lambda: False,
+        stopped_fn=lambda: False, restart_fn=lambda: args.get('restart', True),
+        sender=lambda _: True)
+    print(json.dumps(result))
+'''
+
+
+class LocalCapture(unittest.TestCase):
+    def test_cross_process_recovery_and_opt_out(self):
+        received = []
+
+        class Receiver(BaseHTTPRequestHandler):
+            def do_POST(self):
+                received.append(json.loads(self.rfile.read(int(self.headers['Content-Length']))))
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b'{"status":1}')
+
+            def log_message(self, *_):
+                pass
+
+        server = ThreadingHTTPServer(('127.0.0.1', 0), Receiver)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        self.addCleanup(server.server_close)
+        self.addCleanup(server.shutdown)
+        with tempfile.TemporaryDirectory() as directory:
+            env = dict(os.environ, POSTHOG_HOST=f'http://127.0.0.1:{server.server_port}',
+                       POSTHOG_API_KEY='local-test-only', DO_NOT_TRACK='0', SUTANDO_TELEMETRY='1',
+                       SUTANDO_STATE_DIR=directory,
+                       SUTANDO_TELEMETRY_ID_FILE=str(Path(directory)/'telemetry-id'),
+                       SUTANDO_SURFACE='oss', SUTANDO_SUPPRESS_CCD_FALLBACK_BANNER='1')
+
+            def run(kind, **args):
+                result = subprocess.run([sys.executable, '-c', CHILD, str(ROOT), directory,
+                                         kind, json.dumps(args)], env=env, capture_output=True,
+                                        text=True, timeout=20)
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+            run('core', now=10000)
+            run('core', now=10121, restart=False)
+            run('core', now=10122, restart=False)
+            run('core', now=10123)
+            run('core', now=10130, status_ts=11)
+            run('core', now=10140, status_ts=12)
+            checks = [{'name': 'private-a', 'status': 'down'},
+                      {'name': 'private-b', 'status': 'down'}]
+            run('health', now=10, start=True, checks=checks)
+            checks[0]['status'] = 'ok'
+            run('health', now=20, checks=checks)
+            run('health', now=30, start=True, checks=checks)
+            checks[1]['status'] = 'ok'
+            run('health', now=40, checks=checks)
+            run('health', now=50, checks=checks)
+
+            issues = [e for e in received if e['event'].startswith('recovery_issue_')]
+            detected = {e['properties']['issue_id'] for e in issues if e['event'].endswith('_detected')}
+            recovered = [e['properties']['issue_id'] for e in issues if e['event'].endswith('_recovered')]
+            self.assertEqual(len(detected), 3)
+            self.assertEqual(len(recovered), 3)
+            self.assertEqual(detected, set(recovered))
+            self.assertEqual(sum(e['event'].endswith('_attempted') for e in issues), 6)
+            self.assertEqual(len({e['distinct_id'] for e in received}), 1)
+            self.assertNotIn('private-', json.dumps(received))
+            self.assertTrue(all(e['api_key'] == 'local-test-only' for e in received))
+            print('Local HTTP: 6 attempts, 3 unique issues, 3 recoveries (100%), 1 install')
+
+            checks[0]['status'] = 'down'
+            run('health', now=60, start=True, checks=checks)
+            new_id = [e['properties']['issue_id'] for e in received
+                      if e['event'] == 'recovery_issue_detected'][-1]
+            self.assertNotIn(new_id, detected)
+            print('Recurrence: new issue ID confirmed')
+            before = len(received)
+            env['DO_NOT_TRACK'] = '1'
+            run('health', now=70, checks=[{'name': 'private-a', 'status': 'ok'}])
+            self.assertEqual(len(received), before)
+            print('DO_NOT_TRACK=1: zero HTTP events')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/recovery-issues.test.py
+++ b/tests/recovery-issues.test.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Recovery identity persistence, concurrency, recurrence, and failure contracts."""
+from concurrent.futures import ThreadPoolExecutor
+import importlib
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
+import recovery_issues as ri
+
+
+class Issues(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.path = Path(self.tmp.name) / 'issues.json'
+        self.events = []
+
+    def emit(self, event, **props):
+        self.events.append((event, props))
+
+    def health(self, status, start=False):
+        ri.track_health_issues(self.path, [{'name': 'private-check', 'status': status}],
+                               start=start, emit=self.emit)
+
+    def test_retries_survive_module_reload_and_recurrence_gets_new_id(self):
+        self.health('down', True)
+        first = self.events[0][1]['issue_id']
+        importlib.reload(ri)
+        self.health('down', True)
+        self.health('ok')
+        self.health('ok')
+        self.assertEqual(len({p['issue_id'] for _, p in self.events}), 1)
+        self.assertEqual(sum(e.endswith('_recovered') for e, _ in self.events), 1)
+        self.health('down', True)
+        self.assertNotEqual(self.events[-1][1]['issue_id'], first)
+
+    def test_missing_check_and_warning_leave_issue_open(self):
+        self.health('down', True)
+        ri.track_health_issues(self.path, [], start=False, emit=self.emit)
+        self.health('warn')
+        self.assertEqual(len(self.events), 2)
+        self.assertTrue(json.loads(self.path.read_text()))
+
+    def test_concurrent_writers_only_detect_and_recover_once(self):
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            list(pool.map(lambda _: self.health('down', True), range(20)))
+            list(pool.map(lambda _: self.health('ok'), range(20)))
+        self.assertEqual(sum(e.endswith('_detected') for e, _ in self.events), 1)
+        self.assertEqual(sum(e.endswith('_recovered') for e, _ in self.events), 1)
+        self.assertEqual(len({p['issue_id'] for _, p in self.events}), 1)
+
+    def test_atomic_failure_preserves_identity_and_emits_nothing(self):
+        self.health('down', True)
+        before = self.path.read_text()
+        self.events.clear()
+        with patch.object(ri.os, 'replace', side_effect=OSError('disk full')):
+            self.health('ok')
+        self.assertEqual(self.path.read_text(), before)
+        self.assertEqual(self.events, [])
+        self.assertEqual(list(self.path.parent.glob('.recovery-issues-*')), [])
+        self.health('ok')
+        self.assertEqual(self.events[0][1]['issue_id'], json.loads(before)['private-check']['issue_id'])
+
+    def test_corrupt_state_does_not_invent_new_identity(self):
+        self.path.write_text('{broken')
+        self.health('down', True)
+        self.assertEqual(self.events, [])
+        self.assertEqual(self.path.read_text(), '{broken')
+
+    def test_sender_failure_and_unsupported_lock_are_nonfatal(self):
+        with patch.object(self, 'emit', side_effect=RuntimeError('offline')):
+            self.health('down', True)
+        self.assertTrue(self.path.exists())
+        with patch.object(ri, 'fcntl', None):
+            self.health('ok')
+        self.assertTrue(json.loads(self.path.read_text()))
+
+    def test_core_unknown_dead_and_retry_keep_identity_until_progress(self):
+        def core(alive, status=10, start=False):
+            ri.track_core_issue(self.path, alive=alive, task='private-task',
+                                status_ts=status, start=start, emit=self.emit)
+        core(False, start=True)
+        core(None, 11)
+        core(True)
+        core(False, start=True)
+        self.assertFalse(any(e.endswith('_recovered') for e, _ in self.events))
+        core(True, 11)
+        core(True, 12)
+        self.assertEqual(sum(e.endswith('_recovered') for e, _ in self.events), 1)
+        self.assertEqual(len({p['issue_id'] for _, p in self.events}), 1)
+        self.assertNotIn('private-task', json.dumps(self.events))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Repeated recovery attempts currently inflate the denominator: two failed launches followed by recovery cannot be identified as one recovered issue. Add durable issue identities so each installation can count unique issues and observed recoveries.

Health checks get individual UUIDs, retained across retries until that check reports OK. Core recovery retains one UUID through launch failures, exceptions, and dead/wedged retries until progress is observed. A later recurrence gets a new UUID. Add `recovery_issue_detected`, `recovery_issue_attempted`, and `recovery_issue_recovered` with `issue_id` and a categorical `issue_type`; preserve the existing batch/attempt events and recovery behavior.

Review `src/recovery_issues.py` first, then its three call sites in `src/health-check.py`. The shared writer uses nonblocking locking and atomic publication, stores check/task correlation only locally, and cannot interrupt repairs on state or telemetry errors. No new dependency or configuration. Existing opt-out behavior applies.

Validation:

- `python3 tests/health-check-recovery-telemetry.test.py`: 15 tests pass, including the production health/core entry points, failed-launch retries, individual resolution after a partial batch, and opt-out.
- `python3 tests/recovery-issues.test.py`: 7 tests pass covering persistence, recurrence, concurrent writers, absent checks, atomic write failure, corrupt state, unavailable telemetry, and unknown/dead core observations.
- `python3 tests/health-check-recover-core.test.py`: `All core-recovery invariants hold.`
- `python3 tests/telemetry.test.py`: `ALL PASS (24 checks)`.
- `bash scripts/review-checks.sh --diff <(git diff origin/main...HEAD)`: `review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)`.
- `git diff --check`: passes.

Before/after evidence: run the two newly added integration cases against the unmodified `src/health-check.py` at base `436dcc23`, then against this change:

```text
python3 tests/health-check-recovery-telemetry.test.py \
  RecoveryMetrics.test_issue_ids_survive_failed_restarts_and_close_once \
  RecoveryMetrics.test_health_issues_close_individually_after_partial_batch

BASELINE exit: 1
AssertionError: Lists differ: [] != ['recovery_issue_detected', ...]
AssertionError: 0 != 2
Ran 2 tests in 0.003s
FAILED (failures=2)

After (full integration suite):
Ran 15 tests in 0.038s
OK
```

Scope/limitations: this is the client instrumentation needed for issue-based rates, not a dashboard change. `docs/recovery-issue-metrics.md` defines the event contract and cohort query; documentation navigation/catalog and source map are updated. Historical events cannot be backfilled reliably. Open issues are not terminal failures; different health checks may reflect the same underlying root cause. Telemetry remains best effort, so missing events/state loss limit completeness. Rollback leaves unused sibling issue-state files without changing repair behavior. No production errors were induced or production PostHog events sent during validation; verification uses the real tracking entry points with injected recovery dependencies and offline capture. Voice/phone manual testing: N/A.


Additional local transport verification (`python3 tests/recovery-issues-http.test.py`): separate Python processes use the real health/core tracking entry points, durable state, installation identity, and telemetry HTTP sender. A loopback HTTP receiver replaces the PostHog destination; only health observations and restart outcomes are injected. No live core is restarted. Test key and installation/state paths are isolated in a temporary directory.

```text
Ran 1 test in 1.378s
OK
Local HTTP: 6 attempts, 3 unique issues, 3 recoveries (100%), 1 install
Recurrence: new issue ID confirmed
DO_NOT_TRACK=1: zero HTTP events
```

This verifies local transport and cross-process correlation, not production PostHog ingestion or the effectiveness of actual repairs. The repeatable test is included in the PR and discovered by the Python test suite.
