### PR TITLE
feat(discord-read): --jsonl carries each message's id and jump link

### DIFF
--- a/src/discord-read.py
+++ b/src/discord-read.py
@@ -14,8 +14,12 @@ privileged mode for the core's own monitoring (no serving context exists);
 choosing it is visible in the invocation, not a silent default.
 
 Requires DISCORD_BOT_TOKEN in $CLAUDE_CONFIG_DIR/channels/discord/.env or env var.
+
+--jsonl prints one JSON object per message (id, ts, author, text, reply, url) instead of the
+text lines, for a consumer that needs to link back to the message (the owner's triage card).
 """
 import argparse
+import json
 import sys
 from pathlib import Path
 
@@ -53,6 +57,8 @@ def _parse_args(argv):
     parser.add_argument("--full", action="store_true",
                         help="Do not clip bodies. Use when the read is a VERIFICATION instrument ('did my message land?') rather than a scan: a grep past the 200-char clip returns 0 for text that WAS delivered, and a false negative there causes a duplicate send.")
     parser.add_argument("--until", default=None, help="Snowflake ID or ISO date/time (e.g. 2026-06-24T23:25) — page BACKWARD until reaching this boundary, then stop. Condition-based depth, NOT a message count: use to reconstruct context however far back the referent / conversational boundary is.")
+    parser.add_argument("--jsonl", action="store_true",
+                        help="One JSON object per message (id, ts, author, text, reply, url) instead of the text lines. url is the message's jump link; it costs one channel lookup for the guild id.")
     mode = parser.add_mutually_exclusive_group()
     mode.add_argument("--serving", default=None,
                       help="Origin channel_id of the task being served. Runs the contextNotFrom gate BEFORE any fetch; exit 2 on block.")
@@ -105,6 +111,8 @@ def main(argv=None):
         print(f"Error: {e}", file=sys.stderr)
         return 1
 
+    # A jump link needs the guild; a DM channel has none and Discord spells that "@me".
+    guild = discord_context_policy.resolve_guild(args.channel_id, token) if args.jsonl else None
     # Oldest first (snowflake id is time-ordered). Trim anything strictly older
     # than the --until boundary so the output stops exactly where requested.
     for msg in sorted(messages, key=lambda m: int(m["id"])):
@@ -113,8 +121,15 @@ def main(argv=None):
         author = msg.get("author", {}).get("username", "?")
         ts = msg.get("timestamp", "")[:19]
         clip = None if args.full else CLIP
-        print(f"[{ts}] {author}: {_render(msg, clip)}")
         ctx = _reply_context(msg, None if args.full else REPLY_CLIP)
+        if args.jsonl:
+            print(json.dumps({
+                "id": str(msg.get("id", "")), "ts": ts, "author": author,
+                "text": _render(msg, clip), "reply": ctx or "",
+                "url": f"https://discord.com/channels/{guild or '@me'}/{args.channel_id}/{msg.get('id', '')}",
+            }, ensure_ascii=False))
+            continue
+        print(f"[{ts}] {author}: {_render(msg, clip)}")
         if ctx:
             print(f"    {ctx}")
     return 0

--- a/tests/discord-read-jsonl.test.py
+++ b/tests/discord-read-jsonl.test.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""`--jsonl` carries each message's id and jump link; the text mode stays byte-for-byte as it was.
+The owner's triage card asked for links on message rows (2026-09-12); the text lines carry no id.
+"""
+import contextlib
+import importlib.util
+import io
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "src" / "discord-read.py"
+
+_spec = importlib.util.spec_from_file_location("discord_read_jsonl", SCRIPT)
+dr = importlib.util.module_from_spec(_spec)
+sys.modules["discord_read_jsonl"] = dr
+try:
+    _spec.loader.exec_module(dr)
+except SystemExit:
+    pass
+
+MESSAGES = [
+    {"id": "2000", "timestamp": "2026-09-12T18:00:01.000Z", "content": "second",
+     "author": {"username": "Sutando-Pro"}},
+    {"id": "1000", "timestamp": "2026-09-12T17:59:59.000Z", "content": "first é",
+     "author": {"username": "susanliu_"}},
+]
+
+
+def _run(argv, guild="9001"):
+    out = io.StringIO()
+    with mock.patch.object(dr, "_load_token", return_value="tok"), \
+         mock.patch.object(dr, "_fetch", return_value=list(MESSAGES)), \
+         mock.patch.object(dr.discord_context_policy, "resolve_guild", return_value=guild) as rg, \
+         contextlib.redirect_stdout(out):
+        rc = dr.main(argv)
+    return rc, out.getvalue(), rg
+
+
+class JsonlMode(unittest.TestCase):
+    def test_one_object_per_message_oldest_first_with_id_and_jump_link(self):
+        rc, out, rg = _run(["123", "--operator", "--jsonl"])
+        self.assertEqual(rc, 0)
+        rows = [json.loads(line) for line in out.splitlines()]
+        self.assertEqual([r["id"] for r in rows], ["1000", "2000"])
+        self.assertEqual(rows[0]["author"], "susanliu_")
+        self.assertEqual(rows[0]["text"], "first é")
+        self.assertEqual(rows[0]["ts"], "2026-09-12T17:59:59")
+        self.assertEqual(rows[0]["reply"], "")
+        self.assertEqual(rows[0]["url"], "https://discord.com/channels/9001/123/1000")
+        rg.assert_called_once_with("123", "tok")
+
+    def test_a_dm_channel_links_through_at_me(self):
+        _, out, _ = _run(["123", "--operator", "--jsonl"], guild=None)
+        self.assertTrue(all(json.loads(l)["url"].startswith("https://discord.com/channels/@me/123/")
+                            for l in out.splitlines()))
+
+    def test_the_text_mode_is_unchanged_and_looks_up_no_guild(self):
+        rc, out, rg = _run(["123", "--operator"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(out.splitlines(), ["[2026-09-12T17:59:59] susanliu_: first é",
+                                            "[2026-09-12T18:00:01] Sutando-Pro: second"])
+        rg.assert_not_called()
+
+    def test_the_gate_still_runs_first_in_jsonl_mode(self):
+        out = io.StringIO()
+        with mock.patch.object(dr, "_load_token", return_value="tok"), \
+             mock.patch.object(dr, "_fetch") as fetch, \
+             mock.patch.object(dr.discord_context_policy, "gate", return_value="blocked by policy"), \
+             contextlib.redirect_stdout(out):
+            rc = dr.main(["123", "--serving", "456", "--jsonl"])
+        self.assertEqual(rc, 2)
+        fetch.assert_not_called()
+        self.assertIn("BLOCKED", out.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

`src/discord-read.py --jsonl`: one JSON object per message — `id`, `ts`, `author`, `text`, `reply`, `url` — where `url` is the message's jump link (`https://discord.com/channels/<guild>/<channel>/<id>`, `@me` for a DM channel). The text mode is unchanged.

## Why

Owner, 2026-09-12, on the triage card's Discord rows: "c links should be included." The card (sutando-life) reads channels through this script, and the text lines carry no message id, so a row could say what was said but never open it. sutando-life's consumer (its own PR, with a text-mode fallback) uses `url` when this mode is present.

## Evidence

Tests (run at HEAD in the worktree):

```
tests/discord-read-jsonl.test.py:          OK   (4: oldest-first objects with id+link; DM → @me; text mode byte-identical and no guild lookup; gate still runs first)
tests/discord-read-full-body.test.py:      OK
tests/discord-read-reply-context.test.py:  OK
tests/discord-read-redaction.test.py:      OK
tests/read-discord-channel-gate.test.py:   PASS
scripts/review-checks.sh --diff <this diff>:  review-checks: PASS (hardcoded-paths + root-artifacts + prose-cap clean)
python3 scripts/gen-src-map.py:            docs/src-map.md unchanged (header line unchanged)
```

Sample line (from the test fixture):

```
{"id": "1000", "ts": "2026-09-12T17:59:59", "author": "susanliu_", "text": "first é", "reply": "", "url": "https://discord.com/channels/9001/123/1000"}
```

No live round trip here: this changes output formatting of an existing fetch path, not the bridge, delivery loop, or startup; the fetch, gate and redaction code paths are the ones already covered by the existing reader tests above.

Stand: Echo Act IV Blue
