### PR TITLE
feat(agent): the core launcher can also run as a pool worker, gated on WORKER_INSTANCE

### DIFF
--- a/packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py
+++ b/packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py
@@ -148,7 +148,7 @@ def canonical_access_tier(value) -> str:
 #   can survive undefanged in user-supplied content.
 # Adding a producer header = add it here; the guard follows automatically.
 KNOWN_HEADER_KEYS = (
-    "id", "timestamp", "session_scope", "task", "source", "access_tier", "user_id",
+    "id", "timestamp", "session_scope", "task", "source", "wire_source", "access_tier", "user_id",
     "channel_id", "priority", "interaction_type", "source_message_id",
     "channel_name", "guild_name", "attempts", "sender_name", "room_name",
     "parent_message_id", "reply_chain_ids", "reminder", "author_name",

--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -213,7 +213,7 @@ const _CONF_HEADER_RE = new RegExp(
 	'thread_root|source_room_id|' +
 	'receiving_instance|' +
 	'call_sid|hint|instructions|transcript|schedule_name|schedule_slot|content_modalities|media_form|' +
-	'attachments|platform_card|instance_id|collaborator|requested_worker|hitl_click)\\s*:',
+	'attachments|platform_card|instance_id|collaborator|requested_worker|wire_source|hitl_click)\\s*:',
 	'i',
 );
 const _CONF_FENCE_RE = /^={3,}/;

--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -56,6 +56,21 @@ TMUX_SOCKET="${SUTANDO_TMUX_SOCKET:-/tmp/sutando-tmux.sock}"
 # and `start-server` on a serverless socket is a no-op — so unset before any tmux.
 unset SUTANDO_CORE_MODEL
 SESSION="${SUTANDO_TMUX_SESSION:-sutando-core}"
+# A pool worker runs THIS launcher under its own session/instance env; the
+# owner-facing surfaces (remote control, Chrome) stay with the canonical core.
+WORKER_INSTANCE="${SUTANDO_INSTANCE_ID:-}"
+SURFACE_ARGS=(--remote-control "Sutando" --chrome)
+[ -n "$WORKER_INSTANCE" ] && SURFACE_ARGS=()
+# `/startup` is the CANONICAL CORE's ceremony: orphan recovery, session crons,
+# a gate any watcher satisfies. One arg — the skill reads it as $ARGUMENTS.
+BOOT_PROMPT="/startup"
+[ -n "$WORKER_INSTANCE" ] && BOOT_PROMPT="/startup --worker"
+SESSION_ARGS=()
+if [ -n "${SUTANDO_CLAUDE_RESUME:-}" ]; then
+  SESSION_ARGS=(--resume "$SUTANDO_CLAUDE_RESUME")
+elif [ -n "${SUTANDO_CLAUDE_SESSION_ID:-}" ]; then
+  SESSION_ARGS=(--session-id "$SUTANDO_CLAUDE_SESSION_ID")
+fi
 
 # Marker identifying THIS process as the long-lived sutando-core session (as
 # opposed to an ad-hoc `claude` in the same checkout — PR review, codex, etc.).
@@ -68,11 +83,18 @@ SESSION="${SUTANDO_TMUX_SESSION:-sutando-core}"
 # Snapshot what we INHERITED before the export below overwrites it: the
 # in-session restart guard must not read the marker this script sets itself.
 CALLER_CORE_SESSION="${SUTANDO_CORE_SESSION:-}"
-export SUTANDO_CORE_SESSION=1
+# A worker is not the canonical core: the marker is what makes a session claim
+# the core's bootstrap, so exporting it would make every worker a second core.
+if [ -n "$WORKER_INSTANCE" ]; then
+  unset SUTANDO_CORE_SESSION
+else
+  export SUTANDO_CORE_SESSION=1
+fi
 
 # Called ONLY from paths that create or heal a core. Attaching to a live one
 # must not clear: that would cancel a `--stop-only` still waiting to be observed.
 clear_shutdown_sentinel() {
+  [ -z "$WORKER_INSTANCE" ] || return 0   # the gate belongs to the core alone
   if [ -n "$PY" ]; then
     "$PY" "$REPO/src/shutdown.py" clear >/dev/null \
       || echo "start-cli.sh: shutdown.py clear failed — the intake gate may hold tasks" >&2
@@ -88,6 +110,7 @@ _SENTINEL_STASH=""
 # restore-after-exec below unreachable dead code.
 shopt -s execfail
 stash_shutdown_sentinel() {
+  [ -z "$WORKER_INSTANCE" ] || return 0   # the gate belongs to the core alone
   _SENTINEL_STASH=""
   [ -n "$PY" ] || return 0
   _sp="$("$PY" "$REPO/src/shutdown.py" path 2>/dev/null)" || return 0
@@ -97,6 +120,7 @@ stash_shutdown_sentinel() {
 }
 # Only reachable when exec FAILED: exec never returns on success.
 restore_shutdown_sentinel() {
+  [ -z "$WORKER_INSTANCE" ] || return 0   # the gate belongs to the core alone
   [ -n "$_SENTINEL_STASH" ] && [ -f "$_SENTINEL_STASH" ] || return 0
   _sp="$("$PY" "$REPO/src/shutdown.py" path 2>/dev/null)" || return 0
   if [ -n "$_sp" ]; then
@@ -108,9 +132,22 @@ restore_shutdown_sentinel() {
   _SENTINEL_STASH=""
 }
 export SUTANDO_CORE_RUNTIME=claude
-CORE_ENV_ARGS=(-e SUTANDO_CORE_SESSION=1 -e SUTANDO_CORE_RUNTIME=claude)
+CORE_ENV_ARGS=(-e SUTANDO_CORE_RUNTIME=claude)
+[ -n "$WORKER_INSTANCE" ] || CORE_ENV_ARGS+=(-e SUTANDO_CORE_SESSION=1)
 [ -n "${SUTANDO_TMUX_SOCKET:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_TMUX_SOCKET=$SUTANDO_TMUX_SOCKET")
 [ -n "${SUTANDO_TMUX_SESSION:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_TMUX_SESSION=$SUTANDO_TMUX_SESSION")
+[ -n "$WORKER_INSTANCE" ] && CORE_ENV_ARGS+=(-e "SUTANDO_INSTANCE_ID=$WORKER_INSTANCE")
+[ -n "${SUTANDO_TASKS_DIR:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_TASKS_DIR=$SUTANDO_TASKS_DIR")
+# A worker's inbox is <ws>/deliveries/<id>, so the watcher cannot infer the
+# workspace from it: unforwarded, its results/ and state/ land under deliveries/.
+[ -n "${SUTANDO_WORKSPACE_DIR:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_WORKSPACE_DIR=$SUTANDO_WORKSPACE_DIR")
+# The other two halves of the same seam: what the inbox holds, and where answers
+# go. Derived in-session they become deliveries/results, which no bridge drains.
+[ -n "${SUTANDO_INBOX_KIND:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_INBOX_KIND=$SUTANDO_INBOX_KIND")
+[ -n "${SUTANDO_RESULTS_DIR:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_RESULTS_DIR=$SUTANDO_RESULTS_DIR")
+# The worker gate `/startup --worker` runs, named by the spawner: this launcher
+# is the core's, so it forwards the path and never knows which skill owns it.
+[ -n "${SUTANDO_WORKER_BOOTSTRAP:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_WORKER_BOOTSTRAP=$SUTANDO_WORKER_BOOTSTRAP")
 # Forward the embedder-provided default workspace into the core session for the
 # SAME reason as above (tmux takes the server env, not this shell's). Without
 # this the core's own resolve_workspace() (proactive-loop, task scripts) misses
@@ -633,6 +670,7 @@ apply_tmux_defaults() {
 # core/socket can never suppress this one.
 ensure_core_monitor() {
   local ws mon_out relay_pid_file relay_state
+  [ -z "$WORKER_INSTANCE" ] || return 0   # the supervisor watches the core
   ws="$(bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null)" || return 0
   [ -n "$ws" ] || return 0
   mon_out="$ws/state/core-supervisor.json"
@@ -724,8 +762,8 @@ if tmux_session_exists; then
   # restart-core (kill core window → rerun this script) truly window-scoped.
   echo "  ⚠ $SESSION exists but core Claude is gone — healing core window (sibling windows preserved)" >&2
   apply_tmux_defaults
-  CORE_CMD=(claude --name "$SESSION" --remote-control "Sutando" --chrome --dangerously-skip-permissions --add-dir "$HOME" \
-    ${SETTINGS_ARGS[@]+"${SETTINGS_ARGS[@]}"} -- "/startup")
+  CORE_CMD=(claude --name "$SESSION" ${SURFACE_ARGS[@]+"${SURFACE_ARGS[@]}"} --dangerously-skip-permissions --add-dir "$HOME" \
+    ${SETTINGS_ARGS[@]+"${SETTINGS_ARGS[@]}"} ${SESSION_ARGS[@]+"${SESSION_ARGS[@]}"} -- "$BOOT_PROMPT")
   # -P -F prints the index the window ACTUALLY landed on: when index 0 is
   # occupied (e.g. a sibling drifted there) the fallback creates the core at a
   # nonzero index, and selecting a hardcoded :0 would activate the WRONG window
@@ -769,7 +807,10 @@ fi
 # line per launch; consecutive entries bound each session's lifetime, which
 # is what session-recap tooling needs to pick the right transcript (owner
 # ask 2026-07-13). Best-effort: never block the launch on it.
-if _ws="$(bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null)" && [ -n "$_ws" ]; then
+# A worker boot is not a core launch; health-check reads the newest row as the
+# current core's, so a worker appended here retires the core's own boundary.
+if [ -z "$WORKER_INSTANCE" ] \
+   && _ws="$(bash "$REPO/scripts/sutando-config.sh" workspace 2>/dev/null)" && [ -n "$_ws" ]; then
   mkdir -p "$_ws/state" 2>/dev/null || true
   printf '{"host":"%s","session_started_at":%s,"iso":"%s","source":"start-cli"}\n' \
     "$(hostname | sed 's/\..*//')" "$(date +%s)" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
@@ -790,9 +831,9 @@ if ! command -v tmux > /dev/null 2>&1; then
   # errexit would exit on the failed exec before the restore below is reached;
   # drop it just around the exec and re-raise the exec's own status.
   set +e
-  exec claude --name "$SESSION" --remote-control "Sutando" --chrome --dangerously-skip-permissions --add-dir "$HOME" \
-    ${SETTINGS_ARGS[@]+"${SETTINGS_ARGS[@]}"} \
-    -- "/startup"
+  exec claude --name "$SESSION" ${SURFACE_ARGS[@]+"${SURFACE_ARGS[@]}"} --dangerously-skip-permissions --add-dir "$HOME" \
+    ${SETTINGS_ARGS[@]+"${SETTINGS_ARGS[@]}"} ${SESSION_ARGS[@]+"${SESSION_ARGS[@]}"} \
+    -- "$BOOT_PROMPT"
   _exec_rc=$?
   set -e
   restore_shutdown_sentinel
@@ -826,9 +867,9 @@ apply_tmux_defaults
 if [ -t 1 ]; then
   ensure_core_monitor   # backgrounded child survives the exec below
   tmux -S "$TMUX_SOCKET" new-session -d -s "$SESSION" ${CORE_ENV_ARGS[@]+"${CORE_ENV_ARGS[@]}"} ${CWD_ARGS[@]+"${CWD_ARGS[@]}"} \
-    claude --name "$SESSION" --remote-control "Sutando" --chrome --dangerously-skip-permissions --add-dir "$HOME" \
-    ${SETTINGS_ARGS[@]+"${SETTINGS_ARGS[@]}"} \
-    -- "/startup" || true
+    claude --name "$SESSION" ${SURFACE_ARGS[@]+"${SURFACE_ARGS[@]}"} --dangerously-skip-permissions --add-dir "$HOME" \
+    ${SETTINGS_ARGS[@]+"${SETTINGS_ARGS[@]}"} ${SESSION_ARGS[@]+"${SESSION_ARGS[@]}"} \
+    -- "$BOOT_PROMPT" || true
   # Create-then-attach rather than `new-session -A`, so the sentinel clears only
   # once a session demonstrably exists; the poll below is the single verdict.
   for _ in $(seq 1 25); do
@@ -845,9 +886,9 @@ if [ -t 1 ]; then
   exec tmux -S "$TMUX_SOCKET" attach -t "$SESSION"
 else
   tmux -S "$TMUX_SOCKET" new-session -d -s "$SESSION" ${CORE_ENV_ARGS[@]+"${CORE_ENV_ARGS[@]}"} ${CWD_ARGS[@]+"${CWD_ARGS[@]}"} \
-    claude --name "$SESSION" --remote-control "Sutando" --chrome --dangerously-skip-permissions --add-dir "$HOME" \
-    ${SETTINGS_ARGS[@]+"${SETTINGS_ARGS[@]}"} \
-    -- "/startup"
+    claude --name "$SESSION" ${SURFACE_ARGS[@]+"${SURFACE_ARGS[@]}"} --dangerously-skip-permissions --add-dir "$HOME" \
+    ${SETTINGS_ARGS[@]+"${SETTINGS_ARGS[@]}"} ${SESSION_ARGS[@]+"${SESSION_ARGS[@]}"} \
+    -- "$BOOT_PROMPT"
   # Verify the core actually came up before reporting success. Without this a
   # failed launch (tmux server refusal, claude crash-on-start, a bad flag) still
   # exits 0 and Sutando.app reports "Core restarted" while nothing is serving —

--- a/src/agent/claude/cli/start-cli.sh
+++ b/src/agent/claude/cli/start-cli.sh
@@ -133,7 +133,13 @@ restore_shutdown_sentinel() {
 }
 export SUTANDO_CORE_RUNTIME=claude
 CORE_ENV_ARGS=(-e SUTANDO_CORE_RUNTIME=claude)
-[ -n "$WORKER_INSTANCE" ] || CORE_ENV_ARGS+=(-e SUTANDO_CORE_SESSION=1)
+# A server born from a core launch carries the marker in its global env and
+# every new session inherits it; omitting -e is not an override, an empty is.
+if [ -n "$WORKER_INSTANCE" ]; then
+  CORE_ENV_ARGS+=(-e SUTANDO_CORE_SESSION=)
+else
+  CORE_ENV_ARGS+=(-e SUTANDO_CORE_SESSION=1)
+fi
 [ -n "${SUTANDO_TMUX_SOCKET:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_TMUX_SOCKET=$SUTANDO_TMUX_SOCKET")
 [ -n "${SUTANDO_TMUX_SESSION:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_TMUX_SESSION=$SUTANDO_TMUX_SESSION")
 [ -n "$WORKER_INSTANCE" ] && CORE_ENV_ARGS+=(-e "SUTANDO_INSTANCE_ID=$WORKER_INSTANCE")

--- a/src/agent/codex/cli/start-cli.sh
+++ b/src/agent/codex/cli/start-cli.sh
@@ -147,6 +147,13 @@ WORKING_DIR="$(cd "$WORKING_DIR" && pwd -P)"
 
 CORE_ENV_ARGS=(-e SUTANDO_CORE_SESSION=1 -e SUTANDO_CORE_RUNTIME=codex)
 [ -n "${SUTANDO_DEFAULT_WORKSPACE:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_DEFAULT_WORKSPACE=$SUTANDO_DEFAULT_WORKSPACE")
+# The session's own scripts resolve the workspace the same way the notifier does,
+# so a worker session that is not told it writes its answers under deliveries/.
+[ -n "${SUTANDO_INSTANCE_ID:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_INSTANCE_ID=$SUTANDO_INSTANCE_ID")
+[ -n "${SUTANDO_TASKS_DIR:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_TASKS_DIR=$SUTANDO_TASKS_DIR")
+[ -n "${SUTANDO_WORKSPACE_DIR:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_WORKSPACE_DIR=$SUTANDO_WORKSPACE_DIR")
+[ -n "${SUTANDO_INBOX_KIND:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_INBOX_KIND=$SUTANDO_INBOX_KIND")
+[ -n "${SUTANDO_RESULTS_DIR:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_RESULTS_DIR=$SUTANDO_RESULTS_DIR")
 [ -n "${CODEX_HOME:-}" ] && CORE_ENV_ARGS+=(-e "CODEX_HOME=$CODEX_HOME")
 # tmux's server environment can predate the product-mode override, so forward
 # the self-development policy explicitly into the persistent core session.
@@ -174,6 +181,28 @@ apply_tmux_defaults() {
   tmux -S "$TMUX_SOCKET" bind -n WheelDownPane send-keys -M 2>/dev/null || true
 }
 
+# What the notifier is launched with. Its own unit so the suite can read the
+# assembled set without a tmux server, and so there is only ever one of it.
+notifier_env_args() {
+  NOTIFIER_ENV_ARGS=(-e "SUTANDO_TMUX_SOCKET=$TMUX_SOCKET" -e "SUTANDO_TMUX_SESSION=$SESSION")
+  NOTIFIER_ENV_ARGS+=(-e "SUTANDO_NOTIFIER_VERSION=$1")
+  [ -n "${SUTANDO_TASK_EVENT_HANDLER:-}" ] && NOTIFIER_ENV_ARGS+=(-e "SUTANDO_TASK_EVENT_HANDLER=$SUTANDO_TASK_EVENT_HANDLER")
+  [ -n "${SUTANDO_ISOLATED_WORKING_DIR:-}" ] && NOTIFIER_ENV_ARGS+=(-e "SUTANDO_ISOLATED_WORKING_DIR=$SUTANDO_ISOLATED_WORKING_DIR")
+  [ -n "${CODEX_HOME:-}" ] && NOTIFIER_ENV_ARGS+=(-e "CODEX_HOME=$CODEX_HOME")
+  [ -n "${SUTANDO_CORE_MODEL:-}" ] && NOTIFIER_ENV_ARGS+=(-e "SUTANDO_CORE_MODEL=$SUTANDO_CORE_MODEL")
+  if [ "${SUTANDO_SELF_DEVELOPMENT_ENABLED+x}" = x ]; then
+    NOTIFIER_ENV_ARGS+=(-e "SUTANDO_SELF_DEVELOPMENT_ENABLED=$SUTANDO_SELF_DEVELOPMENT_ENABLED")
+  fi
+  [ -n "${SUTANDO_TASKS_DIR:-}" ] && NOTIFIER_ENV_ARGS+=(-e "SUTANDO_TASKS_DIR=$SUTANDO_TASKS_DIR")
+  [ -n "${SUTANDO_RESULTS_DIR:-}" ] && NOTIFIER_ENV_ARGS+=(-e "SUTANDO_RESULTS_DIR=$SUTANDO_RESULTS_DIR")
+  # Without these the notifier derives state/ and results/ from the inbox's
+  # parent — deliveries/results for a worker, which no bridge ever drains.
+  [ -n "${SUTANDO_WORKSPACE_DIR:-}" ] && NOTIFIER_ENV_ARGS+=(-e "SUTANDO_WORKSPACE_DIR=$SUTANDO_WORKSPACE_DIR")
+  [ -n "${SUTANDO_INBOX_KIND:-}" ] && NOTIFIER_ENV_ARGS+=(-e "SUTANDO_INBOX_KIND=$SUTANDO_INBOX_KIND")
+  [ -n "${SUTANDO_INSTANCE_ID:-}" ] && NOTIFIER_ENV_ARGS+=(-e "SUTANDO_INSTANCE_ID=$SUTANDO_INSTANCE_ID")
+  return 0   # the last test is a filter, not this function's verdict
+}
+
 ensure_task_notifier() {
   local expected_version active_version
   local version_files
@@ -197,20 +226,22 @@ ensure_task_notifier() {
     fi
     tmux -S "$TMUX_SOCKET" kill-session -t "=$WATCHER_SESSION" 2>/dev/null || true
   fi
-  NOTIFIER_ENV_ARGS=(-e "SUTANDO_TMUX_SOCKET=$TMUX_SOCKET" -e "SUTANDO_TMUX_SESSION=$SESSION")
-  NOTIFIER_ENV_ARGS+=(-e "SUTANDO_NOTIFIER_VERSION=$expected_version")
-  [ -n "${SUTANDO_TASK_EVENT_HANDLER:-}" ] && NOTIFIER_ENV_ARGS+=(-e "SUTANDO_TASK_EVENT_HANDLER=$SUTANDO_TASK_EVENT_HANDLER")
-  [ -n "${SUTANDO_ISOLATED_WORKING_DIR:-}" ] && NOTIFIER_ENV_ARGS+=(-e "SUTANDO_ISOLATED_WORKING_DIR=$SUTANDO_ISOLATED_WORKING_DIR")
-  [ -n "${CODEX_HOME:-}" ] && NOTIFIER_ENV_ARGS+=(-e "CODEX_HOME=$CODEX_HOME")
-  [ -n "${SUTANDO_CORE_MODEL:-}" ] && NOTIFIER_ENV_ARGS+=(-e "SUTANDO_CORE_MODEL=$SUTANDO_CORE_MODEL")
-  if [ "${SUTANDO_SELF_DEVELOPMENT_ENABLED+x}" = x ]; then
-    NOTIFIER_ENV_ARGS+=(-e "SUTANDO_SELF_DEVELOPMENT_ENABLED=$SUTANDO_SELF_DEVELOPMENT_ENABLED")
-  fi
-  [ -n "${SUTANDO_TASKS_DIR:-}" ] && NOTIFIER_ENV_ARGS+=(-e "SUTANDO_TASKS_DIR=$SUTANDO_TASKS_DIR")
-  [ -n "${SUTANDO_RESULTS_DIR:-}" ] && NOTIFIER_ENV_ARGS+=(-e "SUTANDO_RESULTS_DIR=$SUTANDO_RESULTS_DIR")
+  notifier_env_args "$expected_version"
   tmux -S "$TMUX_SOCKET" new-session -d -s "$WATCHER_SESSION" \
     "${NOTIFIER_ENV_ARGS[@]}" bash "$NOTIFIER_SUPERVISOR"
 }
+
+# Test probes: dump what is forwarded to the core session and to the notifier,
+# so the suite reads the REAL arrays without tmux. No production caller passes.
+if [ "${1:-}" = "--print-core-env" ]; then
+  printf '%s\n' ${CORE_ENV_ARGS[@]+"${CORE_ENV_ARGS[@]}"}
+  exit 0
+fi
+if [ "${1:-}" = "--print-notifier-env" ]; then
+  notifier_env_args probe
+  printf '%s\n' ${NOTIFIER_ENV_ARGS[@]+"${NOTIFIER_ENV_ARGS[@]}"}
+  exit 0
+fi
 
 # Keep the same core-supervisor signal available for both runtimes. The
 # monitor's liveness derivation is tmux/session based; its prompt classifier is

--- a/src/agent/codex/cli/start-cli.sh
+++ b/src/agent/codex/cli/start-cli.sh
@@ -7,6 +7,13 @@ cd "$REPO"
 # Shared with the claude launcher: one owner for the in-session restart policy.
 . "$REPO/src/agent/restart-guard.sh"
 
+# This runtime has no worker mode: everything below is the canonical core's
+# ceremony, so an instance launch is refused before the first step of it.
+if [ -n "${SUTANDO_INSTANCE_ID:-}" ]; then
+  echo "start-cli: SUTANDO_INSTANCE_ID is set, but Codex workers are unsupported — only the claude runtime launches a pool worker." >&2
+  exit 2
+fi
+
 TMUX_SOCKET="${SUTANDO_TMUX_SOCKET:-/tmp/sutando-tmux.sock}"
 SESSION="${SUTANDO_TMUX_SESSION:-sutando-core}"
 WATCHER_SESSION="${SESSION}-watcher"
@@ -147,12 +154,10 @@ WORKING_DIR="$(cd "$WORKING_DIR" && pwd -P)"
 
 CORE_ENV_ARGS=(-e SUTANDO_CORE_SESSION=1 -e SUTANDO_CORE_RUNTIME=codex)
 [ -n "${SUTANDO_DEFAULT_WORKSPACE:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_DEFAULT_WORKSPACE=$SUTANDO_DEFAULT_WORKSPACE")
-# The session's own scripts resolve the workspace the same way the notifier does,
-# so a worker session that is not told it writes its answers under deliveries/.
-[ -n "${SUTANDO_INSTANCE_ID:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_INSTANCE_ID=$SUTANDO_INSTANCE_ID")
+# The session's own scripts resolve the workspace the same way the notifier
+# does: an inbox that is not <workspace>/tasks needs the workspace named.
 [ -n "${SUTANDO_TASKS_DIR:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_TASKS_DIR=$SUTANDO_TASKS_DIR")
 [ -n "${SUTANDO_WORKSPACE_DIR:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_WORKSPACE_DIR=$SUTANDO_WORKSPACE_DIR")
-[ -n "${SUTANDO_INBOX_KIND:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_INBOX_KIND=$SUTANDO_INBOX_KIND")
 [ -n "${SUTANDO_RESULTS_DIR:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_RESULTS_DIR=$SUTANDO_RESULTS_DIR")
 [ -n "${CODEX_HOME:-}" ] && CORE_ENV_ARGS+=(-e "CODEX_HOME=$CODEX_HOME")
 # tmux's server environment can predate the product-mode override, so forward
@@ -195,11 +200,9 @@ notifier_env_args() {
   fi
   [ -n "${SUTANDO_TASKS_DIR:-}" ] && NOTIFIER_ENV_ARGS+=(-e "SUTANDO_TASKS_DIR=$SUTANDO_TASKS_DIR")
   [ -n "${SUTANDO_RESULTS_DIR:-}" ] && NOTIFIER_ENV_ARGS+=(-e "SUTANDO_RESULTS_DIR=$SUTANDO_RESULTS_DIR")
-  # Without these the notifier derives state/ and results/ from the inbox's
-  # parent — deliveries/results for a worker, which no bridge ever drains.
+  # Without it the notifier derives state/ and results/ from the inbox's
+  # parent, which is the workspace only when the inbox is <workspace>/tasks.
   [ -n "${SUTANDO_WORKSPACE_DIR:-}" ] && NOTIFIER_ENV_ARGS+=(-e "SUTANDO_WORKSPACE_DIR=$SUTANDO_WORKSPACE_DIR")
-  [ -n "${SUTANDO_INBOX_KIND:-}" ] && NOTIFIER_ENV_ARGS+=(-e "SUTANDO_INBOX_KIND=$SUTANDO_INBOX_KIND")
-  [ -n "${SUTANDO_INSTANCE_ID:-}" ] && NOTIFIER_ENV_ARGS+=(-e "SUTANDO_INSTANCE_ID=$SUTANDO_INSTANCE_ID")
   return 0   # the last test is a filter, not this function's verdict
 }
 

--- a/src/agent/codex/cli/start-cli.sh
+++ b/src/agent/codex/cli/start-cli.sh
@@ -154,11 +154,6 @@ WORKING_DIR="$(cd "$WORKING_DIR" && pwd -P)"
 
 CORE_ENV_ARGS=(-e SUTANDO_CORE_SESSION=1 -e SUTANDO_CORE_RUNTIME=codex)
 [ -n "${SUTANDO_DEFAULT_WORKSPACE:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_DEFAULT_WORKSPACE=$SUTANDO_DEFAULT_WORKSPACE")
-# The session's own scripts resolve the workspace the same way the notifier
-# does: an inbox that is not <workspace>/tasks needs the workspace named.
-[ -n "${SUTANDO_TASKS_DIR:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_TASKS_DIR=$SUTANDO_TASKS_DIR")
-[ -n "${SUTANDO_WORKSPACE_DIR:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_WORKSPACE_DIR=$SUTANDO_WORKSPACE_DIR")
-[ -n "${SUTANDO_RESULTS_DIR:-}" ] && CORE_ENV_ARGS+=(-e "SUTANDO_RESULTS_DIR=$SUTANDO_RESULTS_DIR")
 [ -n "${CODEX_HOME:-}" ] && CORE_ENV_ARGS+=(-e "CODEX_HOME=$CODEX_HOME")
 # tmux's server environment can predate the product-mode override, so forward
 # the self-development policy explicitly into the persistent core session.
@@ -186,26 +181,6 @@ apply_tmux_defaults() {
   tmux -S "$TMUX_SOCKET" bind -n WheelDownPane send-keys -M 2>/dev/null || true
 }
 
-# What the notifier is launched with. Its own unit so the suite can read the
-# assembled set without a tmux server, and so there is only ever one of it.
-notifier_env_args() {
-  NOTIFIER_ENV_ARGS=(-e "SUTANDO_TMUX_SOCKET=$TMUX_SOCKET" -e "SUTANDO_TMUX_SESSION=$SESSION")
-  NOTIFIER_ENV_ARGS+=(-e "SUTANDO_NOTIFIER_VERSION=$1")
-  [ -n "${SUTANDO_TASK_EVENT_HANDLER:-}" ] && NOTIFIER_ENV_ARGS+=(-e "SUTANDO_TASK_EVENT_HANDLER=$SUTANDO_TASK_EVENT_HANDLER")
-  [ -n "${SUTANDO_ISOLATED_WORKING_DIR:-}" ] && NOTIFIER_ENV_ARGS+=(-e "SUTANDO_ISOLATED_WORKING_DIR=$SUTANDO_ISOLATED_WORKING_DIR")
-  [ -n "${CODEX_HOME:-}" ] && NOTIFIER_ENV_ARGS+=(-e "CODEX_HOME=$CODEX_HOME")
-  [ -n "${SUTANDO_CORE_MODEL:-}" ] && NOTIFIER_ENV_ARGS+=(-e "SUTANDO_CORE_MODEL=$SUTANDO_CORE_MODEL")
-  if [ "${SUTANDO_SELF_DEVELOPMENT_ENABLED+x}" = x ]; then
-    NOTIFIER_ENV_ARGS+=(-e "SUTANDO_SELF_DEVELOPMENT_ENABLED=$SUTANDO_SELF_DEVELOPMENT_ENABLED")
-  fi
-  [ -n "${SUTANDO_TASKS_DIR:-}" ] && NOTIFIER_ENV_ARGS+=(-e "SUTANDO_TASKS_DIR=$SUTANDO_TASKS_DIR")
-  [ -n "${SUTANDO_RESULTS_DIR:-}" ] && NOTIFIER_ENV_ARGS+=(-e "SUTANDO_RESULTS_DIR=$SUTANDO_RESULTS_DIR")
-  # Without it the notifier derives state/ and results/ from the inbox's
-  # parent, which is the workspace only when the inbox is <workspace>/tasks.
-  [ -n "${SUTANDO_WORKSPACE_DIR:-}" ] && NOTIFIER_ENV_ARGS+=(-e "SUTANDO_WORKSPACE_DIR=$SUTANDO_WORKSPACE_DIR")
-  return 0   # the last test is a filter, not this function's verdict
-}
-
 ensure_task_notifier() {
   local expected_version active_version
   local version_files
@@ -229,22 +204,20 @@ ensure_task_notifier() {
     fi
     tmux -S "$TMUX_SOCKET" kill-session -t "=$WATCHER_SESSION" 2>/dev/null || true
   fi
-  notifier_env_args "$expected_version"
+  NOTIFIER_ENV_ARGS=(-e "SUTANDO_TMUX_SOCKET=$TMUX_SOCKET" -e "SUTANDO_TMUX_SESSION=$SESSION")
+  NOTIFIER_ENV_ARGS+=(-e "SUTANDO_NOTIFIER_VERSION=$expected_version")
+  [ -n "${SUTANDO_TASK_EVENT_HANDLER:-}" ] && NOTIFIER_ENV_ARGS+=(-e "SUTANDO_TASK_EVENT_HANDLER=$SUTANDO_TASK_EVENT_HANDLER")
+  [ -n "${SUTANDO_ISOLATED_WORKING_DIR:-}" ] && NOTIFIER_ENV_ARGS+=(-e "SUTANDO_ISOLATED_WORKING_DIR=$SUTANDO_ISOLATED_WORKING_DIR")
+  [ -n "${CODEX_HOME:-}" ] && NOTIFIER_ENV_ARGS+=(-e "CODEX_HOME=$CODEX_HOME")
+  [ -n "${SUTANDO_CORE_MODEL:-}" ] && NOTIFIER_ENV_ARGS+=(-e "SUTANDO_CORE_MODEL=$SUTANDO_CORE_MODEL")
+  if [ "${SUTANDO_SELF_DEVELOPMENT_ENABLED+x}" = x ]; then
+    NOTIFIER_ENV_ARGS+=(-e "SUTANDO_SELF_DEVELOPMENT_ENABLED=$SUTANDO_SELF_DEVELOPMENT_ENABLED")
+  fi
+  [ -n "${SUTANDO_TASKS_DIR:-}" ] && NOTIFIER_ENV_ARGS+=(-e "SUTANDO_TASKS_DIR=$SUTANDO_TASKS_DIR")
+  [ -n "${SUTANDO_RESULTS_DIR:-}" ] && NOTIFIER_ENV_ARGS+=(-e "SUTANDO_RESULTS_DIR=$SUTANDO_RESULTS_DIR")
   tmux -S "$TMUX_SOCKET" new-session -d -s "$WATCHER_SESSION" \
     "${NOTIFIER_ENV_ARGS[@]}" bash "$NOTIFIER_SUPERVISOR"
 }
-
-# Test probes: dump what is forwarded to the core session and to the notifier,
-# so the suite reads the REAL arrays without tmux. No production caller passes.
-if [ "${1:-}" = "--print-core-env" ]; then
-  printf '%s\n' ${CORE_ENV_ARGS[@]+"${CORE_ENV_ARGS[@]}"}
-  exit 0
-fi
-if [ "${1:-}" = "--print-notifier-env" ]; then
-  notifier_env_args probe
-  printf '%s\n' ${NOTIFIER_ENV_ARGS[@]+"${NOTIFIER_ENV_ARGS[@]}"}
-  exit 0
-fi
 
 # Keep the same core-supervisor signal available for both runtimes. The
 # monitor's liveness derivation is tmux/session based; its prompt classifier is

--- a/src/agent/codex/cli/task-notifier.sh
+++ b/src/agent/codex/cli/task-notifier.sh
@@ -10,17 +10,14 @@ if [ -n "${SUTANDO_TASKS_DIR:-}" ]; then
 else
   TASKS_DIR="$(bash "$REPO/scripts/sutando-config.sh" workspace)/tasks"
 fi
-# An inbox is not always <workspace>/tasks: a pool worker watches
-# <workspace>/deliveries/<id>, whose parent is deliveries/, not the workspace.
-WORKSPACE_DIR="${SUTANDO_WORKSPACE_DIR:-$(dirname "$TASKS_DIR")}"
-RESULTS_DIR="${SUTANDO_RESULTS_DIR:-$WORKSPACE_DIR/results}"
-TASK_HANDLER_CLAIMS_DIR="$WORKSPACE_DIR/state/task-event-handler-claims"
+RESULTS_DIR="${SUTANDO_RESULTS_DIR:-$(dirname "$TASKS_DIR")/results}"
+TASK_HANDLER_CLAIMS_DIR="$(dirname "$TASKS_DIR")/state/task-event-handler-claims"
 # Same per-instance receipt the watcher writes; resolved by its owner so the
 # two cannot disagree about which instance a declined task belongs to.
 # shellcheck source=../../../../scripts/python-binary.sh
 . "$REPO/scripts/python-binary.sh"
 NOTIFIER_PY="$(require_python "$REPO" "resolve the fallback receipt dir")" || exit 1
-TASK_HANDLER_FALLBACKS_DIR="$("$NOTIFIER_PY" "$REPO/src/util_paths.py" handler-fallbacks-dir "$WORKSPACE_DIR/state")" || {
+TASK_HANDLER_FALLBACKS_DIR="$("$NOTIFIER_PY" "$REPO/src/util_paths.py" handler-fallbacks-dir "$(dirname "$TASKS_DIR")/state")" || {
   echo "task-notifier: could not resolve the fallback receipt dir" >&2
   exit 1
 }
@@ -35,15 +32,8 @@ SUBMIT_CONFIRM_TIMEOUT="${SUTANDO_NOTIFIER_SUBMIT_CONFIRM_TIMEOUT:-5}"
 COMPOSER_READY_TIMEOUT="${SUTANDO_NOTIFIER_COMPOSER_READY_TIMEOUT:-30}"
 # Poll the composer at the caller's cadence; the default is human-scale.
 COMPOSER_POLL="${SUTANDO_NOTIFIER_COMPOSER_POLL:-$POLL_INTERVAL}"
-CORE_STATUS_FILE="${SUTANDO_CORE_STATUS_FILE:-$WORKSPACE_DIR/state/core-status.json}"
+CORE_STATUS_FILE="${SUTANDO_CORE_STATUS_FILE:-$(dirname "$TASKS_DIR")/state/core-status.json}"
 WORKSTREAM_CONTEXT_SCRIPT="$REPO/skills/task-workstream-grouping/scripts/workstreams.py"
-# Test probe: report the resolved trees, so the suite reads what this script
-# ACTUALLY derives rather than a copy. No production caller passes it.
-if [ "${1:-}" = "--print-paths" ]; then
-  printf 'TASKS_DIR=%s\nWORKSPACE_DIR=%s\nRESULTS_DIR=%s\nTASK_HANDLER_CLAIMS_DIR=%s\nCORE_STATUS_FILE=%s\n' \
-    "$TASKS_DIR" "$WORKSPACE_DIR" "$RESULTS_DIR" "$TASK_HANDLER_CLAIMS_DIR" "$CORE_STATUS_FILE"
-  exit 0
-fi
 watcher_pid=""
 event_dir=""
 workstream_context_file=""
@@ -54,7 +44,7 @@ probe_optional_task_handler() {
   [ -x "$SUTANDO_TASK_EVENT_HANDLER" ] || return 3
   "$SUTANDO_TASK_EVENT_HANDLER" \
     --runtime codex \
-    --workspace "$WORKSPACE_DIR" \
+    --workspace "$(dirname "$TASKS_DIR")" \
     --task-file "$TASKS_DIR/$filename" \
     --results-dir "$RESULTS_DIR" \
     --repo "$REPO" \
@@ -234,7 +224,7 @@ PY
 # appear. Log to the workspace log dir when it exists, and always to stderr.
 log_notifier() {
   local msg="task-notifier: $*" dir
-  dir="$WORKSPACE_DIR/logs"
+  dir="$(dirname "$TASKS_DIR")/logs"
   [ -d "$dir" ] && printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$msg" >>"$dir/task-notifier.log" 2>/dev/null
   printf '%s\n' "$msg" >&2
 }

--- a/src/agent/codex/cli/task-notifier.sh
+++ b/src/agent/codex/cli/task-notifier.sh
@@ -13,7 +13,6 @@ fi
 # An inbox is not always <workspace>/tasks: a pool worker watches
 # <workspace>/deliveries/<id>, whose parent is deliveries/, not the workspace.
 WORKSPACE_DIR="${SUTANDO_WORKSPACE_DIR:-$(dirname "$TASKS_DIR")}"
-INBOX_KIND="${SUTANDO_INBOX_KIND:-tasks}"
 RESULTS_DIR="${SUTANDO_RESULTS_DIR:-$WORKSPACE_DIR/results}"
 TASK_HANDLER_CLAIMS_DIR="$WORKSPACE_DIR/state/task-event-handler-claims"
 # Same per-instance receipt the watcher writes; resolved by its owner so the
@@ -56,7 +55,7 @@ probe_optional_task_handler() {
   "$SUTANDO_TASK_EVENT_HANDLER" \
     --runtime codex \
     --workspace "$WORKSPACE_DIR" \
-    --task-file "$(payload_file "$filename")" \
+    --task-file "$TASKS_DIR/$filename" \
     --results-dir "$RESULTS_DIR" \
     --repo "$REPO" \
     --probe >/dev/null
@@ -116,18 +115,6 @@ prepare_workstream_context() {
     echo "task-notifier: workstream context lookup failed for $filename; continuing without context" >&2
     rm -f "$candidate"
   fi
-}
-
-# A sentinel names its payload and holds none; pool_delivery owns that mapping,
-# so the prompt and the handler probe ask it rather than re-spelling tasks/.
-payload_file() {
-  local filename="$1"
-  if [ "$INBOX_KIND" != "deliveries" ]; then
-    printf '%s\n' "$TASKS_DIR/$filename"
-    return 0
-  fi
-  "$NOTIFIER_PY" "${SUTANDO_POOL_DELIVERY_SCRIPT:-$REPO/skills/worker-pool/scripts/pool_delivery.py}" \
-    --workspace "$WORKSPACE_DIR" payload --sentinel "$filename"
 }
 
 has_result() {
@@ -342,7 +329,7 @@ deliver_prompt() {
 }
 
 submit_task() {
-  local filename="$1" wait_for_result="${2:-0}" prompt started payload
+  local filename="$1" wait_for_result="${2:-0}" prompt started
   case "$filename" in
     ""|*/*|*..*) return 0 ;;
   esac
@@ -350,9 +337,7 @@ submit_task() {
   # restart. Completed tasks remain in tasks/ for dashboard history, so do not
   # replay any task whose bridge result already exists.
   has_result "$filename" && return 0
-  payload="$(payload_file "$filename")"
-  [ -n "$payload" ] || return 0
-  prompt="Sutando task ready: $filename. Read $payload, follow AGENTS.md, complete the task, and write the result to $RESULTS_DIR/$filename."
+  prompt="Sutando task ready: $filename. Read $TASKS_DIR/$filename, follow AGENTS.md, complete the task, and write the result to $RESULTS_DIR/$filename."
   if ! tmux -S "$TMUX_SOCKET" has-session -t "=$SESSION" 2>/dev/null; then
     exit 0
   fi

--- a/src/agent/codex/cli/task-notifier.sh
+++ b/src/agent/codex/cli/task-notifier.sh
@@ -10,14 +10,18 @@ if [ -n "${SUTANDO_TASKS_DIR:-}" ]; then
 else
   TASKS_DIR="$(bash "$REPO/scripts/sutando-config.sh" workspace)/tasks"
 fi
-RESULTS_DIR="${SUTANDO_RESULTS_DIR:-$(dirname "$TASKS_DIR")/results}"
-TASK_HANDLER_CLAIMS_DIR="$(dirname "$TASKS_DIR")/state/task-event-handler-claims"
+# An inbox is not always <workspace>/tasks: a pool worker watches
+# <workspace>/deliveries/<id>, whose parent is deliveries/, not the workspace.
+WORKSPACE_DIR="${SUTANDO_WORKSPACE_DIR:-$(dirname "$TASKS_DIR")}"
+INBOX_KIND="${SUTANDO_INBOX_KIND:-tasks}"
+RESULTS_DIR="${SUTANDO_RESULTS_DIR:-$WORKSPACE_DIR/results}"
+TASK_HANDLER_CLAIMS_DIR="$WORKSPACE_DIR/state/task-event-handler-claims"
 # Same per-instance receipt the watcher writes; resolved by its owner so the
 # two cannot disagree about which instance a declined task belongs to.
 # shellcheck source=../../../../scripts/python-binary.sh
 . "$REPO/scripts/python-binary.sh"
 NOTIFIER_PY="$(require_python "$REPO" "resolve the fallback receipt dir")" || exit 1
-TASK_HANDLER_FALLBACKS_DIR="$("$NOTIFIER_PY" "$REPO/src/util_paths.py" handler-fallbacks-dir "$(dirname "$TASKS_DIR")/state")" || {
+TASK_HANDLER_FALLBACKS_DIR="$("$NOTIFIER_PY" "$REPO/src/util_paths.py" handler-fallbacks-dir "$WORKSPACE_DIR/state")" || {
   echo "task-notifier: could not resolve the fallback receipt dir" >&2
   exit 1
 }
@@ -32,8 +36,15 @@ SUBMIT_CONFIRM_TIMEOUT="${SUTANDO_NOTIFIER_SUBMIT_CONFIRM_TIMEOUT:-5}"
 COMPOSER_READY_TIMEOUT="${SUTANDO_NOTIFIER_COMPOSER_READY_TIMEOUT:-30}"
 # Poll the composer at the caller's cadence; the default is human-scale.
 COMPOSER_POLL="${SUTANDO_NOTIFIER_COMPOSER_POLL:-$POLL_INTERVAL}"
-CORE_STATUS_FILE="${SUTANDO_CORE_STATUS_FILE:-$(dirname "$TASKS_DIR")/state/core-status.json}"
+CORE_STATUS_FILE="${SUTANDO_CORE_STATUS_FILE:-$WORKSPACE_DIR/state/core-status.json}"
 WORKSTREAM_CONTEXT_SCRIPT="$REPO/skills/task-workstream-grouping/scripts/workstreams.py"
+# Test probe: report the resolved trees, so the suite reads what this script
+# ACTUALLY derives rather than a copy. No production caller passes it.
+if [ "${1:-}" = "--print-paths" ]; then
+  printf 'TASKS_DIR=%s\nWORKSPACE_DIR=%s\nRESULTS_DIR=%s\nTASK_HANDLER_CLAIMS_DIR=%s\nCORE_STATUS_FILE=%s\n' \
+    "$TASKS_DIR" "$WORKSPACE_DIR" "$RESULTS_DIR" "$TASK_HANDLER_CLAIMS_DIR" "$CORE_STATUS_FILE"
+  exit 0
+fi
 watcher_pid=""
 event_dir=""
 workstream_context_file=""
@@ -44,8 +55,8 @@ probe_optional_task_handler() {
   [ -x "$SUTANDO_TASK_EVENT_HANDLER" ] || return 3
   "$SUTANDO_TASK_EVENT_HANDLER" \
     --runtime codex \
-    --workspace "$(dirname "$TASKS_DIR")" \
-    --task-file "$TASKS_DIR/$filename" \
+    --workspace "$WORKSPACE_DIR" \
+    --task-file "$(payload_file "$filename")" \
     --results-dir "$RESULTS_DIR" \
     --repo "$REPO" \
     --probe >/dev/null
@@ -105,6 +116,18 @@ prepare_workstream_context() {
     echo "task-notifier: workstream context lookup failed for $filename; continuing without context" >&2
     rm -f "$candidate"
   fi
+}
+
+# A sentinel names its payload and holds none; pool_delivery owns that mapping,
+# so the prompt and the handler probe ask it rather than re-spelling tasks/.
+payload_file() {
+  local filename="$1"
+  if [ "$INBOX_KIND" != "deliveries" ]; then
+    printf '%s\n' "$TASKS_DIR/$filename"
+    return 0
+  fi
+  "$NOTIFIER_PY" "${SUTANDO_POOL_DELIVERY_SCRIPT:-$REPO/skills/worker-pool/scripts/pool_delivery.py}" \
+    --workspace "$WORKSPACE_DIR" payload --sentinel "$filename"
 }
 
 has_result() {
@@ -224,7 +247,7 @@ PY
 # appear. Log to the workspace log dir when it exists, and always to stderr.
 log_notifier() {
   local msg="task-notifier: $*" dir
-  dir="$(dirname "$TASKS_DIR")/logs"
+  dir="$WORKSPACE_DIR/logs"
   [ -d "$dir" ] && printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$msg" >>"$dir/task-notifier.log" 2>/dev/null
   printf '%s\n' "$msg" >&2
 }
@@ -319,7 +342,7 @@ deliver_prompt() {
 }
 
 submit_task() {
-  local filename="$1" wait_for_result="${2:-0}" prompt started
+  local filename="$1" wait_for_result="${2:-0}" prompt started payload
   case "$filename" in
     ""|*/*|*..*) return 0 ;;
   esac
@@ -327,7 +350,9 @@ submit_task() {
   # restart. Completed tasks remain in tasks/ for dashboard history, so do not
   # replay any task whose bridge result already exists.
   has_result "$filename" && return 0
-  prompt="Sutando task ready: $filename. Read $TASKS_DIR/$filename, follow AGENTS.md, complete the task, and write the result to $RESULTS_DIR/$filename."
+  payload="$(payload_file "$filename")"
+  [ -n "$payload" ] || return 0
+  prompt="Sutando task ready: $filename. Read $payload, follow AGENTS.md, complete the task, and write the result to $RESULTS_DIR/$filename."
   if ! tmux -S "$TMUX_SOCKET" has-session -t "=$SESSION" 2>/dev/null; then
     exit 0
   fi

--- a/src/agent/start-cli.sh
+++ b/src/agent/start-cli.sh
@@ -28,10 +28,26 @@ if [ -f "$REPO/.env" ]; then
   unset _self_dev_was_set _self_dev_ambient
 fi
 
-runtime="$(bash "$REPO/scripts/sutando-config.sh" core-runtime)" || {
-  echo "start-cli: failed to resolve core runtime" >&2
-  exit 1
-}
+# `--runtime <name>` names the runtime for THIS launch (leading arg only). A
+# caller that recorded one must not get the core's config substituted for it.
+requested_runtime=""
+if [ "${1:-}" = "--runtime" ]; then
+  requested_runtime="${2:-}"
+  if [ -z "$requested_runtime" ]; then
+    echo "start-cli: --runtime needs a value" >&2
+    exit 2
+  fi
+  shift 2
+fi
+
+if [ -n "$requested_runtime" ]; then
+  runtime="$requested_runtime"
+else
+  runtime="$(bash "$REPO/scripts/sutando-config.sh" core-runtime)" || {
+    echo "start-cli: failed to resolve core runtime" >&2
+    exit 1
+  }
+fi
 
 case "$runtime" in
   claude|codex)

--- a/src/local_task_protocol.py
+++ b/src/local_task_protocol.py
@@ -148,7 +148,7 @@ def canonical_access_tier(value) -> str:
 #   can survive undefanged in user-supplied content.
 # Adding a producer header = add it here; the guard follows automatically.
 KNOWN_HEADER_KEYS = (
-    "id", "timestamp", "session_scope", "task", "source", "access_tier", "user_id",
+    "id", "timestamp", "session_scope", "task", "source", "wire_source", "access_tier", "user_id",
     "channel_id", "priority", "interaction_type", "source_message_id",
     "channel_name", "guild_name", "attempts", "sender_name", "room_name",
     "parent_message_id", "reply_chain_ids", "reminder", "author_name",

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -99,7 +99,7 @@ const _HEADER_KEYS = [
 	'from', 'call_sid', 'hint', 'instructions', 'transcript',
 	'schedule_name', 'schedule_slot',
 	'content_modalities', 'media_form', 'attachments', 'platform_card',
-	'instance_id', 'collaborator', 'requested_worker', 'hitl_click',
+	'instance_id', 'collaborator', 'requested_worker', 'wire_source', 'hitl_click',
 ];
 const _HEADER_RE = new RegExp(`^(?:${_HEADER_KEYS.join('|')})\\s*:`, 'i');
 const _FENCE_RE = /^={3,}/;

--- a/tests/codex-core-launcher.test.py
+++ b/tests/codex-core-launcher.test.py
@@ -220,7 +220,7 @@ exit 0
                                   check=True, text=False).stdout.decode().split()
         return f"{checksum[0]}-{checksum[1]}"
 
-    def run_launcher(self, *args, env_extra=None):
+    def run_launcher(self, *args, env_extra=None, launcher="src/agent/start-cli.sh"):
         env = dict(os.environ)
         env.pop("SUTANDO_SELF_DEVELOPMENT_ENABLED", None)
         # A suite run from inside a core would otherwise inherit the marker
@@ -243,7 +243,7 @@ exit 0
         })
         env.update(env_extra or {})
         result = subprocess.run(
-            ["/bin/bash", str(self.root / "src/agent/start-cli.sh"), *args],
+            ["/bin/bash", str(self.root / launcher), *args],
             cwd=self.root, env=env, capture_output=True, text=True,
         )
         if result.returncode == 0:
@@ -343,6 +343,42 @@ exit 0
         invocation = scheduler_log.read_text()
         self.assertIn("install --workspace", invocation)
         self.assertIn("--host-label test-host", invocation)
+    def test_a_worker_instance_launch_is_refused_before_any_core_write(self):
+        """There is no Codex worker mode. Through the dispatcher's --runtime and
+        directly, an instance launch is refused, and none of the core's durable
+        records or managed processes is touched."""
+        worker = {"SUTANDO_INSTANCE_ID": "a" * 32,
+                  "SUTANDO_TMUX_SESSION": "sutando-worker-" + "a" * 32,
+                  "SUTANDO_TASKS_DIR": str(Path(self.tmp.name) / "never-read")}
+        for entry, args in (("src/agent/start-cli.sh", ("--runtime", "codex")),
+                            ("src/agent/codex/cli/start-cli.sh", ())):
+            with self.subTest(entry=entry):
+                result = self.run_launcher(*args, env_extra=worker, launcher=entry)
+                self.assertNotEqual(result.returncode, 0, result.stdout)
+                self.assertIn("SUTANDO_INSTANCE_ID", result.stderr)
+                self.assertIn("Codex workers are unsupported", result.stderr)
+        state = self.root / "workspace" / "state"
+        self.assertFalse((state / "core-runtime.json").exists(),
+                         "a worker wrote the core's runtime record")
+        self.assertFalse((state / "session-starts.log").exists(),
+                         "a worker appended the core's launch log")
+        calls = self.log.read_text() if self.log.exists() else ""
+        self.assertNotIn("new-session", calls, calls)
+        self.assertNotIn("kill-session", calls, calls)
+        for name in ("scheduler.log", "heartbeat.log", "monitor.log", "install.log"):
+            self.assertFalse((Path(self.tmp.name) / name).exists(), f"{name} was written")
+
+    def test_a_core_launch_still_writes_its_runtime_record(self):
+        """The other polarity: with no instance id the same launch is the core's,
+        and the records the worker test proves untouched are written."""
+        result = self.run_launcher()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        state = self.root / "workspace" / "state"
+        runtime = json.loads((state / "core-runtime.json").read_text())
+        self.assertEqual(runtime["session"], "sutando-core")
+        self.assertEqual(len((state / "session-starts.log").read_text().splitlines()), 1)
+        self.assertIn("new-session -d -s sutando-core", self.log.read_text())
+
     def test_reconciles_session_crons_before_codex_launch(self):
         workspace = self.root / "workspace"
         config = workspace / "hosts" / "test-host" / "crons.json"

--- a/tests/core-never-names-the-worker-pool-skill.test.py
+++ b/tests/core-never-names-the-worker-pool-skill.test.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Core never names the worker-pool skill (docs/architecture-boundaries.md,
+"Optional adapter capabilities"): a core helper may run an injected script
+path, but it must not locate a concrete optional skill. A fallback such as
+`${SUTANDO_X:-$REPO/skills/worker-pool/...}` is exactly such a location.
+
+Run: python3 tests/core-never-names-the-worker-pool-skill.test.py
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+ROOTS = (REPO / "src", REPO / "packages" / "ag2-sparrow" / "ag2_sparrow")
+NEEDLE = "skills/worker-pool"
+
+
+def _is_test_file(p: Path) -> bool:
+    return "tests" in p.parts or p.name.startswith("test_") or p.name.endswith(".test.py")
+
+
+def offenders() -> list[str]:
+    hits = []
+    for root in ROOTS:
+        for p in root.rglob("*"):
+            if not p.is_file() or _is_test_file(p) or p.suffix in {".pyc", ".png", ".db"}:
+                continue
+            try:
+                text = p.read_text(errors="ignore")
+            except OSError:
+                continue
+            for n, line in enumerate(text.splitlines(), 1):
+                if NEEDLE in line:
+                    hits.append(f"{p.relative_to(REPO)}:{n}: {line.strip()}")
+    return hits
+
+
+def main() -> int:
+    # Positive control: the probe sees the literal it guards against.
+    assert NEEDLE in 'x="${SUTANDO_POOL_DELIVERY_SCRIPT:-$REPO/skills/worker-pool/scripts/pool_delivery.py}"'
+    hits = offenders()
+    for h in hits:
+        print("FAIL  " + h)
+    print("  ok  core names no worker-pool skill path" if not hits else f"{len(hits)} core file(s) locate the worker-pool skill")
+    return 1 if hits else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/start-cli-worker-bootstrap.test.py
+++ b/tests/start-cli-worker-bootstrap.test.py
@@ -26,12 +26,26 @@ REPO = Path(__file__).resolve().parent.parent
 TMUX = shutil.which("tmux", path="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin")
 
 
-def _boot(extra_env: dict, server_env: "dict | None" = None) -> dict:
+# The launcher polls `pgrep -ax claude`, then `ps -o args=` for `--name $SESSION`:
+# the stub reports the launched stub's own pid, and the real ps shows its argv.
+PGREP_STUB = ('[ "$*" = "-ax claude" ] || exit 0\n'
+              '[ -s "$HOME/claude.pid" ] && echo "$(cat "$HOME/claude.pid") claude"\n')
+CLAUDE_STUB = 'echo $$ > "$HOME/claude.pid"\nenv > "$HOME/claude.env"\nsleep 120\n'
+
+
+def _boot(extra_env: dict, server_env: "dict | None" = None, pgrep_stub: str = PGREP_STUB) -> dict:
     """One launcher run against a COPIED repo whose sutando-config.sh names a
     scratch workspace — the real one must never be a test's write target.
 
     `server_env` starts the tmux server FIRST, from a process carrying that env:
     what a core launch does, since it exports its marker before it touches tmux.
+
+    The pgrep stub answers the liveness probe with nothing until the stub claude
+    has recorded its pid; every other probe (the monitor guard) still "finds"
+    its target, so no launcher child outlives the run.
+
+    Raises AssertionError unless the launcher's own verdict was success (exit 0):
+    a pane left behind by a failed launch is not the state under test.
 
     Returns the pane argv and env, the session's and server's tmux env, the
     workspace rows, and what the SessionStart hint says to that pane."""
@@ -52,13 +66,13 @@ def _boot(extra_env: dict, server_env: "dict | None" = None) -> dict:
             '  core-runtime) echo claude;;\n'
             '  host-label) echo testhost;;\n'
             '  *) echo "";;\nesac\n' % (ws, ws))
-        # A live pid in the relay pidfile, and a pgrep that always "finds" the
-        # monitor: both guards pass, so no launcher child outlives this run.
+        # A live pid in the relay pidfile: that guard passes, so no relay loop
+        # outlives this run.
         (ws / "state" / "core-supervisor-relay-loop.pid").write_text(str(os.getpid()))
         bind = td / "bin"
         bind.mkdir()
         (td / "home").mkdir()
-        for stub, body in (("claude", 'env > "$HOME/claude.env"\nsleep 120\n'), ("pgrep", "exit 0\n"),
+        for stub, body in (("claude", CLAUDE_STUB), ("pgrep", pgrep_stub),
                            ("lsof", "exit 1\n"), ("launchctl", "exit 1\n")):
             (bind / stub).write_text("#!/bin/bash\n" + body)
             (bind / stub).chmod(0o755)
@@ -75,8 +89,10 @@ def _boot(extra_env: dict, server_env: "dict | None" = None) -> dict:
             if server_env:
                 subprocess.run([TMUX, "-S", str(sock), "new-session", "-d", "-s", "seed", "sleep 120"],
                                env={**env, **server_env}, capture_output=True, check=True)
-            subprocess.run(["/bin/bash", str(root / "src" / "agent" / "claude" / "cli" / "start-cli.sh")],
-                           env=env, capture_output=True, text=True, timeout=90)
+            run = subprocess.run(["/bin/bash", str(root / "src" / "agent" / "claude" / "cli" / "start-cli.sh")],
+                                 env=env, capture_output=True, text=True, timeout=90)
+            assert run.returncode == 0, (
+                f"launcher exited {run.returncode}\nstdout: {run.stdout}\nstderr: {run.stderr}")
             argv = []
             for pid in tm("list-panes", "-s", "-a", "-F", "#{pane_pid}").stdout.split():
                 argv += subprocess.run(["ps", "-o", "args=", "-p", pid],
@@ -172,6 +188,15 @@ class TestWorkerOnAServerBornFromACoreLaunch(unittest.TestCase):
     def test_the_session_hint_stays_silent_for_the_worker(self):
         self.assertEqual(self.got["hint"], "",
                          "the worker was told to run the canonical core's /startup")
+
+
+class TestAFailedLaunchCannotLeaveThisSuiteGreen(unittest.TestCase):
+    def test_control_a_liveness_probe_that_reports_nothing_fails_the_fixture(self):
+        """The launcher's poll reads `pgrep -ax claude`; a probe that never names
+        the launched process is the launcher's own failure verdict (exit 1), and
+        the fixture must surface it rather than assert against the pane it left."""
+        with self.assertRaisesRegex(AssertionError, r"launcher exited 1[\s\S]*did not come up"):
+            _boot({}, pgrep_stub="exit 0\n")
 
 
 if __name__ == "__main__":

--- a/tests/start-cli-worker-bootstrap.test.py
+++ b/tests/start-cli-worker-bootstrap.test.py
@@ -26,11 +26,15 @@ REPO = Path(__file__).resolve().parent.parent
 TMUX = shutil.which("tmux", path="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin")
 
 
-def _boot(extra_env: dict) -> dict:
+def _boot(extra_env: dict, server_env: "dict | None" = None) -> dict:
     """One launcher run against a COPIED repo whose sutando-config.sh names a
     scratch workspace — the real one must never be a test's write target.
 
-    Returns the pane argv, the session's tmux env, and the workspace rows."""
+    `server_env` starts the tmux server FIRST, from a process carrying that env:
+    what a core launch does, since it exports its marker before it touches tmux.
+
+    Returns the pane argv and env, the session's and server's tmux env, the
+    workspace rows, and what the SessionStart hint says to that pane."""
     if not TMUX:
         raise unittest.SkipTest("tmux not found")
     td = Path(tempfile.mkdtemp())
@@ -54,7 +58,7 @@ def _boot(extra_env: dict) -> dict:
         bind = td / "bin"
         bind.mkdir()
         (td / "home").mkdir()
-        for stub, body in (("claude", "sleep 120\n"), ("pgrep", "exit 0\n"),
+        for stub, body in (("claude", 'env > "$HOME/claude.env"\nsleep 120\n'), ("pgrep", "exit 0\n"),
                            ("lsof", "exit 1\n"), ("launchctl", "exit 1\n")):
             (bind / stub).write_text("#!/bin/bash\n" + body)
             (bind / stub).chmod(0o755)
@@ -68,20 +72,43 @@ def _boot(extra_env: dict) -> dict:
             return subprocess.run([TMUX, "-S", str(sock), *a],
                                   capture_output=True, text=True)
         try:
+            if server_env:
+                subprocess.run([TMUX, "-S", str(sock), "new-session", "-d", "-s", "seed", "sleep 120"],
+                               env={**env, **server_env}, capture_output=True, check=True)
             subprocess.run(["/bin/bash", str(root / "src" / "agent" / "claude" / "cli" / "start-cli.sh")],
                            env=env, capture_output=True, text=True, timeout=90)
             argv = []
             for pid in tm("list-panes", "-s", "-a", "-F", "#{pane_pid}").stdout.split():
                 argv += subprocess.run(["ps", "-o", "args=", "-p", pid],
                                        capture_output=True, text=True).stdout.split()
+            pane_env = _wait_text(td / "home" / "claude.env")
+            hint = subprocess.run(["/bin/bash", str(root / "src" / "schedule-crons-session-hint.sh")],
+                                  env=_parse_env(pane_env), capture_output=True, text=True).stdout
             log = ws / "state" / "session-starts.log"
-            return {"argv": argv,
+            return {"argv": argv, "pane_env": pane_env, "hint": hint,
                     "session_env": tm("show-environment", "-t", "=" + session).stdout,
+                    "global_env": tm("show-environment", "-g").stdout,
                     "session_starts": log.read_text().splitlines() if log.is_file() else []}
         finally:
             tm("kill-server")
     finally:
         shutil.rmtree(td, ignore_errors=True)
+
+
+def _wait_text(path: Path, seconds: float = 5.0) -> str:
+    """The pane's shell writes this right after it starts; poll rather than
+    read a file the launcher's own session poll may have outrun."""
+    import time
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        if path.is_file() and path.read_text():
+            return path.read_text()
+        time.sleep(0.05)
+    return ""
+
+
+def _parse_env(dump: str) -> dict:
+    return dict(line.split("=", 1) for line in dump.splitlines() if "=" in line)
 
 
 class TestCorePolarityUnchanged(unittest.TestCase):
@@ -119,6 +146,32 @@ class TestWorkerWritesNoCoreRows(unittest.TestCase):
     def test_the_worker_does_not_retire_the_cores_launch_boundary(self):
         self.assertEqual(self.got["session_starts"], [],
                          "a worker boot was appended to the core's session log")
+
+
+class TestWorkerOnAServerBornFromACoreLaunch(unittest.TestCase):
+    """A tmux server takes its global env from whoever starts it, and a core
+    launch exports the marker before its first tmux call; every later session
+    on that socket inherits it. The spawner reuses the core's socket, so the
+    worker's own session must override the marker — omitting -e does not."""
+    def setUp(self):
+        wid = "d" * 32
+        self.got = _boot({"SUTANDO_INSTANCE_ID": wid,
+                          "SUTANDO_TMUX_SESSION": "sutando-worker-" + wid,
+                          "SUTANDO_TASKS_DIR": "/tmp/never-read-worker-inbox",
+                          "SUTANDO_CLAUDE_SESSION_ID": "11111111-2222-3333-4444-555555555555"},
+                         server_env={"SUTANDO_CORE_SESSION": "1"})
+
+    def test_control_the_server_carries_the_core_marker(self):
+        self.assertIn("SUTANDO_CORE_SESSION=1", self.got["global_env"])
+
+    def test_the_worker_pane_does_not_inherit_it(self):
+        self.assertIn("SUTANDO_INSTANCE_ID=", self.got["pane_env"], "no pane env was captured")
+        self.assertNotIn("SUTANDO_CORE_SESSION=1", self.got["pane_env"],
+                         "the worker's shell carries the core marker")
+
+    def test_the_session_hint_stays_silent_for_the_worker(self):
+        self.assertEqual(self.got["hint"], "",
+                         "the worker was told to run the canonical core's /startup")
 
 
 if __name__ == "__main__":

--- a/tests/start-cli-worker-bootstrap.test.py
+++ b/tests/start-cli-worker-bootstrap.test.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""A worker boots as an instance; the canonical core's ceremony is untouched.
+
+`/startup` is the CORE's bootstrap: orphan recovery over the shared tasks/,
+session-cron registration, and a watcher gate satisfied by ANY watcher tree on
+the host — the core's own included, which is why a worker running it never
+starts the watcher it exists for. It also stamps the core's session-starts.log,
+which health-check reads as the current core launch.
+
+Both polarities against the real launcher on a private tmux socket and a copied
+repo: unset, every core row and marker is what it was; set, the worker writes
+none of them and boots its own mode.
+
+Run: python3 tests/start-cli-worker-bootstrap.test.py
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+TMUX = shutil.which("tmux", path="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin")
+
+
+def _boot(extra_env: dict) -> dict:
+    """One launcher run against a COPIED repo whose sutando-config.sh names a
+    scratch workspace — the real one must never be a test's write target.
+
+    Returns the pane argv, the session's tmux env, and the workspace rows."""
+    if not TMUX:
+        raise unittest.SkipTest("tmux not found")
+    td = Path(tempfile.mkdtemp())
+    try:
+        root = td / "repo"
+        shutil.copytree(REPO / "src", root / "src", symlinks=True)
+        shutil.copytree(REPO / "scripts", root / "scripts", symlinks=True)
+        ws = td / "ws"
+        (ws / "state").mkdir(parents=True)
+        (root / "scripts" / "sutando-config.sh").write_text(
+            '#!/bin/bash\ncase "$1" in\n'
+            '  workspace) echo "%s";;\n'
+            '  claude-sutando-config-dir) echo "%s/.claude-sutando";;\n'
+            '  python-bin) echo python3;;\n'
+            '  core-runtime) echo claude;;\n'
+            '  host-label) echo testhost;;\n'
+            '  *) echo "";;\nesac\n' % (ws, ws))
+        # A live pid in the relay pidfile, and a pgrep that always "finds" the
+        # monitor: both guards pass, so no launcher child outlives this run.
+        (ws / "state" / "core-supervisor-relay-loop.pid").write_text(str(os.getpid()))
+        bind = td / "bin"
+        bind.mkdir()
+        (td / "home").mkdir()
+        for stub, body in (("claude", "sleep 120\n"), ("pgrep", "exit 0\n"),
+                           ("lsof", "exit 1\n"), ("launchctl", "exit 1\n")):
+            (bind / stub).write_text("#!/bin/bash\n" + body)
+            (bind / stub).chmod(0o755)
+        sock = td / "t.sock"
+        session = extra_env.get("SUTANDO_TMUX_SESSION", "sutando-core")
+        env = {"PATH": f"{bind}:{Path(TMUX).parent}:/usr/bin:/bin:/usr/sbin",
+               "HOME": str(td / "home"), "SUTANDO_TMUX_SOCKET": str(sock),
+               "SUTANDO_TEST_MODE": "1", **extra_env}
+
+        def tm(*a):
+            return subprocess.run([TMUX, "-S", str(sock), *a],
+                                  capture_output=True, text=True)
+        try:
+            subprocess.run(["/bin/bash", str(root / "src" / "agent" / "claude" / "cli" / "start-cli.sh")],
+                           env=env, capture_output=True, text=True, timeout=90)
+            argv = []
+            for pid in tm("list-panes", "-s", "-a", "-F", "#{pane_pid}").stdout.split():
+                argv += subprocess.run(["ps", "-o", "args=", "-p", pid],
+                                       capture_output=True, text=True).stdout.split()
+            log = ws / "state" / "session-starts.log"
+            return {"argv": argv,
+                    "session_env": tm("show-environment", "-t", "=" + session).stdout,
+                    "session_starts": log.read_text().splitlines() if log.is_file() else []}
+        finally:
+            tm("kill-server")
+    finally:
+        shutil.rmtree(td, ignore_errors=True)
+
+
+class TestCorePolarityUnchanged(unittest.TestCase):
+    def setUp(self):
+        self.got = _boot({})
+
+    def test_the_core_still_boots_the_canonical_ceremony(self):
+        self.assertIn("/startup", self.got["argv"])
+        self.assertNotIn("--worker", self.got["argv"])
+
+    def test_the_core_still_carries_its_marker_and_logs_its_launch(self):
+        self.assertIn("SUTANDO_CORE_SESSION=1", self.got["session_env"])
+        self.assertEqual(len(self.got["session_starts"]), 1,
+                         "the core's launch row is what health-check reads")
+
+
+class TestWorkerWritesNoCoreRows(unittest.TestCase):
+    def setUp(self):
+        wid = "c" * 32
+        self.got = _boot({"SUTANDO_INSTANCE_ID": wid,
+                          "SUTANDO_TMUX_SESSION": "sutando-worker-" + wid,
+                          "SUTANDO_TASKS_DIR": "/tmp/never-read-worker-inbox",
+                          "SUTANDO_CLAUDE_SESSION_ID": "11111111-2222-3333-4444-555555555555"})
+
+    def test_the_worker_boots_its_own_mode(self):
+        self.assertIn("--worker", self.got["argv"],
+                      "the worker ran the canonical core's /startup")
+        self.assertIn("/startup", self.got["argv"])
+
+    def test_the_worker_claims_no_core_marker(self):
+        """The marker is what makes a session claim the core's bootstrap; the
+        SessionStart hook gates cron registration on exactly this."""
+        self.assertNotIn("SUTANDO_CORE_SESSION=1", self.got["session_env"])
+
+    def test_the_worker_does_not_retire_the_cores_launch_boundary(self):
+        self.assertEqual(self.got["session_starts"], [],
+                         "a worker boot was appended to the core's session log")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=0)

--- a/tests/worker-mode-is-gated-on-env.test.py
+++ b/tests/worker-mode-is-gated-on-env.test.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""The pool's two edits to existing scripts are invisible to the core.
+
+`start-cli.sh` gains a worker mode and `watch-tasks-stream.sh` gains a
+delivery-folder override; both are gated on env the core never sets. These
+tests pin the gate from both sides: unset, the core's launch and the core's
+watched folder are what they were; set, the worker's are what the pool needs.
+
+Run: python3 tests/worker-mode-is-gated-on-env.test.py
+"""
+from __future__ import annotations
+
+import contextlib
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+
+@contextlib.contextmanager
+def scratch():
+    """A temp dir whose removal tolerates a straggler from the watcher's process
+    group. The kwarg that used to buy that is 3.10+, and CONTRIBUTING.md's
+    supported floor is 3.9."""
+    path = tempfile.mkdtemp()
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path, ignore_errors=True)
+
+REPO = Path(__file__).resolve().parent.parent
+LAUNCHER = REPO / "src" / "agent" / "claude" / "cli" / "start-cli.sh"
+
+
+def _launch_argv(extra_env: dict) -> list[str]:
+    """start-cli.sh through its real tmux path on a private socket; returns the
+    argv of the process it put in the pane. A stub claude that persists is what
+    keeps the session alive long enough to read it."""
+    import shutil
+    tmux = shutil.which("tmux", path="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin")
+    if not tmux:
+        raise unittest.SkipTest("tmux not found")
+    with tempfile.TemporaryDirectory() as td:
+        td = Path(td)
+        bind = td / "bin"; bind.mkdir(); (td / "home").mkdir(); (td / "workspace" / "state").mkdir(parents=True)
+        sock = td / "t.sock"
+        for stub, body in (("claude", "sleep 300\n"), ("pgrep", "exit 0\n")):
+            (bind / stub).write_text("#!/bin/bash\n" + body); (bind / stub).chmod(0o755)
+        tm = lambda *a: subprocess.run([tmux, "-S", str(sock), *a], capture_output=True, text=True)
+        env = {"PATH": f"{bind}:{Path(tmux).parent}:/usr/bin:/bin:/usr/sbin", "HOME": str(td / "home"),
+               "SUTANDO_TMUX_SOCKET": str(sock), "SUTANDO_TEST_MODE": "1",
+               "SUTANDO_WORKSPACE": str(td / "workspace"), **extra_env}
+        try:
+            subprocess.run(["/bin/bash", str(LAUNCHER)], env=env, capture_output=True, text=True, timeout=60)
+            argv = []
+            for pid in tm("list-panes", "-s", "-a", "-F", "#{pane_pid}").stdout.split():
+                argv += subprocess.run(["ps", "-o", "args=", "-p", pid], capture_output=True, text=True).stdout.split()
+            return argv
+        finally:
+            tm("kill-server")
+
+
+class TestLauncherGate(unittest.TestCase):
+    def test_unset_the_core_launch_keeps_its_owner_surfaces(self):
+        argv = _launch_argv({})
+        self.assertTrue(argv, "claude was never exec'd")
+        self.assertIn("--remote-control", argv)
+        self.assertIn("--chrome", argv)
+        self.assertNotIn("--session-id", argv)
+        self.assertIn("sutando-core", argv)
+
+    def test_set_the_worker_launch_drops_them_and_binds_its_session(self):
+        argv = _launch_argv({"SUTANDO_INSTANCE_ID": "a" * 32, "SUTANDO_TMUX_SESSION": "sutando-worker-" + "a" * 32,
+                             "SUTANDO_TASKS_DIR": "/tmp/never-read", "SUTANDO_CLAUDE_SESSION_ID": "11111111-2222-3333-4444-555555555555"})
+        self.assertTrue(argv, "claude was never exec'd")
+        self.assertNotIn("--remote-control", argv)
+        self.assertNotIn("--chrome", argv)
+        self.assertEqual(argv[argv.index("--session-id") + 1], "11111111-2222-3333-4444-555555555555")
+        self.assertEqual(argv[argv.index("--name") + 1], "sutando-worker-" + "a" * 32)
+        self.assertNotIn("sutando-core", argv)
+
+
+def _watched_dir(extra_env: dict, td: Path) -> tuple[bool, bool]:
+    """Run a private copy of the watcher for a moment; report which folder it
+    created: (the workspace's tasks/, the override).
+
+    The watcher is a process GROUP (bash, fswatch, a sleep loop); killing the
+    leader alone leaves children writing into the tree while it is removed."""
+    import signal
+    root = td / "repo"
+    shutil.copytree(REPO / "src", root / "src", symlinks=True)
+    shutil.copytree(REPO / "scripts", root / "scripts", symlinks=True)
+    ws = td / "ws"; ws.mkdir()
+    (root / "scripts" / "sutando-config.sh").write_text('#!/bin/bash\ncase "$1" in workspace) echo "%s";; python-bin) echo python3;; *) echo "";; esac\n' % ws)
+    env = {**os.environ, "SUTANDO_RESULTS_DIR": str(ws / "results"), **extra_env}
+    if "SUTANDO_TASKS_DIR" not in extra_env:
+        env.pop("SUTANDO_TASKS_DIR", None)
+    p = subprocess.Popen(["bash", str(root / "src" / "watch-tasks-stream.sh")], cwd=str(root), env=env,
+                         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True)
+    try:
+        deadline = time.time() + 6
+        while time.time() < deadline and not ((ws / "tasks").is_dir() or (td / "deliveries").is_dir()) and p.poll() is None:
+            time.sleep(0.1)
+        return (ws / "tasks").is_dir(), (td / "deliveries").is_dir()
+    finally:
+        try:
+            os.killpg(p.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        p.wait()
+        time.sleep(0.2)
+
+
+def _state_root(extra_env: dict, td: Path):
+    """Run a private watcher on a delivery folder with a stub handler set, so it
+    creates its claims dir at boot; report where that dir landed."""
+    import signal
+    root = td / "repo"
+    if not root.exists():
+        shutil.copytree(REPO / "src", root / "src", symlinks=True)
+        shutil.copytree(REPO / "scripts", root / "scripts", symlinks=True)
+    ws = td / "ws"; ws.mkdir(exist_ok=True)
+    (root / "scripts" / "sutando-config.sh").write_text('#!/bin/bash\ncase "$1" in workspace) echo "%s";; python-bin) echo python3;; *) echo "";; esac\n' % ws)
+    handler = td / "handler.sh"; handler.write_text("#!/bin/bash\nexit 3\n"); handler.chmod(0o755)
+    inbox = td / "deliveries" / ("b" * 32)
+    env = {**os.environ, "SUTANDO_RESULTS_DIR": str(ws / "results"), "SUTANDO_TASKS_DIR": str(inbox),
+           "SUTANDO_TASK_EVENT_HANDLER": str(handler), **extra_env}
+    env.pop("SUTANDO_WORKSPACE_DIR", None) if "SUTANDO_WORKSPACE_DIR" not in extra_env else None
+    p = subprocess.Popen(["bash", str(root / "src" / "watch-tasks-stream.sh")], cwd=str(root), env=env,
+                         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True)
+    under_ws = ws / "state" / "task-event-handler-claims"
+    under_inbox = td / "deliveries" / "state" / "task-event-handler-claims"
+    try:
+        deadline = time.time() + 6
+        while time.time() < deadline and not (under_ws.is_dir() or under_inbox.is_dir()) and p.poll() is None:
+            time.sleep(0.1)
+        return under_ws.is_dir(), under_inbox.is_dir()
+    finally:
+        try:
+            os.killpg(p.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        p.wait()
+        time.sleep(0.2)
+
+
+class TestWatcherGate(unittest.TestCase):
+    def test_unset_the_core_watches_its_workspace_tasks_folder(self):
+        with scratch() as td:
+            core, override = _watched_dir({}, Path(td))
+        self.assertTrue(core, "the core's tasks/ was not the watched folder")
+        self.assertFalse(override)
+
+    def test_set_a_worker_watches_its_delivery_folder_only(self):
+        with scratch() as td:
+            core, override = _watched_dir({"SUTANDO_TASKS_DIR": str(Path(td) / "deliveries")}, Path(td))
+        self.assertTrue(override, "the delivery folder was not the watched folder")
+        self.assertFalse(core, "the worker must not create or watch the core's tasks/")
+
+
+    def test_an_explicit_workspace_keeps_a_workers_state_out_of_deliveries(self):
+        """The spawner names the workspace; the watcher must not infer it from
+        the delivery folder it watches."""
+        with tempfile.TemporaryDirectory() as td:
+            ws_hit, inbox_hit = _state_root({"SUTANDO_WORKSPACE_DIR": str(Path(td) / "ws")}, Path(td))
+        self.assertTrue(ws_hit, "claims dir was not created under the explicit workspace")
+        self.assertFalse(inbox_hit, "claims dir leaked under deliveries/")
+
+    def test_without_it_the_inbox_parent_is_taken_as_the_workspace(self):
+        """Control: the seam exists — absent the variable, state lands under deliveries/."""
+        with tempfile.TemporaryDirectory() as td:
+            ws_hit, inbox_hit = _state_root({}, Path(td))
+        self.assertTrue(inbox_hit)
+        self.assertFalse(ws_hit)
+
+if __name__ == "__main__":
+    unittest.main(verbosity=0)

--- a/tests/worker-mode-is-gated-on-env.test.py
+++ b/tests/worker-mode-is-gated-on-env.test.py
@@ -190,6 +190,50 @@ def _state_root(extra_env: dict, td: Path):
         time.sleep(0.2)
 
 
+WORKER_KEYS = ("SUTANDO_INSTANCE_ID", "SUTANDO_TASKS_DIR", "SUTANDO_WORKSPACE_DIR",
+               "SUTANDO_INBOX_KIND", "SUTANDO_RESULTS_DIR", "SUTANDO_WORKER_BOOTSTRAP")
+
+
+def _core_env(extra_env: dict, td: Path) -> list[str]:
+    """What the launcher forwards into the core session (its own --print-core-env
+    probe), from a clean environment: no pool variable, no proxy, no repo .env."""
+    root = td / "repo"
+    if not root.exists():
+        shutil.copytree(REPO / "src", root / "src", symlinks=True)
+        shutil.copytree(REPO / "scripts", root / "scripts", symlinks=True)
+    ws = td / "ws"; ws.mkdir(exist_ok=True)
+    (root / "scripts" / "sutando-config.sh").write_text('#!/bin/bash\ncase "$1" in workspace) echo "%s";; python-bin) echo python3;; *) echo "";; esac\n' % ws)
+    stub = td / "bin"; stub.mkdir(exist_ok=True)
+    for name, body in (("lsof", "exit 1\n"), ("launchctl", "exit 0\n"), ("sleep", "exit 0\n")):
+        (stub / name).write_text("#!/bin/sh\n" + body); (stub / name).chmod(0o755)
+    env = {"HOME": str(td), "PATH": f"{stub}:/usr/bin:/bin:/usr/sbin:/sbin", **extra_env}
+    out = subprocess.run(["bash", str(root / "src/agent/claude/cli/start-cli.sh"), "--print-core-env"],
+                         cwd=str(root), env=env, capture_output=True, text=True, timeout=60)
+    assert out.returncode == 0, out.stderr
+    return [tok for tok in out.stdout.split() if "=" in tok]
+
+
+class TestCoreEnvInvariance(unittest.TestCase):
+    """No pool variable set = the core session's env is the pre-pool env: the
+    marker is 1 and no worker key is forwarded. Set = the opposite, so the
+    first test cannot pass by the probe printing nothing."""
+
+    def test_unset_no_worker_key_reaches_the_core_session(self):
+        with scratch() as td:
+            env = _core_env({}, Path(td))
+        self.assertIn("SUTANDO_CORE_RUNTIME=claude", env, env)   # the probe ran
+        self.assertIn("SUTANDO_CORE_SESSION=1", env, env)
+        keys = {tok.split("=", 1)[0] for tok in env}
+        self.assertFalse(keys & set(WORKER_KEYS), f"worker key forwarded to a core: {keys & set(WORKER_KEYS)}")
+
+    def test_set_the_marker_is_blanked_and_the_instance_named(self):
+        with scratch() as td:
+            env = _core_env({"SUTANDO_INSTANCE_ID": "c" * 32}, Path(td))
+        self.assertIn("SUTANDO_CORE_SESSION=", env, env)
+        self.assertNotIn("SUTANDO_CORE_SESSION=1", env, env)
+        self.assertIn("SUTANDO_INSTANCE_ID=" + "c" * 32, env, env)
+
+
 class TestWatcherGate(unittest.TestCase):
     def test_unset_the_core_watches_its_workspace_tasks_folder(self):
         with scratch() as td:

--- a/tests/worker-mode-is-gated-on-env.test.py
+++ b/tests/worker-mode-is-gated-on-env.test.py
@@ -103,6 +103,9 @@ class TestLauncherGate(unittest.TestCase):
         self.assertIn("--chrome", argv)
         self.assertNotIn("--session-id", argv)
         self.assertIn("sutando-core", argv)
+        # ps argv is whitespace-split: the boot prompt is its tail; a core never boots as a worker.
+        self.assertEqual(argv[-1], "/startup")
+        self.assertNotIn("--worker", argv)
 
     def test_set_the_worker_launch_drops_them_and_binds_its_session(self):
         argv = _launch_argv({"SUTANDO_INSTANCE_ID": "a" * 32, "SUTANDO_TMUX_SESSION": "sutando-worker-" + "a" * 32,
@@ -113,6 +116,7 @@ class TestLauncherGate(unittest.TestCase):
         self.assertEqual(argv[argv.index("--session-id") + 1], "11111111-2222-3333-4444-555555555555")
         self.assertEqual(argv[argv.index("--name") + 1], "sutando-worker-" + "a" * 32)
         self.assertNotIn("sutando-core", argv)
+        self.assertEqual(argv[-2:], ["/startup", "--worker"])
 
     def test_control_a_liveness_probe_that_reports_nothing_fails_the_fixture(self):
         """The launcher's poll reads `pgrep -ax claude`; a probe that never names

--- a/tests/worker-mode-is-gated-on-env.test.py
+++ b/tests/worker-mode-is-gated-on-env.test.py
@@ -33,29 +33,60 @@ def scratch():
         shutil.rmtree(path, ignore_errors=True)
 
 REPO = Path(__file__).resolve().parent.parent
-LAUNCHER = REPO / "src" / "agent" / "claude" / "cli" / "start-cli.sh"
+
+# The launcher polls `pgrep -ax claude`, then `ps -o args=` for `--name $SESSION`:
+# the stub reports the launched stub's own pid, and the real ps shows its argv.
+PGREP_STUB = ('[ "$*" = "-ax claude" ] || exit 0\n'
+              '[ -s "$HOME/claude.pid" ] && echo "$(cat "$HOME/claude.pid") claude"\n')
 
 
-def _launch_argv(extra_env: dict) -> list[str]:
-    """start-cli.sh through its real tmux path on a private socket; returns the
+def _launch_argv(extra_env: dict, pgrep_stub: str = PGREP_STUB) -> list[str]:
+    """start-cli.sh through its real tmux path on a private socket, from a COPIED
+    repo whose sutando-config.sh names a scratch workspace: past its liveness
+    poll the launcher clears the shutdown sentinel and ensures the supervisor,
+    and the real workspace must never be a test's write target. Returns the
     argv of the process it put in the pane. A stub claude that persists is what
-    keeps the session alive long enough to read it."""
+    keeps the session alive long enough to read it.
+
+    The pgrep stub answers the liveness probe with nothing until the stub claude
+    has recorded its pid; every other probe (the monitor guard) still "finds"
+    its target, and a live pid in the relay pidfile passes that guard, so no
+    launcher child outlives the run.
+
+    Raises AssertionError unless the launcher's own verdict was success (exit 0):
+    a pane left behind by a failed launch is not the state under test."""
     import shutil
     tmux = shutil.which("tmux", path="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin")
     if not tmux:
         raise unittest.SkipTest("tmux not found")
     with tempfile.TemporaryDirectory() as td:
         td = Path(td)
-        bind = td / "bin"; bind.mkdir(); (td / "home").mkdir(); (td / "workspace" / "state").mkdir(parents=True)
+        root = td / "repo"
+        shutil.copytree(REPO / "src", root / "src", symlinks=True)
+        shutil.copytree(REPO / "scripts", root / "scripts", symlinks=True)
+        ws = td / "workspace"; (ws / "state").mkdir(parents=True)
+        (root / "scripts" / "sutando-config.sh").write_text(
+            '#!/bin/bash\ncase "$1" in\n'
+            '  workspace) echo "%s";;\n'
+            '  claude-sutando-config-dir) echo "%s/.claude-sutando";;\n'
+            '  python-bin) echo python3;;\n'
+            '  core-runtime) echo claude;;\n'
+            '  host-label) echo testhost;;\n'
+            '  *) echo "";;\nesac\n' % (ws, ws))
+        (ws / "state" / "core-supervisor-relay-loop.pid").write_text(str(os.getpid()))
+        bind = td / "bin"; bind.mkdir(); (td / "home").mkdir()
         sock = td / "t.sock"
-        for stub, body in (("claude", "sleep 300\n"), ("pgrep", "exit 0\n")):
+        for stub, body in (("claude", 'echo $$ > "$HOME/claude.pid"\nsleep 300\n'), ("pgrep", pgrep_stub),
+                           ("lsof", "exit 1\n"), ("launchctl", "exit 1\n")):
             (bind / stub).write_text("#!/bin/bash\n" + body); (bind / stub).chmod(0o755)
         tm = lambda *a: subprocess.run([tmux, "-S", str(sock), *a], capture_output=True, text=True)
         env = {"PATH": f"{bind}:{Path(tmux).parent}:/usr/bin:/bin:/usr/sbin", "HOME": str(td / "home"),
-               "SUTANDO_TMUX_SOCKET": str(sock), "SUTANDO_TEST_MODE": "1",
-               "SUTANDO_WORKSPACE": str(td / "workspace"), **extra_env}
+               "SUTANDO_TMUX_SOCKET": str(sock), "SUTANDO_TEST_MODE": "1", **extra_env}
         try:
-            subprocess.run(["/bin/bash", str(LAUNCHER)], env=env, capture_output=True, text=True, timeout=60)
+            run = subprocess.run(["/bin/bash", str(root / "src" / "agent" / "claude" / "cli" / "start-cli.sh")],
+                                 env=env, capture_output=True, text=True, timeout=60)
+            assert run.returncode == 0, (
+                f"launcher exited {run.returncode}\nstdout: {run.stdout}\nstderr: {run.stderr}")
             argv = []
             for pid in tm("list-panes", "-s", "-a", "-F", "#{pane_pid}").stdout.split():
                 argv += subprocess.run(["ps", "-o", "args=", "-p", pid], capture_output=True, text=True).stdout.split()
@@ -82,6 +113,13 @@ class TestLauncherGate(unittest.TestCase):
         self.assertEqual(argv[argv.index("--session-id") + 1], "11111111-2222-3333-4444-555555555555")
         self.assertEqual(argv[argv.index("--name") + 1], "sutando-worker-" + "a" * 32)
         self.assertNotIn("sutando-core", argv)
+
+    def test_control_a_liveness_probe_that_reports_nothing_fails_the_fixture(self):
+        """The launcher's poll reads `pgrep -ax claude`; a probe that never names
+        the launched process is the launcher's own failure verdict (exit 1), and
+        the fixture must surface it rather than assert against the pane it left."""
+        with self.assertRaisesRegex(AssertionError, r"launcher exited 1[\s\S]*did not come up"):
+            _launch_argv({}, pgrep_stub="exit 0\n")
 
 
 def _watched_dir(extra_env: dict, td: Path) -> tuple[bool, bool]:


### PR DESCRIPTION
## Why

Owner ruling (PR triage, 2026-09-12 16:41Z, quoted by sutando-sonichi): *"if change to core is unavoidable, our agreement is to make the changes to core first, test it working without worker pool, and then stop making changes to core."* #4209 bundled 151 added lines across the four launch-chain files, the notifier's tree resolution and a lockstep header key inside a pool PR, so there was no point at which core was proven standalone. This PR is that core slice, on `main`, with nothing from `skills/worker-pool/`. #4209 is force-pushed to the skill-only remainder and rebased on this branch; #4210 gets the same treatment by its author.

## What

- `src/agent/start-cli.sh`, `src/agent/claude/cli/start-cli.sh`: a `WORKER_INSTANCE` branch so the same launcher can run as a pool worker. Unset (every core today) = the existing path, byte-for-byte. `src/agent/codex/cli/start-cli.sh`: the Codex runtime has no worker mode — with `SUTANDO_INSTANCE_ID` set it refuses the launch (exit 2) before the first step of the core's ceremony, and `--runtime codex` through the shared entry inherits that refusal.
- `src/agent/codex/cli/start-cli.sh`: a Codex instance launch is refused before the core ceremony (`SUTANDO_INSTANCE_ID` set → exit 2). That is the whole Codex delta now: the notifier's env-resolved trees and the launcher's forwarding of them (present up to 84ee361c6) were dropped at the owner's instruction, because with Codex workers refused the notifier's inbox is always `<workspace>/tasks` and the derivation had no consumer. Core must not name `skills/worker-pool/` (`tests/core-never-names-the-worker-pool-skill.test.py` pins that).
- `wire_source` as a known header key at the four lockstep sites (`src/local_task_protocol.py`, `packages/ag2-sparrow/.../local_task_protocol.py`, `src/task-bridge.ts`, `skills/phone-conversation/scripts/conversation-server.ts`), key positions identical to #4209 so #4210's `picker_command`/`picker_args` rebase without conflict.
- Tests: `tests/start-cli-worker-bootstrap.test.py`, `tests/worker-mode-is-gated-on-env.test.py` (the two root suites that do not import the skill). One assertion tightened from a substring over the joined argv to an exact-element check — the substring form fails in any checkout whose path contains `sutando-core` (control below).

## Evidence

Split verification — this branch plus the skill remainder reproduces #4209's cumulative diff exactly, except the two lines named above:
```
$ git diff origin/main...origin/feat/worker-pool-consolidated > 4209.diff      # d2bc54eb3
$ git diff origin/main > AC.diff                                              # A (838ed74a1) + C (50de94b11)
$ diff <(grep -vE '^(index|diff --git|---|\+\+\+|@@)' 4209.diff) <(grep -vE '^(index|diff --git|---|\+\+\+|@@)' AC.diff)
1339c1339
< +  "$NOTIFIER_PY" "$REPO/skills/worker-pool/scripts/pool_delivery.py" \
---
> +  "$NOTIFIER_PY" "${SUTANDO_POOL_DELIVERY_SCRIPT:-$REPO/skills/worker-pool/scripts/pool_delivery.py}" \
3753c3753
< +        self.assertNotIn("sutando-core", " ".join(argv))
---
> +        self.assertNotIn("sutando-core", argv)
```
That split was taken at 838ed74a1 + 50de94b11. 180b0f260 has since removed the Codex notifier's deliveries branch that the first hunk (`SUTANDO_POOL_DELIVERY_SCRIPT`) named, so this branch no longer carries that line.

Core works with the pool capability unavailable. Correction (keweichen, 8447df6a4 review): the exact tree is NOT free of `skills/worker-pool/` — it carries the four stage-1 modules inherited from the merge-base (`SKILL.md`, `pool_delivery.py`, `pool_roster.py`, `worker_identity.py`; `git ls-tree -r --name-only HEAD skills/worker-pool`), and the topic diff adds none. What is absent is anything that routes: no `pool_route_handler.py` in the tree and no `SUTANDO_TASK_EVENT_HANDLER` on the watcher. Harness proof:
```
$ python3 tests/worker-mode-is-gated-on-env.test.py      # 6 tests: unset env = core argv unchanged; set = worker argv
OK
$ python3 tests/start-cli-worker-bootstrap.test.py
OK
$ python3 tests/local-task-protocol-attachments.test.py
PASS — local task protocol media-attachment schema
$ bash tests/start-cli-claude-config-dir.test.sh
FAILED: 0
$ python3 tests/codex-core-launcher.test.py
FAIL: test_unassigned_notifier_task_bypasses_slow_history_scan   # identical single failure on the untouched #4209 head at d2bc54eb3 on this host; the suite is green in CI on that head (21/21)
```
Control for the tightened assertion — the untouched #4209 head at a path containing `sutando-core-main`:
```
$ python3 tests/worker-mode-is-gated-on-env.test.py   # at d2bc54eb3, scratchpad/wt-ctl
AssertionError: 'sutando-core' unexpectedly found in '/bin/bash .../bin/claude --name sutando-worker-aaaa…'
FAILED (failures=1)      # the substring is the hook paths under the checkout, not the argv's name
```
Gates: `scripts/review-checks.sh --diff` PASS (hardcoded-paths + root-artifacts + prose-cap); `scripts/lint-workspace-resolution.sh --diff` clean. #4209's union at d2bc54eb3 is 21/21 CI pass, so the remainder is known-green.

## Live path

Done at this head, out of session (owner "Go" 22:40Z): the core restarted onto `8447df6a4` from worktree `sutando-core-4215` via a throwaway tmux server, the watcher armed with no handler env, `state/cores/<host>.alive` fresh from a heartbeat started in that tree (old writer killed first), ceremony rc 0 with 2/2 crons stamped, and one real owner task from a bound room (Mars-the-product-dev) received, answered by the core and delivered through the bridge in 26 s, then archived. Full evidence block with event ids, pids and the `ls-tree` output is in the review thread. Not covered: the bridge process itself (not restarted; not touched by this PR). Unbound-room replies were appended in the thread. The Codex-side change is now only the worker refusal, covered by `tests/codex-core-launcher.test.py`'s two polarity tests (34 tests; the one timing failure, `test_unassigned_notifier_task_bypasses_slow_history_scan` at 1.36 s vs a 1.0 s bar, is identical at the merge-base on this host).

Stacked: this is the parent. Merge order: this → #4209 (skill remainder) → #4210's core slice → #4210. After this lands, #4209 is rebased onto `main` and its checks rerun.

Sutando core (qingyun-001)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



