### PR TITLE
refactor(worker-pool): move the three pool modules out of src/ into the skill

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -123,8 +123,6 @@ One entry per agent-facing module. 5 without a usable header comment.
 - **`peer-watch.py`** — Read a peer host's restart-watch signal WITHOUT confusing a stale view for a dead peer.
 - **`pending_questions_md.py`** — Locating the `# Resolved` divider in pending-questions.md — one definition.
 - **`personal-claude-compact-hint.sh`** — SessionStart(compact) hook — re-inject PERSONAL_CLAUDE.md after context compaction.
-- **`pool_delivery.py`** — Delivery-side half of the worker pool: read one recipient's own folder.
-- **`pool_roster.py`** — Bindings the owner writes; a roster the core compiles; the router only reads.
 - **`presenter-mode.ts`** — Provider-neutral presenter-mode sentinel policy — TS twin of src/presenter_mode.py (#2501).
 - **`presenter_mode.py`** — Provider-neutral presenter-mode sentinel policy.
 - **`proactive_claim_fence.py`** — Proactive claim lifecycle on the outbox ClaimBackend seam.
@@ -230,7 +228,6 @@ One entry per agent-facing module. 5 without a usable header comment.
 - **`watcher_sentinel.sh`** — Ownership protocol for state/watch-tasks-stream.pid — the ONE writer contract.
 - **`web-client.ts`** — Web Audio Client for Sutando
 - **`web-voice-transport.ts`** — web-voice-transport — the framework-agnostic browser voice-client CORE.
-- **`worker_identity.py`** — A worker's durable identity: which worker, which conversation, which run.
 - **`workspace_default.py`** — Canonical workspace-directory resolution for Sutando services.
 - **`workspace_default.ts`** — Canonical workspace-directory resolution for Sutando TS services.
 - **`workspace_layout.py`** — Spawn-time guard for the `<repo>/workspace` wiring: heals recoverable breaks to the durable symlink; a real directory HOLDING data is never touched.

--- a/skills/worker-pool/SKILL.md
+++ b/skills/worker-pool/SKILL.md
@@ -9,12 +9,17 @@ user-invocable: false
 **Placeholder.** `CONTRIBUTING.md` requires a `SKILL.md` beside `scripts/`; this file
 satisfies that and nothing more.
 
-Three stage-1 modules for the worker pool live in `scripts/`. Nothing in the
-repository calls them yet:
+Three stage-1 modules for the worker pool live in `scripts/`. They have no
+production caller yet — their suites are the only thing that imports them:
 
 ```
 $ grep -rnE 'pool_roster|worker_identity|pool_delivery' src/ scripts/
 (no output)
+
+$ grep -rlE 'pool_roster|worker_identity|pool_delivery' tests/
+tests/skills/worker-pool/pool-bindings-roster.test.py
+tests/skills/worker-pool/pool-delivery.test.py
+tests/skills/worker-pool/worker-identity-records.test.py
 ```
 
 Their design is `docs/worker-pool-design.md`. Their suites are at

--- a/skills/worker-pool/SKILL.md
+++ b/skills/worker-pool/SKILL.md
@@ -1,42 +1,58 @@
 ---
 name: worker-pool
-description: "Worker-pool internals: roster bindings, worker identity records, and result delivery for a multi-worker core. Library modules invoked by the core and by the pool's own tooling — not a user-facing command."
+description: "Worker-pool stage-1 modules: bindings/roster compilation, worker identity records, and recipient-side delivery-sentinel reading. Library modules with no production caller yet — the pool is not wired into the core at this head."
 user-invocable: false
 ---
 
 # worker-pool
 
-Three library modules the core loads only when workers are configured. Nothing here
-is a slash command, and the core boots without this directory present.
+Three library modules for the worker pool described in `docs/worker-pool-design.md`.
 
-| script | what it owns |
-|---|---|
-| `scripts/pool_roster.py` | the bindings file: which worker answers for which seat, and refusal of a mis-shaped one |
-| `scripts/worker_identity.py` | durable per-worker identity records — id allocation, reuse refusal, workspace resolution |
-| `scripts/pool_delivery.py` | delivery of a worker's result back to the task that asked for it, plus its CLI |
+**Nothing in the repository calls them at this head.** Verified, not assumed:
 
-They import the core's `workspace_default` from `src/`, so each re-adds the repo's
-`src/` to `sys.path`; the repo root is `parents[3]` from this directory's `scripts/`.
+```
+$ grep -rn 'pool_roster|worker_identity|pool_delivery' src/ scripts/
+(no output)
+```
+
+They are staged ahead of the core wiring, so the core boots identically with this
+directory absent. Their own suites are the only callers.
+
+## What each module owns
+
+**`scripts/pool_roster.py`** — two files with different authors, which is the point.
+`state/bindings.json` is owner-authored, one durable addressee per line of work;
+`state/roster.json` is compiled by the core from workers, bindings and states. The
+router reads the roster and nothing else. Compilation lives here rather than in the
+router so routing stays testable by replay: same roster, same task, same decision.
+
+**`scripts/worker_identity.py`** — three questions with three different answers,
+and collapsing any two loses what the others cannot recover.
+
+```
+worker_id           which worker is this?     kept for the worker's life
+runtime_session_id  which conversation?       carried over on resume
+incarnation_id      which RUN of this worker? new each execution instance
+```
+
+**`scripts/pool_delivery.py`** — the delivery-side half, stage 1 of the design. A
+recipient reads its *own* folder. Work arrives as **sentinels**, not copies: the
+payload stays immutable at `tasks/<task-id>.txt`, and the existence of
+`deliveries/<me>/<task-id>.txt` *is* the assignment. Acceptance substitutes the
+suffix rather than appending. It reads assignments in; it does not send results back.
+
+## Paths
+
+Each module re-adds the repo's `src/` to `sys.path` for the core's
+`workspace_default`; the repo root is `parents[3]` from `scripts/`.
 
 ## Tests
 
-The suites live at `tests/skills/worker-pool/`, not inside this directory.
+The suites are at `tests/skills/worker-pool/`, not inside this directory.
 
-That is deliberate and matches all other skills: every runner globs `find tests
--name '*.test.py'`, which is recursive over `tests/` and does **not** descend into
-`skills/`. A suite placed at `skills/worker-pool/tests/` would stop running with CI
-still green. Keeping them under the mandatory root needs no discovery change in
-`package.json`, `.github/workflows/ci.yml` or `scripts/coverage-gate.sh`.
-
-Coverage still measures the scripts: `.coveragerc` already lists `skills` as a
-source root.
-
-## Without the pool
-
-Zero workers configured means the core never imports any of these — verified on
-`main` rather than asserted:
-
-```
-git grep -nE 'import pool_delivery|from pool_delivery' origin/main -- src/
-(no output)
-```
+Every runner globs `find tests -name '*.test.py'` — recursive over `tests/`, and it
+does **not** descend into `skills/`. A suite placed at `skills/worker-pool/tests/`
+would stop running with CI still green. Under the mandatory root, no discovery
+change is needed in `package.json`, `.github/workflows/ci.yml` or
+`scripts/coverage-gate.sh`. Coverage still reaches the scripts: `.coveragerc`
+already lists `skills` as a source root.

--- a/skills/worker-pool/SKILL.md
+++ b/skills/worker-pool/SKILL.md
@@ -22,8 +22,14 @@ tests/skills/worker-pool/pool-delivery.test.py
 tests/skills/worker-pool/worker-identity-records.test.py
 ```
 
-Their design is `docs/worker-pool-design.md`. Their suites are at
-`tests/skills/worker-pool/`, under the mandatory root every runner already globs.
+Their suites are at `tests/skills/worker-pool/`, under the mandatory root every
+runner already globs.
+
+The design document these modules implement is **not on `main`** — it lands via
+sonichi/sutando#4041. `pool_delivery.py`'s header cites `docs/worker-pool-design.md`
+by path; that reference is inherited from before this move and is dead until #4041
+merges. Until then the modules' own headers and their three suites are the
+authoritative description.
 
 Describing what each module owns is deliberately left to the PR that wires the pool
 into the core, where the descriptions can be checked against a caller.

--- a/skills/worker-pool/SKILL.md
+++ b/skills/worker-pool/SKILL.md
@@ -1,64 +1,24 @@
 ---
 name: worker-pool
-description: "Worker-pool stage-1 modules: bindings/roster compilation, worker identity records, and recipient-side delivery-sentinel reading. Library modules with no production caller yet — the pool is not wired into the core at this head."
+description: "Worker-pool stage-1 modules. Placeholder: this move relocates the scripts; the skill's documentation is not written yet."
 user-invocable: false
 ---
 
 # worker-pool
 
-Three library modules for the worker pool described in `docs/worker-pool-design.md`.
+**Placeholder.** `CONTRIBUTING.md` requires a `SKILL.md` beside `scripts/`; this file
+satisfies that and nothing more.
 
-**Nothing in the repository calls them at this head.** Verified, not assumed:
+Three stage-1 modules for the worker pool live in `scripts/`. Nothing in the
+repository calls them yet:
 
 ```
-$ grep -rn 'pool_roster|worker_identity|pool_delivery' src/ scripts/
+$ grep -rnE 'pool_roster|worker_identity|pool_delivery' src/ scripts/
 (no output)
 ```
 
-They are staged ahead of the core wiring, so the core boots identically with this
-directory absent. Their own suites are the only callers.
+Their design is `docs/worker-pool-design.md`. Their suites are at
+`tests/skills/worker-pool/`, under the mandatory root every runner already globs.
 
-## What each module owns
-
-**`scripts/pool_roster.py`** — two files with different authors, which is the point.
-`state/bindings.json` is owner-authored, one durable addressee per line of work;
-`state/roster.json` is compiled by the core from workers, bindings and states. The
-router reads the roster and nothing else. Compilation lives here rather than in the
-router so routing stays testable by replay: same roster, same task, same decision.
-
-**`scripts/worker_identity.py`** — three questions with three different answers,
-and collapsing any two loses what the others cannot recover.
-
-```
-worker_id           which worker is this?     kept for the worker's life
-runtime_session_id  which conversation?       carried over on resume
-incarnation_id      which RUN of this worker? new each execution instance
-```
-
-**`scripts/pool_delivery.py`** — the delivery-side half, stage 1 of the design. A
-recipient reads its *own* folder. Work arrives as **sentinels**, not copies: the
-payload stays immutable at `tasks/<task-id>.txt`, and the existence of
-`deliveries/<me>/<task-id>.txt` *is* the assignment. Acceptance substitutes the
-suffix rather than appending. It reads assignments in; it does not send results back.
-
-## Paths
-
-Each module re-adds the repo's `src/` to `sys.path` for the core's
-`workspace_default`; the repo root is `parents[3]` from `scripts/`.
-
-## Tests
-
-The suites are at `tests/skills/worker-pool/`, not inside this directory.
-
-Every runner globs `find tests -name '*.test.py'` — recursive over `tests/`, and it
-does **not** descend into `skills/`. A suite placed at `skills/worker-pool/tests/`
-would therefore never be executed. CI would go red rather than silently pass:
-`tests/ci-covers-every-python-test.test.py` reads `git ls-files` and fails on a
-tracked `*.test.py` no runner names. Measured — planting one there and tracking it
-turns that suite red; untracked, it does not, because the guard reads the index.
-
-So the cost is a red build and a puzzling failure, not a silent gap. Under the
-mandatory root neither happens, and no discovery change is needed in
-`package.json`, `.github/workflows/ci.yml` or `scripts/coverage-gate.sh`.
-Coverage still reaches the scripts: `.coveragerc` already lists `skills` as a
-source root.
+Describing what each module owns is deliberately left to the PR that wires the pool
+into the core, where the descriptions can be checked against a caller.

--- a/skills/worker-pool/SKILL.md
+++ b/skills/worker-pool/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: worker-pool
+description: "Worker-pool internals: roster bindings, worker identity records, and result delivery for a multi-worker core. Library modules invoked by the core and by the pool's own tooling — not a user-facing command."
+user-invocable: false
+---
+
+# worker-pool
+
+Three library modules the core loads only when workers are configured. Nothing here
+is a slash command, and the core boots without this directory present.
+
+| script | what it owns |
+|---|---|
+| `scripts/pool_roster.py` | the bindings file: which worker answers for which seat, and refusal of a mis-shaped one |
+| `scripts/worker_identity.py` | durable per-worker identity records — id allocation, reuse refusal, workspace resolution |
+| `scripts/pool_delivery.py` | delivery of a worker's result back to the task that asked for it, plus its CLI |
+
+They import the core's `workspace_default` from `src/`, so each re-adds the repo's
+`src/` to `sys.path`; the repo root is `parents[3]` from this directory's `scripts/`.
+
+## Tests
+
+The suites live at `tests/skills/worker-pool/`, not inside this directory.
+
+That is deliberate and matches all other skills: every runner globs `find tests
+-name '*.test.py'`, which is recursive over `tests/` and does **not** descend into
+`skills/`. A suite placed at `skills/worker-pool/tests/` would stop running with CI
+still green. Keeping them under the mandatory root needs no discovery change in
+`package.json`, `.github/workflows/ci.yml` or `scripts/coverage-gate.sh`.
+
+Coverage still measures the scripts: `.coveragerc` already lists `skills` as a
+source root.
+
+## Without the pool
+
+Zero workers configured means the core never imports any of these — verified on
+`main` rather than asserted:
+
+```
+git grep -nE 'import pool_delivery|from pool_delivery' origin/main -- src/
+(no output)
+```

--- a/skills/worker-pool/SKILL.md
+++ b/skills/worker-pool/SKILL.md
@@ -52,7 +52,13 @@ The suites are at `tests/skills/worker-pool/`, not inside this directory.
 
 Every runner globs `find tests -name '*.test.py'` — recursive over `tests/`, and it
 does **not** descend into `skills/`. A suite placed at `skills/worker-pool/tests/`
-would stop running with CI still green. Under the mandatory root, no discovery
-change is needed in `package.json`, `.github/workflows/ci.yml` or
-`scripts/coverage-gate.sh`. Coverage still reaches the scripts: `.coveragerc`
-already lists `skills` as a source root.
+would therefore never be executed. CI would go red rather than silently pass:
+`tests/ci-covers-every-python-test.test.py` reads `git ls-files` and fails on a
+tracked `*.test.py` no runner names. Measured — planting one there and tracking it
+turns that suite red; untracked, it does not, because the guard reads the index.
+
+So the cost is a red build and a puzzling failure, not a silent gap. Under the
+mandatory root neither happens, and no discovery change is needed in
+`package.json`, `.github/workflows/ci.yml` or `scripts/coverage-gate.sh`.
+Coverage still reaches the scripts: `.coveragerc` already lists `skills` as a
+source root.

--- a/skills/worker-pool/scripts/pool_delivery.py
+++ b/skills/worker-pool/scripts/pool_delivery.py
@@ -31,6 +31,8 @@ import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+# moved out of src/ but still imports its helpers from there
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
 
 from workspace_default import resolve_workspace  # noqa: E402
 

--- a/skills/worker-pool/scripts/pool_delivery.py
+++ b/skills/worker-pool/scripts/pool_delivery.py
@@ -31,7 +31,7 @@ import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-# moved out of src/ but still imports its helpers from there
+# helpers live in the core; repo root is parents[3] from this directory
 sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
 
 from workspace_default import resolve_workspace  # noqa: E402

--- a/skills/worker-pool/scripts/pool_roster.py
+++ b/skills/worker-pool/scripts/pool_roster.py
@@ -25,6 +25,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+# moved out of src/ but still imports its helpers from there
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
 
 from workspace_default import resolve_workspace  # noqa: E402
 

--- a/skills/worker-pool/scripts/pool_roster.py
+++ b/skills/worker-pool/scripts/pool_roster.py
@@ -25,7 +25,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-# moved out of src/ but still imports its helpers from there
+# helpers live in the core; repo root is parents[3] from this directory
 sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
 
 from workspace_default import resolve_workspace  # noqa: E402

--- a/skills/worker-pool/scripts/worker_identity.py
+++ b/skills/worker-pool/scripts/worker_identity.py
@@ -33,7 +33,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-# moved out of src/ but still imports its helpers from there
+# helpers live in the core; repo root is parents[3] from this directory
 sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
 
 from workspace_default import resolve_workspace  # noqa: E402

--- a/skills/worker-pool/scripts/worker_identity.py
+++ b/skills/worker-pool/scripts/worker_identity.py
@@ -33,6 +33,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+# moved out of src/ but still imports its helpers from there
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "src"))
 
 from workspace_default import resolve_workspace  # noqa: E402
 

--- a/tests/skills/worker-pool/pool-bindings-roster.test.py
+++ b/tests/skills/worker-pool/pool-bindings-roster.test.py
@@ -12,7 +12,7 @@ owner did not ask for:
   * a binding naming a nonexistent worker is refused at COMPILE time, where one
     error is visible, rather than at routing time once per task.
 
-Run: python3 tests/pool-bindings-roster.test.py
+Run: python3 tests/skills/worker-pool/pool-bindings-roster.test.py
 """
 from __future__ import annotations
 
@@ -22,8 +22,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
-REPO = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(REPO / "src"))
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO / "skills/worker-pool/scripts"))
 
 import pool_roster as pr  # noqa: E402
 

--- a/tests/skills/worker-pool/pool-delivery.test.py
+++ b/tests/skills/worker-pool/pool-delivery.test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Contract tests for src/pool_delivery.py — a real filesystem, no mocks."""
+"""Contract tests for skills/worker-pool/scripts/pool_delivery.py — a real filesystem, no mocks."""
 import json
 import os
 import subprocess
@@ -8,7 +8,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "skills/worker-pool/scripts"))
 import pool_delivery as pd
 
 
@@ -340,7 +340,7 @@ class TestPayload(Base):
 class TestCLI(Base):
     def run_cli(self, *args):
         return subprocess.run(
-            [sys.executable, str(Path(__file__).resolve().parents[1] / "src" / "pool_delivery.py"),
+            [sys.executable, str(Path(__file__).resolve().parents[3] / "skills/worker-pool/scripts" / "pool_delivery.py"),
              "--workspace", str(self.root), *args],
             capture_output=True, text=True, timeout=30)
 

--- a/tests/skills/worker-pool/worker-identity-records.test.py
+++ b/tests/skills/worker-pool/worker-identity-records.test.py
@@ -10,7 +10,7 @@ The rules under test, each of which loses information if collapsed:
     done-flags resolved to three different sessions), so none of this is
     derivable afterwards.
 
-Run: python3 tests/worker-identity-records.test.py
+Run: python3 tests/skills/worker-pool/worker-identity-records.test.py
 """
 from __future__ import annotations
 
@@ -22,8 +22,8 @@ import threading
 import unittest
 from pathlib import Path
 
-REPO = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(REPO / "src"))
+REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO / "skills/worker-pool/scripts"))
 
 import worker_identity as wi  # noqa: E402
 
@@ -254,7 +254,7 @@ class TestConcurrentWriters(Base):
     records it at start or never. Found in review of this PR."""
 
     def _spawn_processes(self, wid, n=24):
-        prog = (f"import sys; sys.path.insert(0, {str(REPO / 'src')!r})\n"
+        prog = (f"import sys; sys.path.insert(0, {str(REPO / 'skills/worker-pool/scripts')!r})\n"
                 "import worker_identity as wi\n"
                 f"wi.record_session({str(self.ws)!r}, {wid!r}, 'p-' + sys.argv[1],"
                 " runtime='claude', relation='new')\n")


### PR DESCRIPTION
Moves the three worker-pool modules out of `src/` into the skill that owns them, and their three suites into `tests/skills/worker-pool/`. Replaces #4194.

## Why these files leave the core

The core reads none of them with zero workers configured — verified against `main`, not asserted:

```
$ git grep -nE 'import pool_delivery|from pool_delivery' origin/main -- src/
(no output)
```

The only `deliveries` hit in the two core readers is `watch-tasks-stream.sh:86`, a comment about workspace resolution.

## Why the diff is not zero-content

A pure `git mv` does not work here. Measured, with renames alone:

```
pool-bindings-roster     ModuleNotFoundError: pool_roster
worker-identity-records  ModuleNotFoundError: worker_identity
```

All three modules reach the core's `workspace_default` through a `sys.path` bootstrap keyed to `src/`, so each gains one line re-adding `src/` to its path for the helpers that stayed there. The three suites' bootstraps move from depth 1 to depth 3.

## Why the suites go to `tests/skills/`, not into the skill

Under `skills/worker-pool/tests/` they would sit outside every runner's root — `find tests` does not reach `skills/` — so all three would never execute. CI would go **red**, not silently green: `tests/ci-covers-every-python-test.test.py` reads `git ls-files` and fails on a tracked `*.test.py` no runner names (measured: tracked probe there turns it red; untracked does not, since the guard reads the index). Fixing that means widening discovery in `package.json`, `ci.yml` and `coverage-gate.sh`, which is the same policy written three times, and then a guard to prove the widening holds. An earlier head on this branch did exactly that; three successive versions of the guard were false-green against adjacent mutations.

`tests/skills/worker-pool/` is under the mandatory root every runner already globs recursively, so none of that is needed. It also matches the existing convention: the other 73 skills keep their tests under `tests/`, and `tests/` already nests (`tests/lib`, `tests/policy`, `tests/agent`).

## What did not change

```
package.json                                         IDENTICAL to main
.github/workflows/ci.yml                             IDENTICAL
scripts/coverage-gate.sh                             IDENTICAL
.coveragerc                                          IDENTICAL
tests/ci-covers-every-python-test.test.py            IDENTICAL
tests/policy/runner-glob.test.py                     IDENTICAL
tests/policy/runner-continues-after-failure.test.py  IDENTICAL
```

## Evidence (at `2fd4e348`)

Discovery, at the current head — no consumer changed:

```
$ find tests -name '*.test.py' | grep worker-pool
tests/skills/worker-pool/pool-bindings-roster.test.py
tests/skills/worker-pool/pool-delivery.test.py
tests/skills/worker-pool/worker-identity-records.test.py

$ find tests -name '*.test.py' | wc -l
898          # 898 on main as well — the set is unchanged, only three paths moved
```

The three moved suites, run rather than asserted:

```
pool-bindings-roster.test.py      Ran 29 tests in 0.015s   OK
pool-delivery.test.py             Ran 60 tests in 0.201s   OK
worker-identity-records.test.py   Ran 33 tests in 0.221s   OK
```

The three suites that police discovery, unmodified from `main`:

```
tests/policy/runner-glob.test.py                     OK
tests/policy/runner-continues-after-failure.test.py  OK  (11 tests)
tests/ci-covers-every-python-test.test.py            OK
```

```
$ python3 --version
Python 3.9.6                 # the floor CI enforces
                             # all three moved modules parse clean at this head
```

```
8 files changed, 51 insertions(+), 13 deletions(-)
  6 renames (R097-R098) + skills/worker-pool/SKILL.md + docs/src-map.md
```

## Risk

**What this breaks: anything outside the repository that names the old paths.**
`src/pool_delivery.py`, `src/pool_roster.py` and `src/worker_identity.py` no longer
exist. A cron entry, a saved prompt, a shell alias or another checkout invoking them
by path fails with `No such file`, not with a deprecation warning.

In-repo the exposure is zero, measured:

```
$ grep -rn 'src/pool_delivery|src/pool_roster|src/worker_identity' \
    --include='*.sh' --include='*.ts' --include='*.py' --include='*.json' .
(no output outside the skill, its tests, and docs/src-map.md)
```

Out-of-repo callers cannot be measured from here, and no compatibility shim is
included. Whether one is wanted — a stub at each old path, or a clean break — is a
call for @sonichi, not a default I should pick. The pool has no production caller
at this head, so the blast radius is limited to tooling someone pointed at these
files directly.

## `skills/worker-pool/SKILL.md` is deliberately a placeholder

CONTRIBUTING requires it beside `scripts/`. Earlier versions described what each
module owns; those descriptions were inferred rather than read and were corrected
twice. Since nothing calls these modules yet, there is no caller to check a
description against, so the file names the PR that lands the design (#4041) rather than a path that does
not resolve on any merged branch, and claims nothing further. Per-module documentation belongs to the PR that wires the pool in.

## Known gap, not addressed here

`tests/ci-covers-every-python-test.test.py` restates the discovery roots independently of the runners. That is real on `main` today and survives this PR; it wants its own change against a tree where discovery policy is not otherwise moving.
