### PR TITLE
fix(start-cli): the relay loop stops when its interpreter or script is gone, instead of spinning

### DIFF
--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -664,8 +664,10 @@ ensure_core_monitor() {
     # loop forever — so any caller capturing start-cli.sh's output never saw
     # EOF (desktop core_restart: 120 s timeout on every fresh boot). This form
     # also makes $! the loop's own pid, so the pidfile can actually stop it.
+    # Loop only while the interpreter and script exist, and stop if sleep fails:
+    # with them gone (engine dir removed) `while true` would spin at full CPU.
     if [ -n "$PY" ]; then
-      bash -c 'while true; do "$1" "$2" --signal "$3" --state-file "$4" --active-from "$5"; sleep 30; done' \
+      bash -c 'while command -v "$1" > /dev/null 2>&1 && [ -f "$2" ]; do "$1" "$2" --signal "$3" --state-file "$4" --active-from "$5"; sleep 30 || exit 1; done' \
         relay-loop "$PY" "$REPO/src/core-supervisor-relay.py" "$mon_out" "$relay_state" "$ws/state/last-owner-activity.json" \
         >> /tmp/core-supervisor-relay.log 2>&1 < /dev/null &
       echo $! > "$relay_pid_file"

--- a/tests/shutdown-sentinel-immediate-exit-controls.test.py
+++ b/tests/shutdown-sentinel-immediate-exit-controls.test.py
@@ -17,13 +17,16 @@ Run: python3 tests/shutdown-sentinel-immediate-exit-controls.test.py  (exit 0/1)
 """
 from __future__ import annotations
 
+import contextlib
 import os
 import pty
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
 import threading
+import time
 from types import SimpleNamespace
 from pathlib import Path
 
@@ -70,6 +73,30 @@ PGREP_STUB = "#!/bin/bash\nexit 1\n"
 CODEX_STUB = "#!/bin/bash\nexit 0\n"
 
 
+def _reap_fixture_children(tmp: str) -> None:
+    """The launcher backgrounds a relay loop and a monitor that outlive it; kill whatever
+    still references the fixture before deleting it, or rmtree races their writes."""
+    marker = os.path.basename(tmp)
+    for _ in range(100):
+        pids = subprocess.run(["pgrep", "-f", marker], capture_output=True, text=True).stdout.split()
+        if not pids:
+            return
+        for pid in pids:
+            with contextlib.suppress(ProcessLookupError, ValueError):
+                os.kill(int(pid), signal.SIGTERM)
+        time.sleep(0.02)
+    failures.append(f"fixture children survived teardown: {pids}")
+
+
+@contextlib.contextmanager
+def _fixture():
+    with tempfile.TemporaryDirectory() as tmp:
+        try:
+            yield tmp
+        finally:
+            _reap_fixture_children(tmp)
+
+
 def _launch(cmd, env, cwd, tty: bool):
     """Run the launcher, optionally under a pty so `[ -t 1 ]` is true."""
     if not tty:
@@ -106,7 +133,7 @@ def _launch(cmd, env, cwd, tty: bool):
 
 
 def run_branch(label: str, launcher_rel: str, env_extra: dict, *, tty: bool = False) -> None:
-    with tempfile.TemporaryDirectory() as tmp:
+    with _fixture() as tmp:
         root, binp = Path(tmp) / "repo", Path(tmp) / "bin"
         binp.mkdir(parents=True)
         missing = False

--- a/tests/start-cli-relay-loop-dies-with-its-repo.test.py
+++ b/tests/start-cli-relay-loop-dies-with-its-repo.test.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""The relay loop that start-cli.sh backgrounds must stop when its inputs vanish.
+
+The launcher runs `bash -c '<loop>' relay-loop "$PY" "$REPO/src/core-supervisor-relay.py" …`
+detached, with `$PY` an absolute path and `sleep` resolved from PATH. A test that
+runs the real launcher from a temporary repo copy (shutdown-sentinel-immediate-exit-
+controls) deletes that copy afterwards; the loop then has no interpreter and no
+`sleep`, so `while true` spins at full CPU forever, appending two error lines per
+iteration to /tmp/core-supervisor-relay.log (107 GB on one machine before it was
+noticed). The same shape bites whenever the engine directory is removed from under
+a running loop.
+
+This test extracts the loop body from start-cli.sh and drives it directly:
+  a) interpreter, script and `sleep` all gone -> exits promptly, no spin
+  b) the relay is invoked with the launcher's argv and the loop ends once the
+     script disappears
+  c) a failing `sleep` ends the loop instead of degrading into a busy loop
+
+Run: python3 tests/start-cli-relay-loop-dies-with-its-repo.test.py  (exit 0/1)
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+LAUNCHER = REPO / "src" / "agent" / "claude" / "cli" / "start-cli.sh"
+failures: list[str] = []
+
+
+def _loop_body() -> str:
+    src = LAUNCHER.read_text(encoding="utf-8")
+    m = re.search(r"bash -c '([^']*)' \\\n\s*relay-loop ", src)
+    assert m, "relay loop launch not found in start-cli.sh — did its shape change?"
+    return m.group(1)
+
+
+def _run(body: str, argv: list[str], path: str, timeout: float = 5.0):
+    """Returns (rc, stderr) or (None, stderr) when the loop outlived the timeout."""
+    p = subprocess.Popen(["/bin/bash", "-c", body, "relay-loop", *argv],
+                         env={"PATH": path}, stdin=subprocess.DEVNULL,
+                         stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True)
+    try:
+        _, err = p.communicate(timeout=timeout)
+        return p.returncode, err
+    except subprocess.TimeoutExpired:
+        p.kill()
+        _, err = p.communicate()
+        return None, err
+
+
+def _exe(path: Path, body: str) -> None:
+    path.write_text(body)
+    path.chmod(0o755)
+
+
+def check(label: str, ok: bool, detail: str = "") -> None:
+    if not ok:
+        failures.append(f"{label}: {detail}")
+
+
+body = _loop_body()
+
+# a) the fixture is gone: no interpreter, no script, no `sleep` on PATH.
+with tempfile.TemporaryDirectory() as td:
+    gone = Path(td) / "gone"
+rc, err = _run(body, [f"{gone}/bin/python3", f"{gone}/repo/src/core-supervisor-relay.py",
+                      f"{gone}/ws/state/core-supervisor.json",
+                      f"{gone}/ws/state/core-supervisor-relay.state",
+                      f"{gone}/ws/state/last-owner-activity.json"],
+               path=f"{gone}/bin")
+check("a) loop exits when its repo and PATH are gone", rc is not None,
+      f"still running after 5s; wrote {err.count(chr(10))} stderr lines — the busy loop")
+check("a) no spin before exit", err.count("\n") <= 4,
+      f"{err.count(chr(10))} stderr lines before exiting")
+
+# b) the relay runs with the launcher's argv, and the loop ends once the script vanishes.
+with tempfile.TemporaryDirectory() as td:
+    binp, repo = Path(td) / "bin", Path(td) / "repo"
+    binp.mkdir()
+    (repo / "src").mkdir(parents=True)
+    calls = Path(td) / "calls.log"
+    script = repo / "src" / "core-supervisor-relay.py"
+    script.write_text("# stand-in for the relay\n")
+    # Records its argv, then removes the script: the next loop check must stop.
+    _exe(binp / "python3", f'#!/bin/sh\necho "$@" >> "{calls}"\n/bin/rm -f "$1"\n')
+    _exe(binp / "sleep", "#!/bin/sh\nexit 0\n")
+    rc, err = _run(body, [str(binp / "python3"), str(script), "SIG", "STATE", "ACTIVE"],
+                   path=str(binp))
+    recorded = calls.read_text().splitlines() if calls.exists() else []
+    check("b) loop exits once the relay script is gone", rc is not None,
+          f"still running after 5s; relay invoked {len(recorded)} times; stderr: {err[-300:]}")
+    check("b) relay invoked exactly once with the launcher's argv",
+          recorded == [f"{script} --signal SIG --state-file STATE --active-from ACTIVE"],
+          f"recorded {len(recorded)} calls; first: {recorded[:1]!r}")
+
+# c) `sleep` failing must end the loop, not turn it into a busy loop.
+with tempfile.TemporaryDirectory() as td:
+    binp, repo = Path(td) / "bin", Path(td) / "repo"
+    binp.mkdir()
+    (repo / "src").mkdir(parents=True)
+    calls = Path(td) / "calls.log"
+    script = repo / "src" / "core-supervisor-relay.py"
+    script.write_text("# stand-in for the relay\n")
+    _exe(binp / "python3", f'#!/bin/sh\necho run >> "{calls}"\n')
+    _exe(binp / "sleep", "#!/bin/sh\nexit 1\n")
+    rc, err = _run(body, [str(binp / "python3"), str(script), "SIG", "STATE", "ACTIVE"],
+                   path=str(binp))
+    n = len(calls.read_text().splitlines()) if calls.exists() else 0
+    check("c) a failing sleep ends the loop", rc is not None and rc != 0,
+          f"rc={rc}; relay invoked {n} times")
+    check("c) the relay ran once before the loop gave up", n == 1, f"relay invoked {n} times")
+
+if failures:
+    print("\n".join(f"  FAIL {f}" for f in failures))
+else:
+    print("  ok  the relay loop stops when its interpreter, script or sleep are gone")
+sys.exit(1 if failures else 0)


### PR DESCRIPTION
## What changed, and why?

`ensure_core_monitor` in `src/agent/claude/cli/start-cli.sh` backgrounds the communicator relay as `bash -c 'while true; do "$PY" relay.py …; sleep 30; done'`. `$PY` is an absolute path captured at launch and `sleep` is whatever PATH resolved (bash hashes it after the first hit). Nothing re-checks that those still exist. When the directory behind them disappears, both fail with ENOENT in microseconds, `while true` never pauses, and the loop appends two error lines per iteration to `/tmp/core-supervisor-relay.log`.

On one Mac four such loops ran for 45 hours at ~40 % CPU each and grew that log to **107 GB**:

```
$ ps -o pid,%cpu,etime,command -p 44169
44169 39.7 01-21:33:18 bash -c while true; do "$1" "$2" --signal "$3" … relay-loop /var/folders/…/T/tmp0rve2_zs/bin/python3 /var/folders/…/T/tmp0rve2_zs/repo/src/core-supervisor-relay.py …
$ ls -lh /private/tmp/core-supervisor-relay.log
-rw-r--r--  1 yixuan  wheel   107G Sep 11 11:19 /private/tmp/core-supervisor-relay.log
$ tail -2 /private/tmp/core-supervisor-relay.log
relay-loop: /var/folders/…/T/tmpz9ufjm41/bin/python3: No such file or directory
relay-loop: /var/folders/…/T/tmpdy4yubqx/bin/sleep: No such file or directory
```

The vanished directories were fixtures of `tests/shutdown-sentinel-immediate-exit-controls.test.py`: it copies the launcher into a `TemporaryDirectory` with a `bin/` of symlinked tools, runs the **real** launcher with `PATH=<bin>` and a tmux stub that accepts every command, so the launcher reaches `ensure_core_monitor` and starts the loop for real; then the directory is deleted. The launcher-side guard matters beyond tests: the same shape bites whenever the engine directory is removed from under a running loop.

Two changes, one concern:

1. **Launcher (policy owner):** loop `while command -v "$1" && [ -f "$2" ]` instead of `while true`, so a vanished interpreter or relay script ends the loop at its next turn; and `sleep 30 || exit 1`, so a missing `sleep` can never turn the cadence into a busy loop. Pidfile guard and `$!` semantics from #4069 unchanged.
2. **The test that leaked it:** the fixture context now kills every process still referencing the fixture before the directory is removed. This also fixes a race the test already loses on `main` (see evidence): the relay's first run is still writing under `repo/` while `rmtree` runs, so cleanup raises `Directory not empty: 'repo'` and the suite exits 1 after printing all three OK lines.

## What files / sections should reviewers look at first?

- `src/agent/claude/cli/start-cli.sh` — the one-line loop body change in `ensure_core_monitor`.
- `tests/start-cli-relay-loop-dies-with-its-repo.test.py` — new; extracts the loop body from the launcher and drives it directly (three cases).
- `tests/shutdown-sentinel-immediate-exit-controls.test.py` — `_fixture()` / `_reap_fixture_children()`.

## What user behavior or bug does this prove?

A detached relay loop whose interpreter, script or `sleep` disappears exits instead of spinning at 100 % CPU and filling `/tmp`. The sentinel test no longer leaves a loop behind on the developer's machine or CI runner, and no longer fails its own teardown.

## Feature/documentation consistency

N/A — no user-visible feature or capability changes; the relay's cadence, escalation and pidfile contract are unchanged.

## Before/after evidence

**Before** (parent `436dcc23`, with the new test file dropped in):

```
$ python3 tests/start-cli-relay-loop-dies-with-its-repo.test.py
  FAIL a) loop exits when its repo and PATH are gone: still running after 5s; wrote 14872 stderr lines — the busy loop
  FAIL a) no spin before exit: 14872 stderr lines before exiting
  FAIL b) loop exits once the relay script is gone: still running after 5s; relay invoked 658 times; stderr:
  FAIL b) relay invoked exactly once with the launcher's argv: recorded 658 calls; first: ['…/repo/src/core-supervisor-relay.py --signal SIG --state-file STATE --active-from ACTIVE']
  FAIL c) a failing sleep ends the loop: rc=None; relay invoked 823 times
  FAIL c) the relay ran once before the loop gave up: relay invoked 823 times
rc=1

$ python3 tests/shutdown-sentinel-immediate-exit-controls.test.py   # 3 runs, all identical
OK: claude-heal — tmux accepted the command, no core lived, sentinel SURVIVED
OK: codex-detached — tmux accepted the command, no core lived, sentinel SURVIVED
OK: codex-tty — tmux accepted the command, no core lived, sentinel SURVIVED
Traceback (most recent call last):
  …
  File ".../tempfile.py", line 826, in __exit__
  File ".../shutil.py", line 657, in _rmtree_safe_fd
OSError: [Errno 66] Directory not empty: 'repo'
rc=1
$ pgrep -fl /T/tmp        # what the test left running
7584 bash -c while true; do "$1" "$2" --signal "$3" --state-file "$4" --active-from "$5"; sleep 30; done relay-loop <tmpwnonwpjt>/bin/python3 <tmpwnonwpjt>/repo/src/core-supervisor-relay.py …
```

**After** (HEAD):

```
$ python3 tests/start-cli-relay-loop-dies-with-its-repo.test.py
  ok  the relay loop stops when its interpreter, script or sleep are gone
rc=0
$ python3 tests/shutdown-sentinel-immediate-exit-controls.test.py
OK: claude-heal — tmux accepted the command, no core lived, sentinel SURVIVED
OK: codex-detached — tmux accepted the command, no core lived, sentinel SURVIVED
OK: codex-tty — tmux accepted the command, no core lived, sentinel SURVIVED

All immediate-exit controls passed.
rc=0
$ pgrep -fl /T/tmp
(none)
```

Repeated twice more at HEAD: both suites rc=0, nothing left referencing the fixture.

## What tests did you run?

- `python3 tests/start-cli-relay-loop-dies-with-its-repo.test.py` — pass (fails at parent, above)
- `python3 tests/shutdown-sentinel-immediate-exit-controls.test.py` ×3 — pass, no leaked processes (rc=1 + leak at parent, above)
- `python3 tests/shutdown-sentinel-restored-by-real-launcher.test.py` — pass
- `python3 tests/core-supervisor-relay.test.py` — pass
- `python3 tests/start-cli-personal-claude-hook-wiring.test.py`, `tests/start-cli-restart-verify.test.py` — pass
- `python3 tests/start-cli-model-pin.test.py` — 5 failures, **identical at the parent commit** (this Mac has no `tmux` on that test's PATH: "tmux not found — cannot exercise the tmux path"); unrelated to this change
- `bash -n src/agent/claude/cli/start-cli.sh`, `python3 scripts/check-python39-compat.py`, `python3 scripts/lint-hermetic-bridge-tests.py` — clean

## Live path

`ensure_core_monitor` is on the startup path. I did **not** restart the live core on this host for this PR; the launcher change is confined to the relay loop's exit condition, and the sentinel suite above runs the real launcher through `ensure_core_monitor` in a sandbox. If a maintainer wants a post-restart round trip on a live host before merge, say so and I'll capture it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
