### PR TITLE
feat(gateway): push the pool advertisement to the broker; picker keys in the lockstep constant (core slice of #4210)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,7 @@ jobs:
           timeout -k 5 120 python3 packages/ag2-sparrow/tests/test_ack_retry.py
           timeout -k 5 120 python3 packages/ag2-sparrow/tests/test_inflight_recovery.py
           timeout -k 5 120 python3 packages/ag2-sparrow/tests/test_write_task_atomic.py
+          timeout -k 5 120 python3 packages/ag2-sparrow/tests/test_pool_advertisement_push.py
           timeout -k 5 120 python3 packages/ag2-sparrow/tests/test_event_inbox_channel.py
           timeout -k 5 120 python3 packages/ag2-sparrow/tests/test_event_consumer.py
           timeout -k 5 120 python3 packages/ag2-sparrow/tests/test_event_wiring.py

--- a/docs/remote-gateway-protocol.md
+++ b/docs/remote-gateway-protocol.md
@@ -67,6 +67,16 @@ A task object **must** carry a unique `"id"`. Recognized string fields
 and written into the local task file the core consumes. For AG2 Space, the
 broker also supplies its room-policy `access_tier` attestation.
 
+A worker-picker button may be sent as `"picker_command"` (`add` | `pin` |
+`unpin`) plus optional `"picker_args"` — a JSON object, either inline or
+already serialized as a string; the bridge writes it as JSON either way. Both
+are written as trusted pre-body headers, because `worker_picker_commands.py`
+reads them with the parser that stops at `task:`. A command the reader cannot
+honour — an unknown verb, args that are not an object, or arguments that do not
+fit the verb — is refused by name rather than resolved from the sentence, and
+the room always comes from `channel_id`, never from `picker_args`. A broker
+that sends no `picker_command` keeps the prose fallback.
+
 An AG2 Space broker may additionally send `"session_scope": "room"`. The
 bridge writes only that exact value as a trusted pre-body header; missing,
 unknown, or malformed values are omitted, preserving the main-session path for

--- a/packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py
+++ b/packages/ag2-sparrow/ag2_sparrow/local_task_protocol.py
@@ -148,7 +148,7 @@ def canonical_access_tier(value) -> str:
 #   can survive undefanged in user-supplied content.
 # Adding a producer header = add it here; the guard follows automatically.
 KNOWN_HEADER_KEYS = (
-    "id", "timestamp", "session_scope", "task", "source", "wire_source", "access_tier", "user_id",
+    "id", "timestamp", "session_scope", "task", "source", "wire_source", "picker_command", "picker_args", "access_tier", "user_id",
     "channel_id", "priority", "interaction_type", "source_message_id",
     "channel_name", "guild_name", "attempts", "sender_name", "room_name",
     "parent_message_id", "reply_chain_ids", "reminder", "author_name",

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -54,6 +54,7 @@ import base64
 import hashlib
 import json
 import os
+import stat
 import uuid
 import re
 import shlex
@@ -2463,15 +2464,28 @@ def _read_pool_advertisement() -> "tuple[str, dict | None]":
     BEFORE the /v1/tasks poll and may never raise: the outer handler backs off
     and retries the same file, so any exception here — a RecursionError from a
     deeply nested value, not only OSError/ValueError — would stall intake for
-    as long as that file stays. The size is bounded before the parse so a
-    runaway file cannot cost the loop a full read per pass either."""
+    as long as that file stays. The path is opened ONCE, non-blocking, and
+    everything is decided on that descriptor: a FIFO with no writer would park
+    a blocking open forever, and a size read from a second lookup can be
+    stale by the time the content is read, so the bound is enforced on the
+    bytes actually read (MAX+1: one more than allowed proves the overflow)."""
+    fd = -1
     try:
-        if _POOL_ADVERTISEMENT_FILE.stat().st_size > _POOL_ADVERTISEMENT_MAX_BYTES:
+        fd = os.open(str(_POOL_ADVERTISEMENT_FILE), os.O_RDONLY | os.O_NONBLOCK)
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
             return ("", None)
-        rec = json.loads(_POOL_ADVERTISEMENT_FILE.read_text())
+        with os.fdopen(fd, "rb") as fh:
+            fd = -1
+            data = fh.read(_POOL_ADVERTISEMENT_MAX_BYTES + 1)
+        if len(data) > _POOL_ADVERTISEMENT_MAX_BYTES:
+            return ("", None)
+        rec = json.loads(data.decode("utf-8"))
         canonical = json.dumps(rec, sort_keys=True, separators=(",", ":"))
     except Exception:  # noqa: BLE001 — a parser/resource failure is UNAVAILABLE, never a stalled poll
         return ("", None)
+    finally:
+        if fd >= 0:
+            os.close(fd)
     if not isinstance(rec, dict):
         return ("", None)
     if not isinstance(rec.get("workers"), dict):

--- a/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
+++ b/packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py
@@ -51,6 +51,7 @@ from __future__ import annotations
 
 import atexit
 import base64
+import hashlib
 import json
 import os
 import uuid
@@ -1723,7 +1724,13 @@ _TASK_FIELDS = ("id", "timestamp", "session_scope",
                 # A card click already recorded in the HITL store, passed on for the turn it
                 # causes: the core answers [no-send] and lets its Stop hook do the work.
                 "hitl_click",
-                "task", "source", "channel_id",
+                # Which worker-picker button was pressed. Above "task" for the same
+                # reason: worker_picker_commands reads it with the safe parser.
+                "picker_command", "picker_args",
+                # Also above "task": these carry the picker's authorization, and a
+                # task-last reader cannot see a field written below the body.
+                "source", "channel_id",
+                "task",
                 # Context enrichment (AG2 broker writer side): human room/sender
                 # names + reply reference. Serialized only when the gateway sends
                 "room_name", "sender_name", "reply_to_event", "reply_to_me", "reply_to_sender",
@@ -2422,6 +2429,192 @@ def _read_core_status() -> tuple[str | None, str | None]:
         return (None, None)
 
 
+_POOL_ADVERTISEMENT_FILE = _STATE / "pool-advertisement.json"
+# A roster row is ~100 bytes, so this is >10k workers; past it the loop would
+# re-read and re-parse a runaway file every pass before it can poll for tasks.
+_POOL_ADVERTISEMENT_MAX_BYTES = 1 << 20
+_workers_pushed_identity = ""
+_workers_push_retry_at = 0.0
+_advertisement_unavailable_logged = False
+
+# 404/405/501 are the broker saying "this endpoint does not exist here"; every
+# other status is a live endpoint failing, which a short retry can clear.
+_UNSUPPORTED_ENDPOINT_STATUS = frozenset({404, 405, 501})
+
+
+def _read_pool_advertisement() -> "tuple[str, dict | None]":
+    """The pool's roster-derived advertisement -> (identity, record), or
+    ("", None) when the record is UNAVAILABLE — absent, unreadable, mid-write,
+    malformed, or carrying only one of its two halves.
+
+    The identity is a digest of the record's canonical content and is the ONE
+    change signal both publications key on. mtime is not: a restore that lands
+    below the prior file's mtime is new content the picker must see, and the
+    two halves keyed on different signals disagreed on exactly that record.
+
+    Availability is a tri-state, and None is the only "cannot read it" value: a
+    record whose maps are empty is AVAILABLE and means "the pool is empty", an
+    intentional clear the callers must push. Collapsing the two (the pre-fix
+    (0.0, {})) is what let a deleted or half-written file PUT a profile card
+    with no `workers`, and the broker REPLACES that document.
+
+    Both halves are validated from this one read so a one-sided record cannot
+    POST a status map whose labels never ship. This runs in the task loop
+    BEFORE the /v1/tasks poll and may never raise: the outer handler backs off
+    and retries the same file, so any exception here — a RecursionError from a
+    deeply nested value, not only OSError/ValueError — would stall intake for
+    as long as that file stays. The size is bounded before the parse so a
+    runaway file cannot cost the loop a full read per pass either."""
+    try:
+        if _POOL_ADVERTISEMENT_FILE.stat().st_size > _POOL_ADVERTISEMENT_MAX_BYTES:
+            return ("", None)
+        rec = json.loads(_POOL_ADVERTISEMENT_FILE.read_text())
+        canonical = json.dumps(rec, sort_keys=True, separators=(",", ":"))
+    except Exception:  # noqa: BLE001 — a parser/resource failure is UNAVAILABLE, never a stalled poll
+        return ("", None)
+    if not isinstance(rec, dict):
+        return ("", None)
+    if not isinstance(rec.get("workers"), dict):
+        return ("", None)
+    if not isinstance(rec.get("profile_workers"), dict):
+        return ("", None)
+    return (hashlib.sha256(canonical.encode()).hexdigest(), rec)
+
+
+def _advertisement_or_none() -> "tuple[str, dict | None]":
+    """_read_pool_advertisement, logging the availability edge once per edge so
+    an absent producer cannot fill the log at the loop's cadence."""
+    global _advertisement_unavailable_logged
+    identity, rec = _read_pool_advertisement()
+    if rec is None:
+        if not _advertisement_unavailable_logged:
+            _advertisement_unavailable_logged = True
+            _log(f"pool advertisement unavailable ({_POOL_ADVERTISEMENT_FILE.name}"
+                 " missing or unreadable) — keeping the last pushed pool state")
+    elif _advertisement_unavailable_logged:
+        _advertisement_unavailable_logged = False
+        _log("pool advertisement readable again")
+    return (identity, rec)
+
+
+def _defer_push(what: str, e: "urllib.error.HTTPError", now: float) -> float:
+    """The retry taxonomy both pushes share -> the absolute retry-at."""
+    if e.code in _UNSUPPORTED_ENDPOINT_STATUS:
+        _log(f"{what} deferred 1h: broker has no such endpoint (HTTP {e.code})")
+        return now + 3600
+    _log(f"{what} failed, retrying in 5m: endpoint exists, HTTP {e.code}")
+    return now + 300
+
+
+# The broker's copy is a replica: a broker restart empties it, and nothing on
+# our side changes, so resend both halves on a cadence even when unchanged.
+_REPUSH_EVERY_S = 600.0
+_last_full_push_at = 0.0
+_now = time.monotonic
+
+
+def _push_pool_advertisement() -> None:
+    """One read of the advertisement per beat, handed to BOTH publications:
+    two reads let a sibling writer's atomic rename land between them, and the
+    broker would then hold a snapshot and a card from different revisions."""
+    global _workers_pushed_identity, _profile_pushed_identity, _last_full_push_at
+    if _now() - _last_full_push_at >= _REPUSH_EVERY_S:
+        _workers_pushed_identity = ""
+        _profile_pushed_identity = ""
+        _last_full_push_at = _now()
+    record = _advertisement_or_none()
+    _maybe_push_workers_snapshot(record)
+    _maybe_push_agent_profile(record)
+
+
+def _maybe_push_workers_snapshot(record) -> bool:
+    """Push-on-change relay of the pool's workers snapshot (the worker
+    picker's read path). An unavailable advertisement pushes NOTHING and
+    leaves the broker holding the last snapshot we sent; an unsupported
+    endpoint backs the push off an hour and any other HTTP status 5m;
+    nothing here may ever break the task loop."""
+    global _workers_pushed_identity, _workers_push_retry_at
+    now = time.time()
+    if now < _workers_push_retry_at:
+        return False
+    identity, ad = record  # one read per beat, shared with the other publication
+    if ad is None:
+        return False
+    if identity == _workers_pushed_identity:
+        return False
+    try:
+        _req("POST", "/v1/workers", ad["workers"], timeout=15)
+    except urllib.error.HTTPError as e:
+        _workers_push_retry_at = _defer_push("workers-snapshot push", e, now)
+        return False
+    except Exception as e:  # noqa: BLE001 — relay must never kill the loop
+        _workers_push_retry_at = now + 300
+        _log(f"workers-snapshot push failed, retrying in 5m: {e}")
+        return False
+    _workers_pushed_identity = identity
+    _log("workers-snapshot pushed")
+    return True
+
+
+_profile_pushed_identity = ""
+_profile_push_retry_at = 0.0
+
+
+def _build_agent_profile(workers: "dict") -> "dict":
+    """The instance's identity card for PUT /v1/agents/{mxid}/profile.
+    Only instance-authoritative fields — appearance is user/platform-owned
+    and the broker drops it from instance PUTs anyway.
+
+    `workers` comes from an advertisement the caller already established is
+    AVAILABLE: the broker REPLACES the profile document, so this function must
+    never be reached with a map it could not read."""
+    name = (os.environ.get("SUTANDO_DISPLAY_NAME") or "Sutando").strip()
+    try:
+        host_id = socket.gethostname().split(".")[0]
+    except OSError:
+        host_id = "unknown-host"
+    return {"display": {"name": name},
+            "host": {"host_id": host_id, "kind": "local"},
+            "workers": workers}
+
+
+def _maybe_push_agent_profile(record) -> bool:
+    """Push-on-change relay of the agent's profile card. An unavailable
+    advertisement pushes NOTHING: the card carries the `workers` map the
+    picker draws and the broker REPLACES the document, so a card built from
+    a record we could not read would erase the pool. Same retry taxonomy as
+    the workers-snapshot push; nothing here may break the task loop."""
+    global _profile_pushed_identity, _profile_push_retry_at
+    now = time.time()
+    if now < _profile_push_retry_at:
+        return False
+    mxid = _reenroll_identity()
+    if not mxid:
+        return False  # identity may appear mid-episode; recheck next loop
+    identity, ad = record  # one read per beat, shared with the other publication
+    if ad is None:
+        return False
+    # The same record identity the workers push keys on, so the two halves
+    # can never disagree on whether a record is new; mxid may change mid-run.
+    key = f"{mxid}\n{identity}"
+    if key == _profile_pushed_identity:
+        return False
+    card = _build_agent_profile(ad["profile_workers"])
+    try:
+        _req("PUT", f"/v1/agents/{urllib.parse.quote(mxid, safe='')}/profile",
+             card, timeout=15)
+    except urllib.error.HTTPError as e:
+        _profile_push_retry_at = _defer_push("agent-profile push", e, now)
+        return False
+    except Exception as e:  # noqa: BLE001 — relay must never kill the loop
+        _profile_push_retry_at = now + 300
+        _log(f"agent-profile push failed, retrying in 5m: {e}")
+        return False
+    _profile_pushed_identity = key
+    _log(f"agent-profile pushed for {mxid}")
+    return True
+
+
 def _post_heartbeat(inflight: set[str], force: bool = False) -> bool:
     """Best-effort liveness + core-status ping. Liveness feeds hosted dashboards;
     the status/step feed the broker's presence sweep (agent working/available/…)."""
@@ -2923,6 +3116,14 @@ def _write_task(task: dict) -> "tuple[str, bool] | None":
                 _mh = local_task_protocol.media_attachment_headers(_media_refs, bool(_txt.strip()))
                 if _mh:
                     lines.extend(_mh.rstrip("\n").split("\n"))
+        elif f == "picker_args":
+            # The reader parses this with json.loads, so an object must be
+            # re-serialized as JSON — _one_line would emit a Python repr.
+            pa = task.get(f)
+            if isinstance(pa, (dict, list)):
+                lines.append(f"picker_args: {json.dumps(pa, separators=(',', ':'))}")
+            elif pa not in (None, ""):
+                lines.append(f"picker_args: {_one_line(pa)}")
         elif f == "platform_card":
             # Signed platform-metadata pointer: re-serialize only the expected
             # subkeys as one compact JSON line (dict repr or extra keys never
@@ -2930,6 +3131,11 @@ def _write_task(task: dict) -> "tuple[str, bool] | None":
             if isinstance(pc, dict) and all(k in pc for k in _PLATFORM_CARD_KEYS):
                 card = {k: str(pc[k]) for k in _PLATFORM_CARD_KEYS}
                 lines.append(f"platform_card: {json.dumps(card, separators=(',', ':'))}")
+        elif f == "picker_command":
+            # Stamped is stamped: an EMPTY command must reach the parser as a
+            # refused stamp, not vanish and let the prose decide the intent.
+            if f in task and task[f] is not None:
+                lines.append(f"picker_command: {_one_line(task[f])}")
         elif f in task and task[f] not in (None, ""):
             lines.append(f"{f}: {_one_line(task[f])}")
             # After id: so the canonical id-first / HMAC-stamp prefix stays line 0.
@@ -4253,6 +4459,9 @@ def main() -> None:
                     _results_watcher.join(timeout=5)
                 return
             _post_heartbeat(inflight)
+            # The pool's advertisement rides the same beat: push-on-change, never
+            # raising, so a broker without the endpoints costs one deferred log.
+            _push_pool_advertisement()
             _retry_pending_publications()
             _retry_review_card_resolutions()
             _retry_review_control_results()
@@ -4302,6 +4511,9 @@ def main() -> None:
             abandoned_suspects = _reconcile_abandoned(inflight, abandoned_suspects)
             _reconcile_orphan_results(inflight)
             _post_heartbeat(inflight)
+            # The pool's advertisement rides the same beat: push-on-change, never
+            # raising, so a broker without the endpoints costs one deferred log.
+            _push_pool_advertisement()
             backoff = 1  # healthy round-trip → reset backoff
             _emit_gateway_status(True)
         except urllib.error.HTTPError as e:

--- a/packages/ag2-sparrow/tests/test_pool_advertisement_push.py
+++ b/packages/ag2-sparrow/tests/test_pool_advertisement_push.py
@@ -1,0 +1,539 @@
+"""The pool advertisement is what the broker draws the worker picker from.
+
+Both halves ship from one file: POST /v1/workers gives each row its STATUS,
+the profile card's `workers` map gives it a LABEL. The broker REPLACES the
+profile document, so a card sent without `workers` wipes the pool it was
+showing — which makes AVAILABILITY, not content, the load-bearing property
+these tests pin. The file is read-if-present and its producer ships separately
+(#4119): absent, unreadable, half-written and one-sided records are all
+UNAVAILABLE and must push NOTHING, while a valid record whose maps are empty
+is an intentional clear and must push.
+
+Run: python3 packages/ag2-sparrow/tests/test_pool_advertisement_push.py
+"""
+import importlib
+import json
+from pathlib import Path
+import os
+import pathlib
+import sys
+import tempfile
+import time
+import urllib.error
+
+MXID = "@sutando-test:ag2.space"
+W1 = "a3f91c2d4e5b6a7c8d9e0f1a2b3c4d5e"
+
+
+def _load(base):
+    os.environ["AGENT_CONNECT_TASK_DIR"] = str(base / "tasks")
+    os.environ["AGENT_CONNECT_RESULT_DIR"] = str(base / "results")
+    os.environ["AGENT_CONNECT_STATE_DIR"] = str(base / "state")
+    os.environ["AGENT_MXID"] = MXID
+    os.environ.pop("SUTANDO_DISPLAY_NAME", None)
+    os.environ.setdefault("REMOTE_TASK_URL", "https://gw.example/relay")
+    os.environ.setdefault("REMOTE_TASK_TOKEN", "dummy-secret")
+    sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+    mod = importlib.import_module("ag2_sparrow.remote_gateway_bridge")
+    m = importlib.reload(mod)
+    # hermetic: the channel .env fallback must not leak this host's identity
+    m._config_from_channel_env = lambda *a, **k: ""
+    return m
+
+
+def _advertise(m, record, age=0.0):
+    return _write_raw(m, json.dumps(record), age)
+
+
+def _write_raw(m, text, age=0.0):
+    p = m._POOL_ADVERTISEMENT_FILE
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text)
+    if age:
+        os.utime(p, (time.time() + age, time.time() + age))
+    return p
+
+
+def _record(ts=1):
+    return {"ts": ts,
+            "workers": {"ts": ts, "live_cores": [W1], "dead_cores": []},
+            "profile_workers": {W1: {"label": "reviewer", "runtime": "codex"}}}
+
+
+def _capture(m):
+    calls = []
+    m._req = lambda *a, **k: calls.append(a) or {}
+    return calls
+
+
+def _raiser(code):
+    def boom(*a, **k):
+        raise urllib.error.HTTPError("https://gw.example/x", code, "e", {}, None)
+    return boom
+
+
+def test_boot_pushes_workers_and_a_card_carrying_them():
+    """A fresh process has pushed nothing, so a file that predates it is new."""
+    with tempfile.TemporaryDirectory() as d:
+        base = pathlib.Path(d)
+        os.environ["AGENT_CONNECT_STATE_DIR"] = str(base / "state")
+        (base / "state").mkdir(parents=True, exist_ok=True)
+        (base / "state" / "pool-advertisement.json").write_text(
+            json.dumps(_record()))
+        m = _load(base)
+        calls = _capture(m)
+
+        assert m._maybe_push_workers_snapshot(m._advertisement_or_none()) is True
+        assert m._maybe_push_agent_profile(m._advertisement_or_none()) is True
+        assert calls[0][0] == "POST" and calls[0][1] == "/v1/workers"
+        assert calls[0][2] == _record()["workers"], "the body ships verbatim"
+        assert calls[1][0] == "PUT" and "/profile" in calls[1][1]
+        assert calls[1][2]["workers"] == _record()["profile_workers"]
+        assert calls[1][2]["display"]["name"] == "Sutando", "card keeps identity"
+        print("PASS test_boot_pushes_workers_and_a_card_carrying_them")
+
+
+def test_a_missing_file_pushes_nothing_at_all():
+    """Read-if-present: with no producer installed the bridge is a no-op, and
+    in particular does not PUT a card whose absent `workers` clears the pool."""
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        calls = _capture(m)
+
+        assert m._maybe_push_workers_snapshot(m._advertisement_or_none()) is False
+        assert m._maybe_push_agent_profile(m._advertisement_or_none()) is False
+        assert calls == [], "no advertisement = no request of either kind"
+        print("PASS test_a_missing_file_pushes_nothing_at_all")
+
+
+def test_malformed_json_pushes_nothing_and_keeps_the_prior_snapshot():
+    """valid -> mid-write truncation -> restored. The corrupt read must not
+    push, must not advance the push key, and must not disturb what the broker
+    is already holding; the restored read pushes the real map again."""
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        calls = _capture(m)
+        _advertise(m, _record(1))
+        assert m._maybe_push_workers_snapshot(m._advertisement_or_none()) is True
+        assert m._maybe_push_agent_profile(m._advertisement_or_none()) is True
+        good_key, good_id = m._profile_pushed_identity, m._workers_pushed_identity
+
+        _write_raw(m, '{"workers": {"ts": 2}, "profile_wor', age=5)
+        assert m._maybe_push_workers_snapshot(m._advertisement_or_none()) is False
+        assert m._maybe_push_agent_profile(m._advertisement_or_none()) is False
+        assert len(calls) == 2, "a corrupt read issues no request"
+        assert m._profile_pushed_identity == good_key, "prior card is still the live one"
+        assert m._workers_pushed_identity == good_id, "prior snapshot is still live"
+
+        _advertise(m, _record(3), age=10)
+        assert m._maybe_push_workers_snapshot(m._advertisement_or_none()) is True
+        assert m._maybe_push_agent_profile(m._advertisement_or_none()) is True
+        assert calls[3][2]["workers"] == _record(3)["profile_workers"]
+        print("PASS test_malformed_json_pushes_nothing_and_keeps_the_prior_snapshot")
+
+
+def test_a_deleted_file_after_a_good_push_changes_nothing():
+    """valid -> missing. The pre-fix key (mxid + mtime 0.0 + a workers-less
+    card) was GUARANTEED to differ from the last one, so the push-on-change
+    guard fired exactly on the transition that erased the map."""
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        calls = _capture(m)
+        _advertise(m, _record(1))
+        assert m._maybe_push_agent_profile(m._advertisement_or_none()) is True
+        assert "workers" in calls[0][2]
+
+        m._POOL_ADVERTISEMENT_FILE.unlink()
+        assert m._maybe_push_agent_profile(m._advertisement_or_none()) is False
+        assert m._maybe_push_workers_snapshot(m._advertisement_or_none()) is False
+        assert len(calls) == 1, "the deletion is not a profile replacement"
+        print("PASS test_a_deleted_file_after_a_good_push_changes_nothing")
+
+
+def test_a_one_sided_record_pushes_neither_half():
+    """A status map with no label map would POST rows the card never names."""
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        calls = _capture(m)
+        _advertise(m, {"ts": 4, "workers": {"ts": 4, "live_cores": [W1]}})
+        assert m._maybe_push_workers_snapshot(m._advertisement_or_none()) is False
+        assert m._maybe_push_agent_profile(m._advertisement_or_none()) is False
+
+        _advertise(m, {"ts": 5, "profile_workers": {W1: {"label": "x"}}}, age=5)
+        assert m._maybe_push_workers_snapshot(m._advertisement_or_none()) is False
+        assert m._maybe_push_agent_profile(m._advertisement_or_none()) is False
+        assert calls == [], "one-sided is unavailable, not half-available"
+        print("PASS test_a_one_sided_record_pushes_neither_half")
+
+
+def test_a_valid_empty_map_is_an_intentional_clear_and_ships():
+    """The other side of the tri-state: "the pool is empty" is a fact the
+    picker must be told, and is not the same as "cannot read the pool"."""
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        calls = _capture(m)
+        _advertise(m, {"ts": 6, "workers": {"ts": 6, "live_cores": []},
+                       "profile_workers": {}})
+        assert m._maybe_push_workers_snapshot(m._advertisement_or_none()) is True
+        assert m._maybe_push_agent_profile(m._advertisement_or_none()) is True
+        assert calls[1][2]["workers"] == {}, "the empty map ships, explicitly"
+        print("PASS test_a_valid_empty_map_is_an_intentional_clear_and_ships")
+
+
+def test_a_file_without_the_keys_pushes_nothing_extra():
+    """A half-written or foreign record must not blank the picker."""
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        calls = _capture(m)
+        _advertise(m, {"ts": 7})
+
+        assert m._maybe_push_workers_snapshot(m._advertisement_or_none()) is False
+        assert m._maybe_push_agent_profile(m._advertisement_or_none()) is False
+        assert calls == []
+        print("PASS test_a_file_without_the_keys_pushes_nothing_extra")
+
+
+def test_a_non_dict_workers_value_is_ignored():
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        calls = _capture(m)
+        _advertise(m, {"ts": 7, "workers": ["core-1"], "profile_workers": []})
+
+        assert m._maybe_push_workers_snapshot(m._advertisement_or_none()) is False
+        assert m._maybe_push_agent_profile(m._advertisement_or_none()) is False
+        assert calls == []
+        print("PASS test_a_non_dict_workers_value_is_ignored")
+
+
+class _ReadRaises:
+    """A stand-in for the advertisement path whose read fails the way a
+    parser does: the exception the loop must survive is not an OSError."""
+    name = "pool-advertisement.json"
+
+    def __init__(self, exc):
+        self._exc = exc
+
+    def stat(self):
+        return os.stat_result((0o100644, 0, 0, 1, 0, 0, 64, 0, 0, 0))
+
+    def read_text(self):
+        raise self._exc
+
+
+def test_a_parser_failure_of_any_kind_is_unavailable_not_a_stalled_poll():
+    """The reviewer's input: a record carrying both maps plus an unknown
+    1,000-deep array. Older json decoders raise RecursionError on it, and the
+    read runs in the loop BEFORE the task poll, where an escaping exception
+    backs off and retries the same file forever. Whether or not this
+    interpreter's decoder is the recursive one, the read must not raise and
+    the unknown key must change nothing; the injected RecursionError then pins
+    the UNAVAILABLE path on every interpreter."""
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        calls = _capture(m)
+        rec = _record(1)
+        deep = json.dumps(rec)[:-1] + ', "junk": ' + "[" * 1000 + "]" * 1000 + "}"
+        _write_raw(m, deep)
+        _, ad = m._read_pool_advertisement()  # must not raise
+        pushed = m._maybe_push_workers_snapshot(m._advertisement_or_none())
+        assert m._maybe_push_agent_profile(m._advertisement_or_none()) is pushed
+        if ad is None:
+            assert calls == [], "UNAVAILABLE pushes nothing"
+        else:
+            assert calls[0][2] == rec["workers"], "the unknown key ships nothing"
+        n = len(calls)
+
+        real_path = m._POOL_ADVERTISEMENT_FILE
+        m._POOL_ADVERTISEMENT_FILE = _ReadRaises(RecursionError("maximum recursion depth exceeded"))
+        assert m._read_pool_advertisement() == ("", None), "the UNAVAILABLE sentinel"
+        assert m._maybe_push_workers_snapshot(m._advertisement_or_none()) is False
+        assert m._maybe_push_agent_profile(m._advertisement_or_none()) is False
+        assert len(calls) == n, "a parser failure issues no request"
+
+        m._POOL_ADVERTISEMENT_FILE = real_path
+        rec = _record(2)
+        rec["profile_workers"][W1]["label"] = "after"
+        _advertise(m, rec, age=5)
+        assert m._maybe_push_workers_snapshot(m._advertisement_or_none()) is True, "positive control"
+        assert m._maybe_push_agent_profile(m._advertisement_or_none()) is True
+        assert calls[-1][2]["workers"][W1]["label"] == "after"
+        print("PASS test_a_parser_failure_of_any_kind_is_unavailable_not_a_stalled_poll")
+
+
+def test_an_oversized_record_is_unavailable_before_it_is_parsed():
+    """The record is bounded by size before the parse: a runaway file is
+    UNAVAILABLE at the stat, not a full read-and-decode on every loop pass."""
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        calls = _capture(m)
+        rec = _record(1)
+        rec["pad"] = "x" * m._POOL_ADVERTISEMENT_MAX_BYTES
+        _advertise(m, rec)
+        assert m._read_pool_advertisement() == ("", None)
+        assert m._maybe_push_workers_snapshot(m._advertisement_or_none()) is False
+        assert m._maybe_push_agent_profile(m._advertisement_or_none()) is False
+        assert calls == [], "an oversized record pushes nothing"
+
+        _advertise(m, _record(2), age=5)
+        assert m._maybe_push_workers_snapshot(m._advertisement_or_none()) is True, "positive control"
+        assert m._maybe_push_agent_profile(m._advertisement_or_none()) is True
+        print("PASS test_an_oversized_record_is_unavailable_before_it_is_parsed")
+
+
+def test_a_later_mtime_repushes_both():
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        calls = _capture(m)
+        _advertise(m, _record(1))
+        assert m._maybe_push_workers_snapshot(m._advertisement_or_none()) is True
+        assert m._maybe_push_agent_profile(m._advertisement_or_none()) is True
+        assert m._maybe_push_workers_snapshot(m._advertisement_or_none()) is False, "unchanged: no re-post"
+        assert m._maybe_push_agent_profile(m._advertisement_or_none()) is False, "unchanged: no re-put"
+        assert len(calls) == 2
+
+        rec = _record(2)
+        rec["profile_workers"][W1]["label"] = "shipper"
+        _advertise(m, rec, age=5)
+        assert m._maybe_push_workers_snapshot(m._advertisement_or_none()) is True
+        assert m._maybe_push_agent_profile(m._advertisement_or_none()) is True
+        assert calls[2][2] == rec["workers"]
+        assert calls[3][2]["workers"][W1]["label"] == "shipper"
+        print("PASS test_a_later_mtime_repushes_both")
+
+
+def test_a_bumped_mtime_with_unchanged_content_repushes_neither():
+    """Content, not mtime, is the change identity — for BOTH halves."""
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        calls = _capture(m)
+        _advertise(m, _record(1))
+        assert m._maybe_push_workers_snapshot(m._advertisement_or_none()) is True
+        assert m._maybe_push_agent_profile(m._advertisement_or_none()) is True
+        _advertise(m, _record(1), age=5)
+        assert m._maybe_push_workers_snapshot(m._advertisement_or_none()) is False, "same content: no re-post"
+        assert m._maybe_push_agent_profile(m._advertisement_or_none()) is False, "same content: no re-put"
+        assert len(calls) == 2
+        print("PASS test_a_bumped_mtime_with_unchanged_content_repushes_neither")
+
+
+def test_a_restore_at_or_below_the_prior_mtime_repushes_both():
+    """valid -> missing -> restored with a LOWER, then an EQUAL, mtime. Keyed
+    on mtime as a high-water mark the workers POST skipped the restore while
+    the profile (keyed on content) advanced, so /v1/workers sat on revision 1
+    under a card already labelling revision 2 until a later mtime arrived."""
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        calls = _capture(m)
+        _advertise(m, _record(1))
+        first_mtime = m._POOL_ADVERTISEMENT_FILE.stat().st_mtime
+        assert m._maybe_push_workers_snapshot(m._advertisement_or_none()) is True
+        assert m._maybe_push_agent_profile(m._advertisement_or_none()) is True
+
+        m._POOL_ADVERTISEMENT_FILE.unlink()
+        assert m._maybe_push_workers_snapshot(m._advertisement_or_none()) is False
+        assert m._maybe_push_agent_profile(m._advertisement_or_none()) is False
+
+        rec = _record(2)
+        rec["profile_workers"][W1]["label"] = "restored"
+        _advertise(m, rec, age=-10)
+        assert m._POOL_ADVERTISEMENT_FILE.stat().st_mtime < first_mtime
+        assert m._maybe_push_workers_snapshot(m._advertisement_or_none()) is True, "lower mtime, new content"
+        assert m._maybe_push_agent_profile(m._advertisement_or_none()) is True
+        assert [c[2]["ts"] for c in calls if c[0] == "POST"] == [1, 2]
+        assert [c[2]["workers"][W1]["label"] for c in calls if c[0] == "PUT"] == [
+            "reviewer", "restored"]
+
+        rec = _record(3)
+        rec["profile_workers"][W1]["label"] = "again"
+        p = _advertise(m, rec)
+        os.utime(p, (first_mtime, first_mtime))
+        assert m._maybe_push_workers_snapshot(m._advertisement_or_none()) is True, "equal mtime, new content"
+        assert m._maybe_push_agent_profile(m._advertisement_or_none()) is True
+        assert calls[-2][2]["ts"] == 3 and calls[-1][2]["workers"][W1]["label"] == "again"
+        print("PASS test_a_restore_at_or_below_the_prior_mtime_repushes_both")
+
+
+def test_a_server_error_takes_the_short_retry_not_the_hour():
+    """A transient 500 must not leave the picker stale for an hour."""
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        _advertise(m, _record(1))
+        m._req = _raiser(500)
+        t0 = time.time()
+        assert m._maybe_push_workers_snapshot(m._advertisement_or_none()) is False
+        assert m._maybe_push_agent_profile(m._advertisement_or_none()) is False
+        assert 250 < m._workers_push_retry_at - t0 < 350, "5m, not 1h"
+        assert 250 < m._profile_push_retry_at - t0 < 350, "5m, not 1h"
+        print("PASS test_a_server_error_takes_the_short_retry_not_the_hour")
+
+
+def test_an_auth_error_takes_the_short_retry_not_the_hour():
+    """401/403 is a live endpoint refusing us; recovery is minutes away."""
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        _advertise(m, _record(1))
+        m._req = _raiser(401)
+        t0 = time.time()
+        assert m._maybe_push_workers_snapshot(m._advertisement_or_none()) is False
+        assert m._maybe_push_agent_profile(m._advertisement_or_none()) is False
+        assert 250 < m._workers_push_retry_at - t0 < 350
+        assert 250 < m._profile_push_retry_at - t0 < 350
+        print("PASS test_an_auth_error_takes_the_short_retry_not_the_hour")
+
+
+def test_only_an_unsupported_endpoint_earns_the_hour_backoff():
+    """404/405/501 is the broker saying the route does not exist here."""
+    for code in (404, 405, 501):
+        with tempfile.TemporaryDirectory() as d:
+            m = _load(pathlib.Path(d))
+            _advertise(m, _record(1))
+            m._req = _raiser(code)
+            t0 = time.time()
+            assert m._maybe_push_workers_snapshot(m._advertisement_or_none()) is False
+            assert m._maybe_push_agent_profile(m._advertisement_or_none()) is False
+            assert 3550 < m._workers_push_retry_at - t0 < 3650, code
+            assert 3550 < m._profile_push_retry_at - t0 < 3650, code
+    print("PASS test_only_an_unsupported_endpoint_earns_the_hour_backoff")
+
+
+def test_a_network_error_keeps_the_five_minute_control():
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        _advertise(m, _record(1))
+
+        def urlerr(*a, **k):
+            raise urllib.error.URLError("connection refused")
+        m._req = urlerr
+        t0 = time.time()
+        assert m._maybe_push_workers_snapshot(m._advertisement_or_none()) is False
+        assert m._maybe_push_agent_profile(m._advertisement_or_none()) is False
+        assert 250 < m._workers_push_retry_at - t0 < 350
+        assert 250 < m._profile_push_retry_at - t0 < 350
+        print("PASS test_a_network_error_keeps_the_five_minute_control")
+
+
+def test_the_unavailable_edge_logs_once_not_every_pass():
+    """The loop calls these every few seconds; an absent producer would
+    otherwise write one line per pass forever."""
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        _capture(m)
+        lines = []
+        m._log = lines.append
+        for _ in range(5):
+            m._maybe_push_workers_snapshot(m._advertisement_or_none())
+            m._maybe_push_agent_profile(m._advertisement_or_none())
+        assert sum("unavailable" in ln for ln in lines) == 1, lines
+
+        _advertise(m, _record(1))
+        assert m._maybe_push_agent_profile(m._advertisement_or_none()) is True
+        assert sum("readable again" in ln for ln in lines) == 1, lines
+        m._POOL_ADVERTISEMENT_FILE.unlink()
+        m._maybe_push_agent_profile(m._advertisement_or_none())
+        assert sum("unavailable" in ln for ln in lines) == 2, "re-armed per edge"
+        print("PASS test_the_unavailable_edge_logs_once_not_every_pass")
+
+
+def test_the_production_loop_calls_both_relays():
+    """Helper-only tests cannot show the shipped path runs: main() must call
+    each relay at least as often as it posts the heartbeat (AST call sites)."""
+    import ast
+    src = (Path(__file__).resolve().parents[1] / "ag2_sparrow" / "remote_gateway_bridge.py").read_text()
+    tree = ast.parse(src)
+    main_fn = next(n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef) and n.name == "main")
+    calls = [n.func.id for n in ast.walk(main_fn) if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)]
+    beats = calls.count("_post_heartbeat")
+    assert beats >= 1, "no heartbeat in main()"
+    assert calls.count("_push_pool_advertisement") >= beats, calls
+    # and never the two pushers separately: that is the two-reads shape
+    assert calls.count("_maybe_push_workers_snapshot") == 0 and calls.count("_maybe_push_agent_profile") == 0, calls
+
+
+def test_one_beat_publishes_one_revision_even_if_the_file_changes_mid_beat():
+    """kewei on #4162: a sibling writer's atomic rename between the two reads
+    gave the broker a snapshot from revision 1 and a card from revision 2."""
+    with tempfile.TemporaryDirectory() as d:
+        base = pathlib.Path(d)
+        os.environ["AGENT_CONNECT_STATE_DIR"] = str(base / "state")
+        (base / "state").mkdir(parents=True, exist_ok=True)
+        m = _load(base)
+        _advertise(m, _record(ts=1))
+        calls = []
+        def req(*a, **k):
+            calls.append(a)
+            if a[0] == "POST":  # the writer lands revision 2 during the first request
+                _advertise(m, {**_record(ts=2), "profile_workers": {W1: {"label": "second", "runtime": "codex"}}})
+            return {}
+        m._req = req
+        m._push_pool_advertisement()
+        assert [c[0] for c in calls] == ["POST", "PUT"], calls
+        assert calls[0][2]["ts"] == 1
+        assert calls[1][2]["workers"][W1]["label"] == "reviewer", "card from the same revision as the snapshot"
+        # the next beat ships revision 2 as a whole
+        calls.clear()
+        m._push_pool_advertisement()
+        assert calls[0][2]["ts"] == 2 and calls[1][2]["workers"][W1]["label"] == "second"
+
+
+def test_the_identity_is_one_path_segment():
+    """kewei on #4162: a slash in the identity must not become a path separator."""
+    with tempfile.TemporaryDirectory() as d:
+        base = pathlib.Path(d)
+        os.environ["AGENT_CONNECT_STATE_DIR"] = str(base / "state")
+        (base / "state").mkdir(parents=True, exist_ok=True)
+        m = _load(base)
+        _advertise(m, _record())
+        m._reenroll_identity = lambda: "@agent/name:example.test"
+        calls = _capture(m)
+        assert m._maybe_push_agent_profile(m._advertisement_or_none()) is True
+        assert calls[0][1] == "/v1/agents/%40agent%2Fname%3Aexample.test/profile", calls[0][1]
+
+
+def test_an_unchanged_pool_is_resent_on_the_cadence_so_a_restarted_broker_heals():
+    """Production 2026-09-12: the broker redeployed at 07:43Z after the last
+    snapshot push at 22:58Z and the picker stayed empty, because nothing here
+    changed. Both halves must go again on the cadence, unchanged or not."""
+    with tempfile.TemporaryDirectory() as d:
+        base = pathlib.Path(d)
+        os.environ["AGENT_CONNECT_STATE_DIR"] = str(base / "state")
+        (base / "state").mkdir(parents=True, exist_ok=True)
+        m = _load(base)
+        _advertise(m, _record())
+        clock = [1000.0]
+        m._now = lambda: clock[0]
+        calls = _capture(m)
+        m._push_pool_advertisement()
+        assert [c[0] for c in calls] == ["POST", "PUT"], calls
+        calls.clear()
+        clock[0] += 60
+        m._push_pool_advertisement()
+        assert calls == [], "within the cadence and unchanged: nothing resent"
+        clock[0] += m._REPUSH_EVERY_S
+        m._push_pool_advertisement()
+        assert [c[0] for c in calls] == ["POST", "PUT"], "past the cadence: both halves resent unchanged"
+
+
+if __name__ == "__main__":
+    test_boot_pushes_workers_and_a_card_carrying_them()
+    test_a_missing_file_pushes_nothing_at_all()
+    test_malformed_json_pushes_nothing_and_keeps_the_prior_snapshot()
+    test_a_deleted_file_after_a_good_push_changes_nothing()
+    test_a_one_sided_record_pushes_neither_half()
+    test_a_valid_empty_map_is_an_intentional_clear_and_ships()
+    test_a_file_without_the_keys_pushes_nothing_extra()
+    test_a_non_dict_workers_value_is_ignored()
+    test_a_parser_failure_of_any_kind_is_unavailable_not_a_stalled_poll()
+    test_an_oversized_record_is_unavailable_before_it_is_parsed()
+    test_a_later_mtime_repushes_both()
+    test_a_bumped_mtime_with_unchanged_content_repushes_neither()
+    test_a_restore_at_or_below_the_prior_mtime_repushes_both()
+    test_a_server_error_takes_the_short_retry_not_the_hour()
+    test_an_auth_error_takes_the_short_retry_not_the_hour()
+    test_only_an_unsupported_endpoint_earns_the_hour_backoff()
+    test_a_network_error_keeps_the_five_minute_control()
+    test_the_unavailable_edge_logs_once_not_every_pass()
+    test_the_production_loop_calls_both_relays()
+    test_one_beat_publishes_one_revision_even_if_the_file_changes_mid_beat()
+    test_the_identity_is_one_path_segment()
+    test_an_unchanged_pool_is_resent_on_the_cadence_so_a_restarted_broker_heals()
+    print("ALL PASS test_pool_advertisement_push")

--- a/packages/ag2-sparrow/tests/test_pool_advertisement_push.py
+++ b/packages/ag2-sparrow/tests/test_pool_advertisement_push.py
@@ -513,6 +513,56 @@ def test_an_unchanged_pool_is_resent_on_the_cadence_so_a_restarted_broker_heals(
         assert [c[0] for c in calls] == ["POST", "PUT"], "past the cadence: both halves resent unchanged"
 
 
+def test_a_fifo_with_no_writer_is_unavailable_not_a_wedged_loop():
+    """The reader runs in the intake loop before the /v1/tasks poll: a FIFO at
+    the advertisement path with no writer must come back UNAVAILABLE at once,
+    not park the loop on a blocking open. Exercised in a child process under a
+    timeout, since a wedge here would wedge the test too."""
+    import subprocess
+    with tempfile.TemporaryDirectory() as d:
+        base = pathlib.Path(d)
+        (base / "state").mkdir()
+        fifo = base / "state" / "pool-advertisement.json"
+        os.mkfifo(fifo)
+        env = {**os.environ, "AGENT_CONNECT_TASK_DIR": str(base / "tasks"),
+               "AGENT_CONNECT_RESULT_DIR": str(base / "results"),
+               "AGENT_CONNECT_STATE_DIR": str(base / "state"), "AGENT_MXID": MXID,
+               "REMOTE_TASK_URL": "https://gw.example/relay", "REMOTE_TASK_TOKEN": "dummy-secret"}
+        code = ("import sys; sys.path.insert(0, %r); "
+                "from ag2_sparrow import remote_gateway_bridge as m; "
+                "print(repr(m._read_pool_advertisement()))"
+                % str(pathlib.Path(__file__).resolve().parents[1]))
+        try:
+            r = subprocess.run([sys.executable, "-c", code], env=env, capture_output=True,
+                               text=True, timeout=5)
+        except subprocess.TimeoutExpired:
+            raise AssertionError("the reader wedged on a FIFO with no writer")
+        assert r.returncode == 0, r.stderr[-400:]
+        assert "('', None)" in r.stdout, r.stdout
+        print("PASS test_a_fifo_with_no_writer_is_unavailable_not_a_wedged_loop")
+
+
+def test_a_record_that_grows_after_a_small_stat_is_still_bounded():
+    """Mutation control for the two-lookup race: the bound is enforced on the
+    bytes read, so a file replaced between a one-byte stat and the read cannot
+    slip an oversized record past the guard."""
+    with tempfile.TemporaryDirectory() as d:
+        m = _load(pathlib.Path(d))
+        big = _record(1)
+        big["pad"] = "x" * m._POOL_ADVERTISEMENT_MAX_BYTES
+        _advertise(m, big)
+        # Prove the guard is on the read: a stat that lied small would not help.
+        real_fstat = os.fstat
+        os.fstat = lambda fd: type("st", (), {"st_mode": real_fstat(fd).st_mode, "st_size": 1})()
+        try:
+            assert m._read_pool_advertisement() == ("", None)
+        finally:
+            os.fstat = real_fstat
+        _advertise(m, _record(2), age=5)
+        assert m._read_pool_advertisement()[1] is not None, "positive control"
+        print("PASS test_a_record_that_grows_after_a_small_stat_is_still_bounded")
+
+
 if __name__ == "__main__":
     test_boot_pushes_workers_and_a_card_carrying_them()
     test_a_missing_file_pushes_nothing_at_all()
@@ -524,6 +574,8 @@ if __name__ == "__main__":
     test_a_non_dict_workers_value_is_ignored()
     test_a_parser_failure_of_any_kind_is_unavailable_not_a_stalled_poll()
     test_an_oversized_record_is_unavailable_before_it_is_parsed()
+    test_a_fifo_with_no_writer_is_unavailable_not_a_wedged_loop()
+    test_a_record_that_grows_after_a_small_stat_is_still_bounded()
     test_a_later_mtime_repushes_both()
     test_a_bumped_mtime_with_unchanged_content_repushes_neither()
     test_a_restore_at_or_below_the_prior_mtime_repushes_both()

--- a/skills/phone-conversation/scripts/conversation-server.ts
+++ b/skills/phone-conversation/scripts/conversation-server.ts
@@ -213,7 +213,7 @@ const _CONF_HEADER_RE = new RegExp(
 	'thread_root|source_room_id|' +
 	'receiving_instance|' +
 	'call_sid|hint|instructions|transcript|schedule_name|schedule_slot|content_modalities|media_form|' +
-	'attachments|platform_card|instance_id|collaborator|requested_worker|wire_source|hitl_click)\\s*:',
+	'attachments|platform_card|instance_id|collaborator|requested_worker|wire_source|picker_command|picker_args|hitl_click)\\s*:',
 	'i',
 );
 const _CONF_FENCE_RE = /^={3,}/;

--- a/src/local_task_protocol.py
+++ b/src/local_task_protocol.py
@@ -148,7 +148,7 @@ def canonical_access_tier(value) -> str:
 #   can survive undefanged in user-supplied content.
 # Adding a producer header = add it here; the guard follows automatically.
 KNOWN_HEADER_KEYS = (
-    "id", "timestamp", "session_scope", "task", "source", "wire_source", "access_tier", "user_id",
+    "id", "timestamp", "session_scope", "task", "source", "wire_source", "picker_command", "picker_args", "access_tier", "user_id",
     "channel_id", "priority", "interaction_type", "source_message_id",
     "channel_name", "guild_name", "attempts", "sender_name", "room_name",
     "parent_message_id", "reply_chain_ids", "reminder", "author_name",

--- a/src/task-bridge.ts
+++ b/src/task-bridge.ts
@@ -99,7 +99,7 @@ const _HEADER_KEYS = [
 	'from', 'call_sid', 'hint', 'instructions', 'transcript',
 	'schedule_name', 'schedule_slot',
 	'content_modalities', 'media_form', 'attachments', 'platform_card',
-	'instance_id', 'collaborator', 'requested_worker', 'wire_source', 'hitl_click',
+	'instance_id', 'collaborator', 'requested_worker', 'wire_source', 'picker_command', 'picker_args', 'hitl_click',
 ];
 const _HEADER_RE = new RegExp(`^(?:${_HEADER_KEYS.join('|')})\\s*:`, 'i');
 const _FENCE_RE = /^={3,}/;


### PR DESCRIPTION
Core slice of #4210, split out under the re-sequencing ruling (PR triage 16:41Z; owner: "DO the re-sequencing required in the two PRs we have"): core-impacting changes land first, proven working with no worker pool; the pool follows. Merge order, all core before any skill: #4215 → **this** → the two outage guard PRs → #4209 → #4210 (skill remainder). Rebased onto 838ed74a1 (#4215) at 99e0e4426; the diff is byte-identical to the slice first cut on #4209'.

### What it changes (core only, 8 files)

- `packages/ag2-sparrow/ag2_sparrow/remote_gateway_bridge.py` (+213): `_push_pool_advertisement()` reads `state/pool-advertisement.json` once per loop pass and pushes the workers snapshot and the agent profile when the file's revision moved; resends every 600 s (`_REPUSH_EVERY_S`, `_now` seam) so a broker that restarted with an empty copy is refilled without an operator touch (production 2026-09-12 07:43Z). Pushers require the agent record; the identity is quoted as one path segment; dedicated write branch for `picker_command` / `picker_args`. Called after `_post_heartbeat` at both `main()` sites (AST-checked).
- Lockstep header constant, four mirrors (`src/local_task_protocol.py`, ag2-sparrow copy, `src/task-bridge.ts`, `conversation-server.ts`): `picker_command`, `picker_args` added once, after `wire_source` (positions as #4215 keeps them).
- `.github/workflows/ci.yml`: the new sparrow suite. `docs/remote-gateway-protocol.md`: the push.

### Proven working with no pool

With no advertisement file the loop pushes nothing: `test_a_missing_file_pushes_nothing_at_all`. A core without workers is a no-op on this path.

### Evidence

```
python3 packages/ag2-sparrow/tests/test_pool_advertisement_push.py   → ALL PASS (22)
ruff                                                                → clean
scripts/review-checks.sh --diff <slice>                             → PASS
scripts/lint-workspace-resolution.sh --diff <slice>                 → clean
```
Split verification: for each of the 8 files, `git diff 838ed74a1..99e0e4426 -- <file>` is byte-identical (index lines aside) to `git diff 4e8964a0f..ae48e2c08 -- <file>`, the cumulative #4210 diff on its old base. The ten skill files and `tests/gateway-writeside-picker-command.test.py` (it imports the skill's parser) form the remainder, re-pushed as #4210 on this branch.

-- Mars-the-product-dev



### d1a363d86 — the reader is FIFO-safe and bounded on the read (Kewei's P1, filed on #4219 against this code)

Before, `_read_pool_advertisement` did a separate `stat()` and then a blocking `read_text()`; a FIFO at the path with no writer parked the intake loop before its next `/v1/tasks` poll, and the size guard read from a second lookup could be stale by the time the bytes were. Now: one `os.open(O_RDONLY|O_NONBLOCK)`, `fstat` on that descriptor, refuse anything but a regular file, read at most MAX+1 bytes from the same descriptor, refuse the overflow; the descriptor is closed on every path.

```
BEFORE (535076174 reader, FIFO with no writer, child process): TIMEOUT after 5s — the loop wedges
AFTER  (d1a363d86):        ('', None) within the 5 s subprocess timeout
```
Tests: `test_a_fifo_with_no_writer_is_unavailable_not_a_wedged_loop` (child process under a timeout) and `test_a_record_that_grows_after_a_small_stat_is_still_bounded` (the bound is on the read, positive control after). Suite ALL PASS (24); ruff, review-checks and the workspace lint clean.
