### PR TITLE
feat(proactive-loop): force a relevant memory in front of the agent before a choice, not after

### DIFF
--- a/skills/proactive-loop/scripts/memory-relevance-check.py
+++ b/skills/proactive-loop/scripts/memory-relevance-check.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Force consultation of a relevant memory BEFORE a choice, not after it recurs.
+
+WHY THIS EXISTS (Chi, 2026-09-11, event-mining room): "the expected behavior is
+the system gets auto improved from all my interactions w/ the system." Recording
+already happens automatically-ish -- almost every correction becomes a
+`feedback_*.md` memory file. What was missing is APPLICATION: nothing forced
+this session to consult `feedback_own_defaults_are_not_decisions.md` at the
+exact moment it repeated that pattern on the refresh-button design, three
+correction rounds later, despite the memory already being on file. A memory
+loaded once at session start is passive; this makes the check active, at the
+one moment it can still change what happens next.
+
+Same shape as `warn-already-triaged.py` (extract, then match across a fixed
+corpus) applied to a different question: that script asks "is this ALREADY
+triaged", this one asks "have I ALREADY been corrected on this" -- but a naive
+port of its word-matching (first version of this script, kept as a lesson, not
+deleted) treated any shared common word as a hit and called 31 of 32 files
+relevant to everything -- a detector that always fires is not a detector.
+Fixed by scoring on DISCRIMINATIVE tokens only: a token counts only if it
+appears in at most a quarter of the corpus (document frequency), the same
+reason tf-idf downweights "the" -- a word every file uses tells you nothing
+about which one matches THIS claim. Verified on the actual case it exists for:
+the refresh-button claim below now surfaces exactly the one directly-on-point
+file first, not a same-sized slice of the whole corpus.
+
+  python3 memory-relevance-check.py --claim "shipping a UI-facing feature with no explicit spec for one behavior"
+
+Output: RELEVANT (memory file + matching line + the tokens that made it match)
+or NONE FOUND. A RELEVANT hit is a pointer to re-read before proceeding, not a
+verdict already applied -- reading the snippet is not the same as reading the
+file, and reading the file is not the same as changing the decision.
+
+exit 0 nothing relevant found · 1 relevant memory found -- read it before proceeding · 2 cannot answer
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+MIN_LEN = 5
+MAX_DOC_FRACTION = 0.25  # a token in more than this share of files is too common to discriminate
+MIN_SHARED_TOKENS = 3
+SHOW = 8
+
+
+def memory_files():
+    sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3] / "src"))
+    from util_paths import memory_dir
+    mem = memory_dir()
+    if not mem.is_dir():
+        return []
+    return sorted(p for p in mem.glob("feedback_*.md") if p.is_file())
+
+
+def words(text):
+    """Lowercased alnum/hyphen/underscore tokens, length >= MIN_LEN. No hand-listed
+    stopwords: document frequency below does that job, and does it without a list
+    someone has to remember to extend."""
+    return {w for w in re.findall(r"[a-z][a-z0-9_-]{%d,}" % (MIN_LEN - 1), text.lower())}
+
+
+def main():
+    if "--claim" not in sys.argv:
+        print('usage: memory-relevance-check.py --claim "<what you are about to do>"')
+        return 2
+    text = " ".join(sys.argv[sys.argv.index("--claim") + 1:]).strip()
+    if not text:
+        print("--claim needs a sentence describing the action about to be taken")
+        return 2
+
+    files = memory_files()
+    if not files:
+        print("MEMORY DIR NOT FOUND — cannot answer; do NOT read this as 'nothing relevant'")
+        return 2
+
+    claim_tokens = words(text)
+    if not claim_tokens:
+        print("NO NOUNS — extracted 0 searchable tokens from the claim; cannot answer")
+        return 2
+
+    # Document frequency across the corpus, so commonness is measured, not guessed.
+    file_words = {}
+    for f in files:
+        try:
+            file_words[f] = words(f.read_text(errors="ignore"))
+        except OSError:
+            file_words[f] = set()
+    doc_freq = {t: sum(1 for w in file_words.values() if t in w) for t in claim_tokens}
+    max_docs = max(1, int(len(files) * MAX_DOC_FRACTION))
+    discriminative = {t for t, n in doc_freq.items() if 0 < n <= max_docs}
+
+    if not discriminative:
+        common = sorted(claim_tokens)[:SHOW]
+        print(f"NO DISCRIMINATIVE TOKENS — every token in the claim appears in more than "
+              f"{max_docs} of {len(files)} memory files (checked: {', '.join(common)}"
+              f"{'…' if len(claim_tokens) > SHOW else ''}). Cannot answer; re-state with a "
+              f"more specific term (a name, a file, a quoted phrase).")
+        return 2
+
+    print(f"searching {len(files)} feedback memory file(s) for "
+          f"{len(discriminative)} discriminative token(s) of {len(claim_tokens)} total\n")
+
+    hits = []
+    for f, fw in file_words.items():
+        matched = discriminative & fw
+        if len(matched) >= MIN_SHARED_TOKENS:
+            hits.append((f.name, matched))
+
+    if not hits:
+        print(f"NONE FOUND — no feedback memory shares {MIN_SHARED_TOKENS}+ discriminative "
+              f"tokens with this claim (discriminative set: {', '.join(sorted(discriminative))})")
+        return 0
+
+    # Rarer shared tokens are stronger evidence; rank by their total rarity, not just count.
+    hits.sort(key=lambda h: (-len(h[1]), sum(doc_freq[t] for t in h[1])))
+    print(f"RELEVANT — {len(hits)} feedback memory file(s) share specific vocabulary with "
+          f"this claim. READ before proceeding, not just noted:")
+    for name, matched in hits[:SHOW]:
+        ordered = sorted(matched, key=lambda t: doc_freq[t])
+        print(f"  memory/{name}  (shared: {', '.join(ordered)})")
+    if len(hits) > SHOW:
+        print(f"  +{len(hits) - SHOW} further file(s) not shown — narrow the claim to see them")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/proactive-loop-memory-relevance-check.test.py
+++ b/tests/proactive-loop-memory-relevance-check.test.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Contract for memory-relevance-check.py.
+
+The first version of this script scored on ANY shared word and called 31 of 32
+real feedback memory files "relevant" to a claim about a refresh button -- a
+detector that always fires is not a detector, and these tests exist so that
+regression can never again ship silently: a positive control (the real
+refresh-button case must hit exactly the on-point file) paired with negative
+controls (an unrelated claim, and a claim built only from words common across
+the whole fixture corpus, must both come back NONE FOUND).
+"""
+
+import contextlib
+import importlib.util
+import io
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "skills" / "proactive-loop" / "scripts"
+_s = importlib.util.spec_from_file_location("mrc", str(SCRIPTS / "memory-relevance-check.py"))
+mrc = importlib.util.module_from_spec(_s)
+_s.loader.exec_module(mrc)
+
+
+def _corpus(**files):
+    d = Path(tempfile.mkdtemp())
+    out = []
+    for name, text in files.items():
+        p = d / name
+        p.write_text(text)
+        out.append(p)
+    return sorted(out)
+
+
+def _run(claim, files):
+    buf = io.StringIO()
+    with mock.patch.object(mrc, "memory_files", lambda: files), \
+            mock.patch.object(sys, "argv", ["mrc", "--claim", claim]), \
+            contextlib.redirect_stdout(buf):
+        rc = mrc.main()
+    return rc, buf.getvalue()
+
+
+class Tokenizing(unittest.TestCase):
+    def test_short_words_are_dropped(self):
+        self.assertNotIn("a", mrc.words("a big red dog ran"))
+        self.assertNotIn("ran", mrc.words("a big red dog ran"))  # len 3 < MIN_LEN
+
+    def test_a_real_word_is_kept(self):
+        self.assertIn("button", mrc.words("the button stays"))
+
+    def test_hyphenated_and_underscored_tokens_survive(self):
+        self.assertIn("show-only", mrc.words("a show-only icon"))
+        self.assertIn("owner_verdicts", mrc.words("calls owner_verdicts once"))
+
+    def test_case_is_folded(self):
+        self.assertIn("button", mrc.words("BUTTON Button"))
+
+
+class DocumentFrequencyDiscrimination(unittest.TestCase):
+    """The bug this script was rewritten to fix: a word common across the whole
+    corpus must not count as evidence, however many files happen to share it."""
+
+    def test_a_word_in_every_file_does_not_make_them_relevant(self):
+        # "system" appears in all 4 fixtures below -- with 32 real files and a
+        # 25%-of-corpus cap this is exactly the shape that produced 31/32 hits.
+        files = _corpus(**{
+            f"f{i}.md": "the system does something unrelated to the claim here"
+            for i in range(4)
+        })
+        rc, out = _run("the system needs work", files)
+        self.assertEqual(rc, 2, "every token common -> cannot answer, not a false hit")
+        self.assertIn("NO DISCRIMINATIVE TOKENS", out)
+
+    def test_a_word_rare_in_the_corpus_does_count(self):
+        files = _corpus(**{
+            "on-point.md": "the wordmark button icon design was flagged as unspecified",
+            "unrelated-1.md": "a totally different bridge restart problem",
+            "unrelated-2.md": "a totally different quota exhaustion problem",
+            "unrelated-3.md": "a totally different memory rotation problem",
+            "unrelated-4.md": "a totally different task watcher problem",
+        })
+        rc, out = _run("shipping the wordmark button icon with no design spec", files)
+        self.assertEqual(rc, 1)
+        self.assertIn("on-point.md", out)
+        self.assertNotIn("unrelated-1.md", out)
+
+
+class SharedTokenThreshold(unittest.TestCase):
+    def test_a_single_shared_rare_token_is_not_enough(self):
+        # MIN_SHARED_TOKENS=3: one coincidental overlap must not fire the gate.
+        files = _corpus(**{
+            "maybe.md": "unrelated content entirely but mentions gizmotron once",
+            "filler.md": "nothing relevant in this one at all whatsoever",
+        })
+        rc, out = _run("a claim about gizmotron and nothing else shared", files)
+        self.assertIn(rc, (0, 2))
+        self.assertNotIn("maybe.md", out)
+
+    def test_three_shared_rare_tokens_does_fire(self):
+        files = _corpus(**{
+            "match.md": "gizmotron whirlwind paradox all appear in this file together",
+            "filler.md": "nothing relevant in this one at all whatsoever",
+        })
+        rc, out = _run("a claim mentioning gizmotron whirlwind paradox", files)
+        self.assertEqual(rc, 1)
+        self.assertIn("match.md", out)
+
+
+class Refusals(unittest.TestCase):
+    def test_missing_memory_dir_is_cannot_answer(self):
+        with mock.patch.object(mrc, "memory_files", lambda: []):
+            rc, out = _run("anything at all here", [])
+        self.assertEqual(rc, 2)
+        self.assertIn("MEMORY DIR NOT FOUND", out)
+
+    def test_empty_claim_is_refused(self):
+        files = _corpus(**{"f.md": "content"})
+        rc, out = _run("   ", files)
+        self.assertEqual(rc, 2)
+
+    def test_a_claim_with_no_searchable_words_cannot_answer(self):
+        files = _corpus(**{"f.md": "content here"})
+        rc, out = _run("go do it", files)  # every word < MIN_LEN
+        self.assertEqual(rc, 2)
+        self.assertIn("NO NOUNS", out)
+
+    def test_missing_claim_flag_is_refused(self):
+        files = _corpus(**{"f.md": "content"})
+        buf = io.StringIO()
+        with mock.patch.object(mrc, "memory_files", lambda: files), \
+                mock.patch.object(sys, "argv", ["mrc"]), \
+                contextlib.redirect_stdout(buf):
+            rc = mrc.main()
+        self.assertEqual(rc, 2)
+        self.assertIn("usage:", buf.getvalue())
+
+
+class EndToEndOnTheRealCorpus(unittest.TestCase):
+    """Positive control against the actual installed memory dir: the exact
+    incident this script was built for must be found, by name, in the real
+    corpus -- not a fixture standing in for it."""
+
+    def test_the_refresh_button_claim_finds_the_design_intent_memory(self):
+        files = mrc.memory_files()
+        if not files:
+            self.skipTest("no installed memory dir on this host")
+        names = {f.name for f in files}
+        if "feedback_ask_for_design_intent_not_around_it.md" not in names:
+            self.skipTest("the specific memory this test pins is not installed here")
+        rc, out = _run(
+            "shipping a refresh button, persistent vs show-only-on-update icon, "
+            "no spec named which one", files)
+        self.assertEqual(rc, 1)
+        self.assertIn("feedback_ask_for_design_intent_not_around_it.md", out)
+
+    def test_an_unrelated_real_claim_does_not_false_positive_on_the_same_memory(self):
+        files = mrc.memory_files()
+        if not files:
+            self.skipTest("no installed memory dir on this host")
+        rc, out = _run(
+            "checking the discord bridge process for a stale pid before restarting it",
+            files)
+        # Negative control for the test above: without it, a checker that always
+        # says RELEVANT would still pass the positive case.
+        self.assertNotIn("feedback_ask_for_design_intent_not_around_it.md", out)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What this is

The owner's own words (2026-09-11, event-mining room): "the expected behavior
is the system gets auto improved from all my interactions w/ the system." This
session already writes a `feedback_*.md` memory file after almost every
correction — recording already happens. What's missing is **application**:
nothing forces the agent to re-consult a relevant memory at the exact moment
it's about to repeat the mistake that memory describes. The precipitating
case: `feedback_own_defaults_are_not_decisions.md` already existed, on file,
describing this exact failure shape — and it recurred anyway on a UI design
choice, three correction rounds deep, because the memory is loaded passively
at session start and nothing prompts a re-read at decision time.

`skills/proactive-loop/scripts/memory-relevance-check.py` takes a `--claim`
describing the action about to be taken and searches the `feedback_*.md`
corpus for files sharing **discriminative** vocabulary with it.

## Before/after evidence

A naive first version (word-overlap, no frequency weighting) called 31 of 32
real memory files "relevant" to one claim — every file shares *some* common
word with any sentence, so that detector always fires:

```
$ python3 skills/proactive-loop/scripts/memory-relevance-check.py --claim "shipping a refresh button, persistent vs show-only-on-update icon, no spec named which one"
RELEVANT — 31 feedback memory file(s) share vocabulary with this claim.
```

Fixed by requiring shared tokens to be **discriminative** — a token counts
only if it appears in at most a quarter of the corpus (the same reason
tf-idf downweights "the") — and requiring 3+ such tokens to fire, at HEAD:

```
$ python3 skills/proactive-loop/scripts/memory-relevance-check.py --claim "shipping a refresh button, persistent vs show-only-on-update icon, no spec named which one"
RELEVANT — 1 feedback memory file(s) share specific vocabulary with this claim.
  memory/feedback_ask_for_design_intent_not_around_it.md  (shared: persistent, button, refresh)

$ python3 skills/proactive-loop/scripts/memory-relevance-check.py --claim "checking the discord bridge process for a stale pid before restarting it"
NONE FOUND — no feedback memory shares 3+ discriminative tokens with this claim
```

One on-point hit for the real case; a genuine negative on an unrelated one.

## Tests

14 tests in `tests/proactive-loop-memory-relevance-check.test.py`: tokenizing,
the document-frequency discrimination fix itself (a word common across every
fixture file must not count, a rare shared word must), the shared-token
threshold, refusal paths (missing memory dir, empty claim, no searchable
words), and two end-to-end tests against the **real installed memory
corpus** — a positive control (the actual refresh-button claim must find
`feedback_ask_for_design_intent_not_around_it.md` by name) and a negative
control (an unrelated claim must not). Those two skip cleanly on a checkout
with no memory directory (this repo checkout, verified below) rather than
failing or silently passing.

```
$ python3 tests/proactive-loop-memory-relevance-check.test.py
Ran 14 tests in 0.005s
OK (skipped=2)
```

`bash scripts/review-checks.sh` on the diff: PASS (hardcoded-paths +
root-artifacts + prose-cap clean).

## What this is NOT

This PR ships the mechanism only — it is not yet wired into any required
step. Where it should gate (a pre-flight before opening a UI-facing PR,
a proactive-loop step alongside the existing 3.4/3.45/9.5 gates, or both)
is an open question I'm not deciding unilaterally in the same PR that ships
the checker — happy to do the wiring as a fast follow once there's agreement
on where it bites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
