### PR TITLE
fix(auth-preflight): check the scoped Keychain item, not only the vanilla one

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -99,6 +99,7 @@ One entry per agent-facing module. 5 without a usable header comment.
 - **`install-gateway-bridge-launchd.sh`** — Install / uninstall / check the launchd-supervised ag2.space gateway-bridge.
 - **`install-health-check-launchd.sh`** — Install / uninstall the launchd-supervised health-check FALLBACK job.
 - **`install-sutando-app-launchd.sh`** — Install / uninstall / check the launchd-supervised Sutando.app job.
+- **`keychain_service.py`** — Shared macOS Keychain resolution for Claude Code CLI credentials.
 - **`live-agent-runtime.ts`** — LiveAgentRuntime — step 5a-2 of the interaction-planes refactor.
 - **`local_task_protocol.py`** — Local Task Protocol — read-side reference implementation.
 - **`meeting-tools.ts`** — Meeting tools — Google Meet, phone call, and meeting ID lookup.

--- a/src/auth_preflight.py
+++ b/src/auth_preflight.py
@@ -12,8 +12,9 @@ report, and the easy-restart flow can all call it.
 
 Static checks (default, fast, read-only):
   * `.claude.json` in the target dir carries a non-empty `oauthAccount`
-  * credentials exist: `.credentials.json` on disk OR the macOS Keychain
-    item (`Claude Code-credentials`) — existence only, value never read
+  * credentials exist: `.credentials.json` on disk OR the macOS Keychain item
+    scoped to this config dir, or the vanilla shared item as fallback
+    (`keychain_service.py`) — existence only, value never read
   * SSH context (`$SSH_CONNECTION`) — a locked keychain cannot be unlocked
     from an SSH-spawned process, so completing /login needs a GUI Terminal
 
@@ -35,22 +36,24 @@ import shlex
 import subprocess
 import sys
 
+from keychain_service import resolved_credential_service
+
+# Kept as a constant for anything still importing it directly; the real
+# lookup now also checks the per-config-dir scoped item (see below).
 KEYCHAIN_SERVICE = "Claude Code-credentials"
 
 
-def keychain_has_credentials() -> bool:  # pragma: no cover - external I/O (security CLI)
-    """True when the macOS Keychain holds a Claude Code credentials item.
+def keychain_has_credentials(config_dir: str = "") -> bool:  # pragma: no cover - external I/O (security CLI)
+    """True when the macOS Keychain holds a Claude Code credentials item for
+    this config dir — the scoped per-install item, or the vanilla shared one.
 
-    Existence check only — `-s <service>` lookup, output discarded, the
-    secret value is never requested. Non-macOS (no `security`) → False.
+    Existence check only — the secret value is never requested. Found the hard
+    way (2026-09-11): checking only the vanilla name made a genuinely
+    authenticated, scoped-keychain install (the common case, per
+    credential-proxy.ts's own scopedKeychainService) read as logged-out on
+    every restart, permanently aborting startup on a healthy host.
     """
-    try:
-        r = subprocess.run(
-            ["security", "find-generic-password", "-s", KEYCHAIN_SERVICE],
-            capture_output=True, timeout=10)
-        return r.returncode == 0
-    except (OSError, subprocess.TimeoutExpired):
-        return False
+    return bool(resolved_credential_service(config_dir))
 
 
 def _oauth_account_present(config_dir: str) -> bool:
@@ -82,7 +85,7 @@ def check_auth_state(config_dir: str, *, keychain_check=keychain_has_credentials
         reasons.append("no oauthAccount in .claude.json (fresh or never-logged-in config dir)")
 
     creds_file = os.path.isfile(os.path.join(config_dir, ".credentials.json"))
-    creds_keychain = bool(keychain_check())
+    creds_keychain = bool(keychain_check(config_dir))
     if not creds_file and not creds_keychain:
         reasons.append("no credentials: .credentials.json absent and no Keychain item")
 

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5735,10 +5735,7 @@ def _quota_windows(headers: dict) -> dict:
     return out
 
 
-# Mirror of credential-proxy.ts `scopedKeychainService`, centralized in
-# keychain_service.py because auth_preflight.py needs the identical
-# resolution (a copy that drifted between the two is what let a genuinely
-# authenticated, scoped-keychain install read as logged-out — 2026-09-11).
+# Centralized: auth_preflight.py needs this exact resolution too.
 from keychain_service import (  # noqa: E402
     scoped_keychain_service as _scoped_keychain_service,
     keychain_service_exists as _keychain_service_exists,

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -5735,27 +5735,14 @@ def _quota_windows(headers: dict) -> dict:
     return out
 
 
-def _scoped_keychain_service(config_dir: Optional[str]) -> Optional[str]:
-    """Mirror of credential-proxy.ts `scopedKeychainService`.
-
-    Empty/whitespace -> None, so the caller falls back to the vanilla item —
-    the same contract the proxy implements.
-    """
-    dir_ = (config_dir or "").strip()
-    if not dir_:
-        return None
-    digest = hashlib.sha256(dir_.encode()).hexdigest()[:8]
-    return f"Claude Code-credentials-{digest}"
-
-
-def _keychain_service_exists(service: str) -> bool:
-    try:
-        return subprocess.run(
-            ["security", "find-generic-password", "-s", service],
-            capture_output=True, timeout=5,
-        ).returncode == 0
-    except (OSError, subprocess.SubprocessError):
-        return False
+# Mirror of credential-proxy.ts `scopedKeychainService`, centralized in
+# keychain_service.py because auth_preflight.py needs the identical
+# resolution (a copy that drifted between the two is what let a genuinely
+# authenticated, scoped-keychain install read as logged-out — 2026-09-11).
+from keychain_service import (  # noqa: E402
+    scoped_keychain_service as _scoped_keychain_service,
+    keychain_service_exists as _keychain_service_exists,
+)
 
 
 # Distinct from None and from "": the environment could not be READ at all.

--- a/src/keychain_service.py
+++ b/src/keychain_service.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""keychain_service.py — shared macOS Keychain resolution for Claude Code CLI credentials.
+"""Shared macOS Keychain resolution for Claude Code CLI credentials.
 
 Mirrors credential-proxy.ts's `scopedKeychainService`: a per-CLAUDE_CONFIG_DIR
 Keychain item name (`Claude Code-credentials-<sha256(config_dir)[:8]>`), with a

--- a/src/keychain_service.py
+++ b/src/keychain_service.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""keychain_service.py — shared macOS Keychain resolution for Claude Code CLI credentials.
+
+Mirrors credential-proxy.ts's `scopedKeychainService`: a per-CLAUDE_CONFIG_DIR
+Keychain item name (`Claude Code-credentials-<sha256(config_dir)[:8]>`), with a
+fallback to the vanilla shared item (`Claude Code-credentials`) for installs
+that predate per-config-dir scoping.
+
+Centralized because more than one adapter needs this exact resolution
+(src/health-check.py's quota-account-identity probe, src/auth_preflight.py's
+boot-auth probe) — a copy that drifts between them is the defect (see
+CLAUDE.md "Shared adapter policy is core"). Found via a real, install-breaking
+instance of that drift: auth_preflight.py checked only the vanilla name,
+so a scoped-keychain install (the common case) always read as logged-out
+even while genuinely authenticated, and `bash src/restart.sh` permanently
+aborted startup on a healthy host (2026-09-11).
+"""
+from __future__ import annotations
+
+import hashlib
+import subprocess
+from typing import Optional
+
+VANILLA_SERVICE = "Claude Code-credentials"
+
+
+def scoped_keychain_service(config_dir: Optional[str]) -> Optional[str]:
+    """The per-config-dir Keychain item name, or None for an empty config_dir."""
+    dir_ = (config_dir or "").strip()
+    if not dir_:
+        return None
+    digest = hashlib.sha256(dir_.encode()).hexdigest()[:8]
+    return f"{VANILLA_SERVICE}-{digest}"
+
+
+def keychain_service_exists(service: str) -> bool:  # pragma: no cover - external I/O (security CLI)
+    """Existence check only — the secret value is never requested. Non-macOS
+    (no `security` binary) -> False."""
+    try:
+        return subprocess.run(
+            ["security", "find-generic-password", "-s", service],
+            capture_output=True, timeout=5,
+        ).returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+def resolved_credential_service(config_dir: Optional[str]) -> Optional[str]:
+    """First EXISTING item of [scoped(config_dir), vanilla] — the proxy's own order."""
+    for service in (scoped_keychain_service(config_dir), VANILLA_SERVICE):
+        if service and keychain_service_exists(service):
+            return service
+    return None

--- a/src/keychain_service.py
+++ b/src/keychain_service.py
@@ -14,6 +14,17 @@ instance of that drift: auth_preflight.py checked only the vanilla name,
 so a scoped-keychain install (the common case) always read as logged-out
 even while genuinely authenticated, and `bash src/restart.sh` permanently
 aborted startup on a healthy host (2026-09-11).
+
+Property worth stating rather than assuming (review, #4196, 2026-09-11): the
+scoped name is a pure function of the config_dir STRING, not of the machine —
+two different hosts with the same CLAUDE_CONFIG_DIR path produce the identical
+service name (confirmed live: two independent hosts both produced
+`Claude Code-credentials-b0888206` from the same path string). Harmless while
+each machine's Keychain stays local, as it does today; it would become a
+genuine collision (two different secrets, one name) only if some future
+mechanism merged keychain items across machines. Neither observed nor
+implemented anywhere in this codebase as of this fix — noted so it is a known
+property if that ever changes, not a surprise.
 """
 from __future__ import annotations
 

--- a/tests/auth-preflight.test.py
+++ b/tests/auth-preflight.test.py
@@ -37,7 +37,7 @@ def _mkconfig(td, oauth=False, creds=False):
 class TestDecision(unittest.TestCase):
     def test_fresh_empty_dir_requires_login(self):
         with tempfile.TemporaryDirectory() as td:
-            r = check_auth_state(td, keychain_check=lambda: False, env={})
+            r = check_auth_state(td, keychain_check=lambda _cd: False, env={})
             self.assertEqual(r["verdict"], "login_required")
             self.assertEqual(len(r["reasons"]), 2)  # no oauthAccount + no creds
             self.assertIn("GUI /login", r["remedy"])
@@ -53,7 +53,7 @@ class TestDecision(unittest.TestCase):
         # config dir (no services, gate never runs), and restart.sh appears
         # only AFTER /login.
         with tempfile.TemporaryDirectory() as td:
-            r = check_auth_state(td, keychain_check=lambda: False, env={})
+            r = check_auth_state(td, keychain_check=lambda _cd: False, env={})
             self.assertEqual(r["verdict"], "login_required")
             remedy = r["remedy"]
             self.assertIn(f"CLAUDE_CONFIG_DIR={td} claude", remedy)
@@ -74,7 +74,7 @@ class TestDecision(unittest.TestCase):
             spaced = os.path.join(td, "ccd path with spaces")
             os.makedirs(spaced)
             r = auth_preflight.check_auth_state(
-                spaced, keychain_check=lambda: False, env={})
+                spaced, keychain_check=lambda _cd: False, env={})
             self.assertEqual(r["verdict"], "login_required")
             self.assertIn(f"CLAUDE_CONFIG_DIR={shlex.quote(spaced)} claude",
                           r["remedy"])
@@ -84,7 +84,7 @@ class TestDecision(unittest.TestCase):
     def test_oauth_plus_credentials_file_ok(self):
         with tempfile.TemporaryDirectory() as td:
             _mkconfig(td, oauth=True, creds=True)
-            r = check_auth_state(td, keychain_check=lambda: False, env={})
+            r = check_auth_state(td, keychain_check=lambda _cd: False, env={})
             self.assertEqual(r["verdict"], "ok")
             self.assertIsNone(r["remedy"])
 
@@ -93,21 +93,21 @@ class TestDecision(unittest.TestCase):
         # .credentials.json never exists — must still be OK.
         with tempfile.TemporaryDirectory() as td:
             _mkconfig(td, oauth=True)
-            r = check_auth_state(td, keychain_check=lambda: True, env={})
+            r = check_auth_state(td, keychain_check=lambda _cd: True, env={})
             self.assertEqual(r["verdict"], "ok")
 
     def test_keychain_without_oauth_account_requires_login(self):
         # Keychain item exists but the fresh dir's .claude.json lacks the
         # oauthAccount linkage → CLI treats the install as logged-out.
         with tempfile.TemporaryDirectory() as td:
-            r = check_auth_state(td, keychain_check=lambda: True, env={})
+            r = check_auth_state(td, keychain_check=lambda _cd: True, env={})
             self.assertEqual(r["verdict"], "login_required")
             self.assertTrue(any("oauthAccount" in x for x in r["reasons"]))
 
     def test_oauth_without_any_credentials_requires_login(self):
         with tempfile.TemporaryDirectory() as td:
             _mkconfig(td, oauth=True)
-            r = check_auth_state(td, keychain_check=lambda: False, env={})
+            r = check_auth_state(td, keychain_check=lambda _cd: False, env={})
             self.assertEqual(r["verdict"], "login_required")
             self.assertTrue(any("no credentials" in x for x in r["reasons"]))
 
@@ -115,26 +115,26 @@ class TestDecision(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             with open(os.path.join(td, ".claude.json"), "w") as f:
                 json.dump({"oauthAccount": None}, f)
-            r = check_auth_state(td, keychain_check=lambda: True, env={})
+            r = check_auth_state(td, keychain_check=lambda _cd: True, env={})
             self.assertEqual(r["verdict"], "login_required")
 
     def test_malformed_claude_json_is_login_required_not_crash(self):
         with tempfile.TemporaryDirectory() as td:
             with open(os.path.join(td, ".claude.json"), "w") as f:
                 f.write("{not json")
-            r = check_auth_state(td, keychain_check=lambda: False, env={})
+            r = check_auth_state(td, keychain_check=lambda _cd: False, env={})
             self.assertEqual(r["verdict"], "login_required")
 
     def test_ssh_context_prepends_ssh_warning(self):
         with tempfile.TemporaryDirectory() as td:
-            r = check_auth_state(td, keychain_check=lambda: False,
+            r = check_auth_state(td, keychain_check=lambda _cd: False,
                                  env={"SSH_CONNECTION": "1.2.3.4 5 6.7.8.9 22"})
             self.assertTrue(r["ssh"])
             self.assertTrue(r["remedy"].startswith("SSH session detected"))
 
     def test_no_ssh_no_warning(self):
         with tempfile.TemporaryDirectory() as td:
-            r = check_auth_state(td, keychain_check=lambda: False, env={})
+            r = check_auth_state(td, keychain_check=lambda _cd: False, env={})
             self.assertFalse(r["ssh"])
             self.assertTrue(r["remedy"].startswith("needs GUI /login"))
 
@@ -143,7 +143,7 @@ class TestCli(unittest.TestCase):
     def test_exit_2_and_json_on_fresh_dir(self):
         with tempfile.TemporaryDirectory() as td:
             orig = auth_preflight.keychain_has_credentials
-            auth_preflight.keychain_has_credentials = lambda: False
+            auth_preflight.keychain_has_credentials = lambda *_a, **_k: False
             try:
                 import io
                 from contextlib import redirect_stdout
@@ -170,7 +170,7 @@ class TestCli(unittest.TestCase):
     def test_human_output_login_required_prints_reasons_and_remedy(self):
         with tempfile.TemporaryDirectory() as td:
             orig = auth_preflight.keychain_has_credentials
-            auth_preflight.keychain_has_credentials = lambda: False
+            auth_preflight.keychain_has_credentials = lambda *_a, **_k: False
             try:
                 import io
                 from contextlib import redirect_stdout

--- a/tests/keychain-service.test.py
+++ b/tests/keychain-service.test.py
@@ -33,7 +33,7 @@ class TestScopedKeychainService(unittest.TestCase):
 
     def test_scoped_name_is_deterministic_sha256_prefix(self):
         import hashlib
-        d = "/Users/wangchi/Library/Application Support/space.ag2.app/workspace/.claude-sutando"
+        d = "/x/some install/.claude-sutando"
         digest = hashlib.sha256(d.encode()).hexdigest()[:8]
         self.assertEqual(ks.scoped_keychain_service(d), f"Claude Code-credentials-{digest}")
 

--- a/tests/keychain-service.test.py
+++ b/tests/keychain-service.test.py
@@ -49,21 +49,16 @@ class TestResolvedCredentialService(unittest.TestCase):
             self.assertEqual(ks.resolved_credential_service(config_dir), scoped)
 
     def test_vanilla_only_host_still_resolves_via_fallback(self):
-        # Pro's host: a non-default CLAUDE_CONFIG_DIR, stored under the vanilla
-        # name, no scoped item at all. The fix must not invert the bug onto this
-        # population -- vanilla must still be found.
+        # A non-default CLAUDE_CONFIG_DIR with only the vanilla item stored: the
+        # fix must not invert the bug onto this population -- vanilla must still resolve.
         config_dir = "/some/nondefault/.claude-sutando"
         with mock.patch.object(ks, "keychain_service_exists",
                                side_effect=lambda s: s == ks.VANILLA_SERVICE):
             self.assertEqual(ks.resolved_credential_service(config_dir), ks.VANILLA_SERVICE)
 
     def test_both_present_prefers_the_scoped_item(self):
-        # Mini's host: carries the vanilla item AND its own scoped item (plus
-        # others from other config dirs). The old vanilla-only check passed
-        # here by coincidence of the extra item, not because the scoped path
-        # was correct -- pruning the vanilla item would have broken it. The
-        # fix must resolve to the scoped item for THIS config dir, not just
-        # "any item exists".
+        # Both the vanilla item and this config dir's scoped item exist: must
+        # resolve to the scoped item for THIS config dir, not just "any item exists".
         config_dir = "/y/.claude-sutando"
         scoped = ks.scoped_keychain_service(config_dir)
         present = {scoped, ks.VANILLA_SERVICE, "Claude Code-credentials-b0888206",
@@ -76,14 +71,8 @@ class TestResolvedCredentialService(unittest.TestCase):
             self.assertIsNone(ks.resolved_credential_service("/z/.claude-sutando"))
 
     def test_another_hosts_scoped_item_never_counts_as_this_hosts(self):
-        # Pro's control (2026-09-11): a fleet keychain can carry OTHER hosts'
-        # scoped items (a shared login keychain, or several config dirs tried
-        # on one machine) -- their mere presence must never make THIS config
-        # dir look configured. resolved_credential_service only ever checks
-        # the ONE name it computes from the given config_dir, by construction,
-        # but the point is worth pinning: a keychain full of unrelated scoped
-        # items, with neither this config dir's own item nor the vanilla one
-        # present, must still refuse.
+        # A keychain full of OTHER config dirs' scoped items must never make
+        # this config dir look configured -- only its own exact name counts.
         config_dir = "/this/hosts/own/.claude-sutando"
         this_digest = ks.scoped_keychain_service(config_dir)
         unrelated = {"Claude Code-credentials-b0888206", "Claude Code-credentials-b23ac34d",

--- a/tests/keychain-service.test.py
+++ b/tests/keychain-service.test.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Tests for src/keychain_service.py.
+
+Pins the exact "which population is this host in" matrix Pro and Mini asked
+for on PR #4196 (2026-09-11), each from a real host: an install that stores
+under the vanilla name with a non-default CLAUDE_CONFIG_DIR (Pro's host) must
+keep passing, an install that stores under the scoped name (the bug this PR
+fixes) must start passing, and one carrying BOTH (Mini's host: the old
+vanilla-only check passed there by coincidence, not correctness -- pruning
+the vanilla item would have broken it) must resolve to the scoped item
+first. Neither present must still refuse. `keychain_service_exists` is
+mocked; nothing here touches a real Keychain.
+
+Run: python3 tests/keychain-service.test.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(_HERE, "..", "src"))
+import keychain_service as ks  # noqa: E402
+
+
+class TestScopedKeychainService(unittest.TestCase):
+    def test_empty_or_missing_config_dir_is_none(self):
+        self.assertIsNone(ks.scoped_keychain_service(""))
+        self.assertIsNone(ks.scoped_keychain_service("   "))
+        self.assertIsNone(ks.scoped_keychain_service(None))
+
+    def test_scoped_name_is_deterministic_sha256_prefix(self):
+        import hashlib
+        d = "/Users/wangchi/Library/Application Support/space.ag2.app/workspace/.claude-sutando"
+        digest = hashlib.sha256(d.encode()).hexdigest()[:8]
+        self.assertEqual(ks.scoped_keychain_service(d), f"Claude Code-credentials-{digest}")
+
+
+class TestResolvedCredentialService(unittest.TestCase):
+    """The matrix from the PR thread: each row is a real host's shape."""
+
+    def test_scoped_only_host_resolves_to_the_scoped_item(self):
+        # The bug this PR fixes: a scoped-keychain install with no vanilla item.
+        config_dir = "/x/.claude-sutando"
+        scoped = ks.scoped_keychain_service(config_dir)
+        with mock.patch.object(ks, "keychain_service_exists", side_effect=lambda s: s == scoped):
+            self.assertEqual(ks.resolved_credential_service(config_dir), scoped)
+
+    def test_vanilla_only_host_still_resolves_via_fallback(self):
+        # Pro's host: a non-default CLAUDE_CONFIG_DIR, stored under the vanilla
+        # name, no scoped item at all. The fix must not invert the bug onto this
+        # population -- vanilla must still be found.
+        config_dir = "/some/nondefault/.claude-sutando"
+        with mock.patch.object(ks, "keychain_service_exists",
+                               side_effect=lambda s: s == ks.VANILLA_SERVICE):
+            self.assertEqual(ks.resolved_credential_service(config_dir), ks.VANILLA_SERVICE)
+
+    def test_both_present_prefers_the_scoped_item(self):
+        # Mini's host: carries the vanilla item AND its own scoped item (plus
+        # others from other config dirs). The old vanilla-only check passed
+        # here by coincidence of the extra item, not because the scoped path
+        # was correct -- pruning the vanilla item would have broken it. The
+        # fix must resolve to the scoped item for THIS config dir, not just
+        # "any item exists".
+        config_dir = "/y/.claude-sutando"
+        scoped = ks.scoped_keychain_service(config_dir)
+        present = {scoped, ks.VANILLA_SERVICE, "Claude Code-credentials-b0888206",
+                  "Claude Code-credentials-b23ac34d", "Claude Code-credentials-f0daa6b6"}
+        with mock.patch.object(ks, "keychain_service_exists", side_effect=lambda s: s in present):
+            self.assertEqual(ks.resolved_credential_service(config_dir), scoped)
+
+    def test_neither_present_still_refuses(self):
+        with mock.patch.object(ks, "keychain_service_exists", return_value=False):
+            self.assertIsNone(ks.resolved_credential_service("/z/.claude-sutando"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/keychain-service.test.py
+++ b/tests/keychain-service.test.py
@@ -75,6 +75,23 @@ class TestResolvedCredentialService(unittest.TestCase):
         with mock.patch.object(ks, "keychain_service_exists", return_value=False):
             self.assertIsNone(ks.resolved_credential_service("/z/.claude-sutando"))
 
+    def test_another_hosts_scoped_item_never_counts_as_this_hosts(self):
+        # Pro's control (2026-09-11): a fleet keychain can carry OTHER hosts'
+        # scoped items (a shared login keychain, or several config dirs tried
+        # on one machine) -- their mere presence must never make THIS config
+        # dir look configured. resolved_credential_service only ever checks
+        # the ONE name it computes from the given config_dir, by construction,
+        # but the point is worth pinning: a keychain full of unrelated scoped
+        # items, with neither this config dir's own item nor the vanilla one
+        # present, must still refuse.
+        config_dir = "/this/hosts/own/.claude-sutando"
+        this_digest = ks.scoped_keychain_service(config_dir)
+        unrelated = {"Claude Code-credentials-b0888206", "Claude Code-credentials-b23ac34d",
+                    "Claude Code-credentials-f0daa6b6"}
+        assert this_digest not in unrelated  # sanity: the fixture must actually be unrelated
+        with mock.patch.object(ks, "keychain_service_exists", side_effect=lambda s: s in unrelated):
+            self.assertIsNone(ks.resolved_credential_service(config_dir))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What broke, live, on my own host (2026-09-11)

`bash src/restart.sh` on a healthy, actively-authenticated Sutando install permanently aborted startup. `auth-preflight-gate.sh` (#2396/#2413) reported:

```
✗ auth-preflight-gate: CLI login required for <config dir> — ABORTING startup
  Remedy: needs GUI /login on <host>: ...
```

The exact same CLI session that hit this was running and making real API calls at the time — the credential was genuinely valid.

## Root cause

`auth_preflight.py`'s Keychain check looks up the literal service name `Claude Code-credentials` only:

```python
KEYCHAIN_SERVICE = "Claude Code-credentials"
...
subprocess.run(["security", "find-generic-password", "-s", KEYCHAIN_SERVICE], ...)
```

But `credential-proxy.ts` — and `health-check.py`'s `quota-account-identity` probe, which already does this correctly — scope the actual Keychain item per `CLAUDE_CONFIG_DIR`: `Claude Code-credentials-<sha256(config_dir)[:8]>`. On any install using that scoped item (the common/default case), the exact-match lookup for the vanilla name never finds it, `keychain_has_credentials()` always returns `False`, and the gate reports `login_required` regardless of actual auth state.

Verified directly on the affected host:

```
$ security find-generic-password -s "Claude Code-credentials"
security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.   # rc 44

$ security find-generic-password -s "Claude Code-credentials-a751ceb4"
keychain: "/Users/.../login.keychain-db"
...
"mdat"<timedate>=...  "20260911130127Z"   # modified TODAY — actively in use
```

This is also duplicated policy (CLAUDE.md's own architecture rule names this exact shape): `health-check.py` already had the correct scoped-then-vanilla resolution; `auth_preflight.py` had a second, incomplete copy, and the copy is what broke.

## Fix

- New `src/keychain_service.py` — the one shared implementation (`scoped_keychain_service`, `keychain_service_exists`, `resolved_credential_service`), so this doesn't drift a third time.
- `health-check.py`'s two local functions become imports from it (byte-identical behavior verified; its own `_resolved_credential_service` composition stays locally defined so existing `mock.patch.object(hc, "_keychain_service_exists", ...)` tests keep working unchanged).
- `auth_preflight.py`'s `keychain_has_credentials` now takes `config_dir` and uses the shared resolver; `check_auth_state` passes it through.
- Test lambdas updated for the new one-arg `keychain_check(config_dir)` signature (was zero-arg).

## Impact if unfixed

Any restart of an install using the scoped Keychain convention (the default, per `credential-proxy.ts`) permanently aborts startup with no automatic recovery. On my host this took down voice-agent, the task watcher, and (via a related, separate cold-start gap already worked around locally) the Discord bridge, mid-session, because the gate correctly stopped `startup.sh` from relaunching anything — the gate did its job, on a false premise.

## Evidence

```
$ python3 tests/auth-preflight.test.py && python3 tests/auth-preflight-gate.test.py \
    && python3 tests/health-check-quota-account-identity.test.py \
    && python3 tests/health-check-import-without-plistlib.test.py
Ran 17 tests ... OK
Ran 7 tests ... OK
Ran 42 tests ... OK
Ran 9 tests ... OK
```

Before/after on the actual affected config dir:
```
# before (unpatched):
$ bash src/auth-preflight-gate.sh "<config dir>"
✗ auth-preflight-gate: CLI login required ... ABORTING startup

# after:
$ bash src/auth-preflight-gate.sh "<config dir>"
auth-preflight-gate: OK — <config dir> can boot authenticated
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Property worth stating (review, 2026-09-11)

The scoped name is a pure function of the `config_dir` **string**, not of the machine — two different hosts with the same `CLAUDE_CONFIG_DIR` path produce the identical Keychain service name. Confirmed live: two independent hosts (from peer review, see thread below) both produced `Claude Code-credentials-b0888206` from the same path string, and that is expected, not a bug.

Harmless while each machine's Keychain stays local (true today). It would become a genuine collision — two different secrets under one name — only if some future mechanism merged Keychain items across machines, which nothing in this codebase does. Now documented directly in `src/keychain_service.py`'s module docstring, and calling it out here so it's visible before merge, not discovered after.

## Review thread (credit)

Pro and Mini (fellow Stands) pressure-tested this fix live against their own hosts tonight and found two real gaps worth pinning as explicit tests (now 7/7 on `tests/keychain-service.test.py`):
- A host storing under the vanilla name only, with a non-default `CLAUDE_CONFIG_DIR` (must keep resolving via the fallback).
- A host carrying both the vanilla item and its own scoped item (must resolve to the *scoped* item specifically, not just succeed — the case that made the old vanilla-only check look correct there by coincidence).
- An unrelated host's scoped item present in the same keychain must never be mistaken for this config dir's own (already true by construction; pinned explicitly).

Neither is approving/merging — this is theirs and the property note above is theirs, credited here since it improved the fix.

