### PR TITLE
fix(task-orphan-check): a task a pool worker has accepted is in flight, not an orphan

### DIFF
--- a/skills/task-orphan-check/SKILL.md
+++ b/skills/task-orphan-check/SKILL.md
@@ -51,6 +51,7 @@ For each file in `tasks/`, let `<id>` be the value of the `id:` header line (e.g
    - **`<workspace>/results/<id>.txt`** exists → **DONE**. The result file is the canonical completion marker; if it exists the task was processed.
    - **`<workspace>/results/archive/<id>.txt`** exists → **DONE** (post-archive case).
    - **`<workspace>/results/proactive-<id>.txt`** OR `.sending` variant exists → see step 2b below for the in-progress-vs-done split.
+   - **`<workspace>/deliveries/<worker>/<id>.accepted`** (or `.claimed`) exists → **DELIVERED**: the route handler handed the task to a pool worker and the worker accepted it. It is in flight there, and the worker's finish archives the task file, so this pass leaves it in `tasks/`, never archives it and never re-queues it, whatever its age. Count it in the summary; do not list it in the recovery DM. (2026-09-11: three owner asks accepted by a worker were archived by this pass and re-queued, so the owner got two answers each.)
 
    **Step 2b — `.sending` contract clarification** (per qingyun-sutando review of #1074):
    - `results/<id>.txt` (no suffix) → task completed AND result body written. **DONE.**
@@ -84,6 +85,7 @@ For each file in `tasks/`, let `<id>` be the value of the `id:` header line (e.g
 
 4. **Classify outcome**:
    - **DONE** → archive the task file: `mv tasks/<id>.txt tasks/archive/<id>.txt`. Log: `done: completion marker found at <path>`.
+   - **DELIVERED** → leave alone. Log: `delivered: held by worker <inbox>, its finish archives it`.
    - **FRESH** → leave alone. Log: `fresh: arrived <N>s ago, watcher will handle`.
    - **IMPORT-RESUME** → leave alone (see step 3a). Log: `import-resume: consented import already started (phase <p>)`.
    - **IMPORT-STALLED** → leave alone, but append it to the in-pass `stalled_imports` list so step 3b names it in the DM (see step 3a). Log: `import-stalled: consented import stalled at phase <p>, status.json last moved <idle>s ago`.
@@ -195,11 +197,12 @@ orphan-check complete:
   left fresh for watcher: K
   left for the watcher as a started import (import-resume): I
   left for the watcher but reported as stalled (import-stalled): S
+  left with a pool worker that accepted it (delivered): D
   left for the watcher but reported as unmatched (import-unbound): U
   recovered as orphan (sentinel result written): J
 ```
 
-The summary lands in the conversation buffer so the agent's first turn (and operator) sees what happened. If `M+K+I+S+U+J ≠ N`, the script bailed mid-pass — log a warning and let the operator investigate.
+The summary lands in the conversation buffer so the agent's first turn (and operator) sees what happened. If `M+K+I+S+U+J+D ≠ N`, the script bailed mid-pass — log a warning and let the operator investigate.
 
 ## What this DOES NOT touch
 

--- a/skills/task-orphan-check/scripts/classify.py
+++ b/skills/task-orphan-check/scripts/classify.py
@@ -35,6 +35,10 @@ Verdicts (first match wins):
                   to this request; say 'import my Claude history' to re-run").
                   Fail toward recovery: a spurious DM line is cheap, a wrong
                   archive loses the owner's import.
+  delivered       a pool worker holds it — deliveries/<worker>/<id>.accepted
+                  (or .claimed) exists: the worker's finish archives the
+                  task, so it is left in tasks/ and never archived here,
+                  whatever its age; counted, not listed in the recovery DM.
   fresh           younger than the age line — 300 s for any task, 1800 s for
                   an import task whose run has not started.
   orphan          no marker and past the age line: step 3 applies.
@@ -192,6 +196,23 @@ def completion_marker(results_dir: Path, task_id: str) -> str:
     return ""
 
 
+DELIVERY_SUFFIXES = (".accepted", ".claimed")
+
+
+def worker_delivery(workspace: Path, task_id: str) -> str:
+    """Path of a worker's in-flight marker for the task, or ''."""
+    # Grammar is pool_delivery's: deliveries/<worker>/<task-id><suffix>; matched
+    # by path only so this skill stays importable with no pool skill installed.
+    root = workspace / "deliveries"
+    if not root.is_dir():
+        return ""
+    for inbox in sorted(p for p in root.iterdir() if p.is_dir()):
+        for suffix in DELIVERY_SUFFIXES:
+            if (inbox / f"{task_id}{suffix}").is_file():
+                return str(inbox / f"{task_id}{suffix}")
+    return ""
+
+
 def channel_label(headers: dict) -> str:
     name = headers.get("room_name") or headers.get("channel_name")
     cid = headers.get("channel_id") or headers.get("chat_id") or ""
@@ -223,6 +244,11 @@ def classify_task(path: Path, workspace: Path, now: float) -> dict:
     marker = completion_marker(workspace / "results", task_id)
     if marker:
         row.update(verdict="done", reason=f"completion marker found at {marker}")
+        return row
+    held = worker_delivery(workspace, task_id)
+    if held:
+        row.update(verdict="delivered",
+                   reason=f"a worker holds it ({held}); its finish archives the task — left in tasks/")
         return row
 
     intent = import_intent(headers, parsed.body)

--- a/tests/task-orphan-check-classify.test.py
+++ b/tests/task-orphan-check-classify.test.py
@@ -678,5 +678,62 @@ class TestCli(unittest.TestCase):
             self.assertIsNone(mod.resolve_workspace())
 
 
+class TestWorkerDelivery(ClassifyBase):
+    """A task a pool worker has accepted is in flight there, not an orphan.
+
+    2026-09-11: the route handler delivered three owner asks to a worker
+    (deliveries/<worker>/<id>.accepted); the boot pass read no marker, archived
+    them past 300 s and the core re-queued them, so the owner got two answers each.
+    """
+
+    HELD_ID = "task-88f8f3535989bf32f7"
+    WORKER = "39041ce6a4444e28bf94859ec2426270"
+
+    def held_task(self, queued: float = NOW - 2400) -> Path:
+        return self.ws.task(f"{self.HELD_ID}.txt", chat_task_text(self.HELD_ID, queued, source="ag2space"))
+
+    def mark(self, suffix: str = ".accepted", task_id: str | None = None, worker: str | None = None) -> Path:
+        inbox = self.ws.root / "deliveries" / (worker or self.WORKER)
+        inbox.mkdir(parents=True, exist_ok=True)
+        p = inbox / f"{task_id or self.HELD_ID}{suffix}"
+        p.write_text("")
+        return p
+
+    def test_control_without_a_marker_is_an_orphan(self):
+        """The discriminator: same task, no marker, past the age line -> orphan."""
+        self.held_task()
+        self.assertEqual(self.one()["verdict"], "orphan")
+
+    def test_accepted_by_a_worker_is_delivered_whatever_its_age(self):
+        self.held_task(queued=NOW - 3 * 86400)
+        marker = self.mark(".accepted")
+        row = self.one()
+        self.assertEqual(row["verdict"], "delivered", row)
+        self.assertIn(str(marker), row["reason"])
+
+    def test_claimed_by_a_worker_is_delivered_too(self):
+        self.held_task()
+        self.mark(".claimed")
+        self.assertEqual(self.one()["verdict"], "delivered")
+
+    def test_another_tasks_marker_does_not_count(self):
+        self.held_task()
+        self.mark(".accepted", task_id="task-4a5b4bfd1daacdaba2")
+        self.assertEqual(self.one()["verdict"], "orphan")
+
+    def test_a_result_file_still_wins_over_delivery(self):
+        """The worker finished: its result is the completion marker, delivery is history."""
+        self.held_task()
+        self.mark(".accepted")
+        (self.ws.root / "results" / f"{self.HELD_ID}.txt").write_text("done\n")
+        self.assertEqual(self.one()["verdict"], "done")
+
+    def test_delivered_is_counted(self):
+        self.held_task()
+        self.mark(".accepted")
+        out = self.mod.classify_workspace(self.ws.root, NOW)
+        self.assertEqual(out["counts"], {"delivered": 1, "total": 1})
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=1)


### PR DESCRIPTION
## What broke

`/task-orphan-check` (boot, step 1 of `/startup`) classifies a live task by `results/` markers and age. On a pool host the route handler delivers a task to a worker by writing `deliveries/<worker>/<id>.accepted` and the worker's `finish` archives the task file when it answers — but the boot pass never reads that marker. So an accepted task older than 300 s was ORPHAN, archived into the recovery DM, and the core re-queued and answered it.

Observed 2026-09-11 (this host, `logs/pool-route-handler.log`): three owner asks delivered to worker `39041ce6…` at 12:19–12:31 PT, `.accepted` written; the core booted at 12:38, archived them at 12:42, re-queued at 12:48; the worker's answers went out 12:49–12:51 and the core's second answers followed. The owner got two replies per ask, with conflicting advice on one.

## Fix

`classify.py` gains a `delivered` verdict: `deliveries/*/<id>.accepted` or `.claimed` present (grammar is `pool_delivery`'s, matched by path so the skill imports with no pool skill installed) → left in `tasks/`, never archived, counted in the summary, not listed in the DM. Checked after the completion marker (a worker that finished still reads `done`) and before the import branch. `SKILL.md` step 2 / 4 / 5 say the same.

## Evidence

```
# HEAD 
$ python3 tests/task-orphan-check-classify.test.py
Ran 60 tests in 0.750s
OK

# CONTROL — parent's classify.py, this PR's tests (git stash of the script):
FAIL: test_accepted_by_a_worker_is_delivered_whatever_its_age
FAIL: test_claimed_by_a_worker_is_delivered_too
FAIL: test_delivered_is_counted
Ran 60 tests in 0.591s
FAILED (failures=3)
```

The other three new tests pass at both ends by design: the no-marker control (still `orphan`), another task's marker (still `orphan`), and a result file present (still `done`).

`bash scripts/review-checks.sh --diff <cumulative>`: PASS (hardcoded-paths + root-artifacts + prose-cap clean).

## Worst case for existing installs

A host with no `deliveries/` dir is unchanged (`worker_delivery` returns '' before any listdir). A stale `.accepted` left by a dead worker keeps its task in `tasks/` instead of archiving it — the watcher's sweep re-emits it, which is the pre-existing behaviour for anything the pass leaves; the reaper (`reclaim_claimed`) owns that case, not this pass.

Signed: Sutando core (qingyun-001).

🤖 Generated with [Claude Code](https://claude.com/claude-code)