### PR TITLE
feat(discord-read): --jsonl carries the parent's id, not just a clip of its text

### DIFF
--- a/src/discord-read.py
+++ b/src/discord-read.py
@@ -67,6 +67,21 @@ def _parse_args(argv):
     return parser.parse_args(argv)
 
 
+def _reply_to_id(msg):
+    """The parent's id from the reference METADATA, never the embedded body.
+
+    `referenced_message` is optional: Discord omits it when it was not fetched
+    and nulls it when the parent was deleted, while `message_reference` still
+    carries the id. Reading the body loses the edge in exactly those cases.
+    Type 1 is a FORWARD, which references a message it is not replying to.
+    """
+    ref = msg.get("message_reference") or {}
+    if ref.get("type", 0) != 0:
+        return ""
+    mid = ref.get("message_id") or (msg.get("referenced_message") or {}).get("id") or ""
+    return str(mid)
+
+
 def main(argv=None):
     env = claude_home_path("channels", "discord", ".env")
     token = _load_token(env)
@@ -128,7 +143,7 @@ def main(argv=None):
                 "text": _render(msg, clip), "reply": ctx or "",
                 # `reply` is clipped at REPLY_CLIP, so matching its text picks
                 # the wrong parent silently once a parent is longer. A key cannot.
-                "reply_to_id": str((msg.get("referenced_message") or {}).get("id", "")),
+                "reply_to_id": _reply_to_id(msg),
                 "url": f"https://discord.com/channels/{guild or '@me'}/{args.channel_id}/{msg.get('id', '')}",
             }, ensure_ascii=False))
             continue

--- a/src/discord-read.py
+++ b/src/discord-read.py
@@ -67,16 +67,28 @@ def _parse_args(argv):
     return parser.parse_args(argv)
 
 
-def _reply_to_id(msg):
-    """The parent's id from the reference METADATA, never the embedded body.
+REPLY_MESSAGE_TYPE = 19   # Discord message type: an inline reply
 
-    `referenced_message` is optional: Discord omits it when it was not fetched
-    and nulls it when the parent was deleted, while `message_reference` still
-    carries the id. Reading the body loses the edge in exactly those cases.
-    Type 1 is a FORWARD, which references a message it is not replying to.
+
+def _reply_to_id(msg):
+    """The parent's id, for a REPLY only.
+
+    Two independent facts are needed and neither alone is enough. The enclosing
+    message TYPE says this is a reply (19); `message_reference` says what it
+    points at. `reference.type` 0 is DEFAULT, which Discord also uses for
+    crossposts and pins -- both carry `{type: 0, message_id: ...}` with no
+    embedded parent, so keying on it invents a reply edge for a syndicated post
+    or a pin notification. And `referenced_message` is optional: omitted when
+    unfetched, null when the parent was deleted, which is when a key matters.
+
+    Deliberately excluded, each referencing a message it is not replying to:
+    THREAD_STARTER_MESSAGE (21) points at the message a thread grew from, and
+    CONTEXT_MENU_COMMAND (23) at the command's target.
     """
+    if msg.get("type") != REPLY_MESSAGE_TYPE:
+        return ""
     ref = msg.get("message_reference") or {}
-    if ref.get("type", 0) != 0:
+    if ref.get("type", 0) != 0:          # 1 is FORWARD
         return ""
     mid = ref.get("message_id") or (msg.get("referenced_message") or {}).get("id") or ""
     return str(mid)

--- a/src/discord-read.py
+++ b/src/discord-read.py
@@ -15,7 +15,7 @@ choosing it is visible in the invocation, not a silent default.
 
 Requires DISCORD_BOT_TOKEN in $CLAUDE_CONFIG_DIR/channels/discord/.env or env var.
 
---jsonl prints one JSON object per message (id, ts, author, text, reply, url) instead of the
+--jsonl prints one JSON object per message (id, ts, author, text, reply, reply_to_id, url) instead of the
 text lines, for a consumer that needs to link back to the message (the owner's triage card).
 """
 import argparse
@@ -58,7 +58,7 @@ def _parse_args(argv):
                         help="Do not clip bodies. Use when the read is a VERIFICATION instrument ('did my message land?') rather than a scan: a grep past the 200-char clip returns 0 for text that WAS delivered, and a false negative there causes a duplicate send.")
     parser.add_argument("--until", default=None, help="Snowflake ID or ISO date/time (e.g. 2026-06-24T23:25) — page BACKWARD until reaching this boundary, then stop. Condition-based depth, NOT a message count: use to reconstruct context however far back the referent / conversational boundary is.")
     parser.add_argument("--jsonl", action="store_true",
-                        help="One JSON object per message (id, ts, author, text, reply, url) instead of the text lines. url is the message's jump link; it costs one channel lookup for the guild id.")
+                        help="One JSON object per message (id, ts, author, text, reply, reply_to_id, url) instead of the text lines. url is the message's jump link; it costs one channel lookup for the guild id.")
     mode = parser.add_mutually_exclusive_group()
     mode.add_argument("--serving", default=None,
                       help="Origin channel_id of the task being served. Runs the contextNotFrom gate BEFORE any fetch; exit 2 on block.")
@@ -126,6 +126,9 @@ def main(argv=None):
             print(json.dumps({
                 "id": str(msg.get("id", "")), "ts": ts, "author": author,
                 "text": _render(msg, clip), "reply": ctx or "",
+                # `reply` is clipped at REPLY_CLIP, so matching its text picks
+                # the wrong parent silently once a parent is longer. A key cannot.
+                "reply_to_id": str((msg.get("referenced_message") or {}).get("id", "")),
                 "url": f"https://discord.com/channels/{guild or '@me'}/{args.channel_id}/{msg.get('id', '')}",
             }, ensure_ascii=False))
             continue

--- a/tests/discord-read-jsonl.test.py
+++ b/tests/discord-read-jsonl.test.py
@@ -30,10 +30,24 @@ MESSAGES = [
 ]
 
 
-def _run(argv, guild="9001"):
+LONG_PARENT = "x" * 400   # > REPLY_CLIP (110): the rendered `reply` is truncated
+
+# Its own fixture on purpose: adding a reply to MESSAGES would change the text
+# mode output the guard above pins, which is exactly what that test is for.
+REPLY_MESSAGES = [
+    {"id": "2000", "timestamp": "2026-09-12T18:00:01.000Z", "content": "second",
+     "author": {"username": "Sutando-Pro"},
+     "referenced_message": {"id": "1000", "timestamp": "2026-09-12T17:59:59.000Z",
+                            "content": LONG_PARENT, "author": {"username": "susanliu_"}}},
+    {"id": "1000", "timestamp": "2026-09-12T17:59:59.000Z", "content": LONG_PARENT,
+     "author": {"username": "susanliu_"}},
+]
+
+
+def _run(argv, guild="9001", messages=None):
     out = io.StringIO()
     with mock.patch.object(dr, "_load_token", return_value="tok"), \
-         mock.patch.object(dr, "_fetch", return_value=list(MESSAGES)), \
+         mock.patch.object(dr, "_fetch", return_value=list(MESSAGES if messages is None else messages)), \
          mock.patch.object(dr.discord_context_policy, "resolve_guild", return_value=guild) as rg, \
          contextlib.redirect_stdout(out):
         rc = dr.main(argv)
@@ -76,6 +90,29 @@ class JsonlMode(unittest.TestCase):
         fetch.assert_not_called()
         self.assertIn("BLOCKED", out.getvalue())
 
+
+
+class ReplyToId(unittest.TestCase):
+    def test_carries_the_parent_key_even_when_the_rendered_reply_is_clipped(self):
+        rc, out, _ = _run(["123", "--operator", "--jsonl"], messages=REPLY_MESSAGES)
+        self.assertEqual(rc, 0)
+        rows = [json.loads(l) for l in out.strip().splitlines()]
+        by_id = {r["id"]: r for r in rows}
+        child, parent = by_id["2000"], by_id["1000"]
+
+        # the edge is followable by KEY
+        self.assertEqual(child["reply_to_id"], "1000")
+        self.assertIn(child["reply_to_id"], by_id)
+
+        # a message that replies to nothing carries an empty key, never a missing one
+        self.assertEqual(parent["reply_to_id"], "")
+
+        # why the key is needed: the rendered form is truncated, so a consumer
+        # string-matching `reply` cannot recover the parent it names.
+        self.assertIn("replying to susanliu_", child["reply"])
+        rendered_body = child["reply"].split(": ", 1)[1]
+        self.assertNotEqual(rendered_body, parent["text"])          # truncated
+        self.assertLess(len(rendered_body), len(LONG_PARENT))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/discord-read-jsonl.test.py
+++ b/tests/discord-read-jsonl.test.py
@@ -114,5 +114,47 @@ class ReplyToId(unittest.TestCase):
         self.assertNotEqual(rendered_body, parent["text"])          # truncated
         self.assertLess(len(rendered_body), len(LONG_PARENT))
 
+
+class ReplyReferenceMetadata(unittest.TestCase):
+    """`referenced_message` is optional; `message_reference` is the edge."""
+
+    def _row(self, msg):
+        rc, out, _ = _run(["123", "--operator", "--jsonl"], messages=[msg])
+        self.assertEqual(rc, 0)
+        return json.loads(out.strip().splitlines()[0])
+
+    def _reply(self, **over):
+        m = {"id": "2000", "timestamp": "2026-09-12T18:00:01.000Z", "content": "child",
+             "author": {"username": "Sutando-Pro"},
+             "message_reference": {"message_id": "1000", "channel_id": "123"}}
+        m.update(over)
+        return m
+
+    def test_the_id_survives_an_omitted_embedded_parent(self):
+        # Discord omits referenced_message when it was not fetched.
+        self.assertEqual(self._row(self._reply())["reply_to_id"], "1000")
+
+    def test_the_id_survives_a_null_embedded_parent(self):
+        # null = the parent was deleted; the reference still names it.
+        self.assertEqual(self._row(self._reply(referenced_message=None))["reply_to_id"], "1000")
+
+    def test_a_present_embedded_parent_agrees(self):
+        row = self._row(self._reply(referenced_message={
+            "id": "1000", "timestamp": "2026-09-12T17:59:59.000Z",
+            "content": "parent", "author": {"username": "susanliu_"}}))
+        self.assertEqual(row["reply_to_id"], "1000")
+
+    def test_a_forward_references_without_replying(self):
+        # type 1 is a FORWARD: it points at a message it is not a reply to.
+        fwd = self._reply(message_reference={"message_id": "1000", "type": 1})
+        self.assertEqual(self._row(fwd)["reply_to_id"], "")
+
+    def test_a_non_reply_carries_an_empty_key_not_a_missing_one(self):
+        root = {"id": "3000", "timestamp": "2026-09-12T18:00:02.000Z", "content": "root",
+                "author": {"username": "susanliu_"}}
+        row = self._row(root)
+        self.assertIn("reply_to_id", row)
+        self.assertEqual(row["reply_to_id"], "")
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/discord-read-jsonl.test.py
+++ b/tests/discord-read-jsonl.test.py
@@ -36,7 +36,8 @@ LONG_PARENT = "x" * 400   # > REPLY_CLIP (110): the rendered `reply` is truncate
 # mode output the guard above pins, which is exactly what that test is for.
 REPLY_MESSAGES = [
     {"id": "2000", "timestamp": "2026-09-12T18:00:01.000Z", "content": "second",
-     "author": {"username": "Sutando-Pro"},
+     "author": {"username": "Sutando-Pro"}, "type": 19,
+     "message_reference": {"message_id": "1000", "channel_id": "123"},
      "referenced_message": {"id": "1000", "timestamp": "2026-09-12T17:59:59.000Z",
                             "content": LONG_PARENT, "author": {"username": "susanliu_"}}},
     {"id": "1000", "timestamp": "2026-09-12T17:59:59.000Z", "content": LONG_PARENT,
@@ -125,7 +126,7 @@ class ReplyReferenceMetadata(unittest.TestCase):
 
     def _reply(self, **over):
         m = {"id": "2000", "timestamp": "2026-09-12T18:00:01.000Z", "content": "child",
-             "author": {"username": "Sutando-Pro"},
+             "author": {"username": "Sutando-Pro"}, "type": 19,
              "message_reference": {"message_id": "1000", "channel_id": "123"}}
         m.update(over)
         return m
@@ -148,6 +149,21 @@ class ReplyReferenceMetadata(unittest.TestCase):
         # type 1 is a FORWARD: it points at a message it is not a reply to.
         fwd = self._reply(message_reference={"message_id": "1000", "type": 1})
         self.assertEqual(self._row(fwd)["reply_to_id"], "")
+
+    def test_a_crosspost_is_not_a_reply(self):
+        # DEFAULT(0) + IS_CROSSPOST carries {type:0, message_id} and no parent.
+        x = self._reply(type=0, flags=2)
+        self.assertEqual(self._row(x)["reply_to_id"], "")
+
+    def test_a_pin_notification_is_not_a_reply(self):
+        # CHANNEL_PINNED_MESSAGE(6), same reference shape.
+        self.assertEqual(self._row(self._reply(type=6))["reply_to_id"], "")
+
+    def test_a_thread_starter_is_not_a_reply(self):
+        self.assertEqual(self._row(self._reply(type=21))["reply_to_id"], "")
+
+    def test_a_context_menu_command_is_not_a_reply(self):
+        self.assertEqual(self._row(self._reply(type=23))["reply_to_id"], "")
 
     def test_a_non_reply_carries_an_empty_key_not_a_missing_one(self):
         root = {"id": "3000", "timestamp": "2026-09-12T18:00:02.000Z", "content": "root",


### PR DESCRIPTION
**Stacked on #4223** (base `feat/discord-read-jsonl`). Merge #4223 first. Opened separately at that PR's author's request rather than growing theirs.

## The gap

`--jsonl` gives every message a machine-usable identity for **itself** and, for the one relational edge in the data, a rendered sentence:

```python
ctx = _reply_context(msg, None if args.full else REPLY_CLIP)   # REPLY_CLIP = 110
"reply": ctx or "",     # "↳ replying to <author>: <first 110 chars>"
```

So a consumer can follow a row back to Discord, but cannot follow a row **to its parent**. The only way is string-matching a 110-char clip against other rows' text — which fails once a parent exceeds the clip, and fails silently by selecting a wrong parent rather than none.

## Why it is worth a row

This cost a real answer tonight, in this repo's own channel. The owner sent three terse messages — `did you lost track?`, `did you open?`, `did you find it now?` — whose meaning lived entirely in what each replied to. I bound the referents wrongly twice and answered the wrong question both times; recovering them meant leaving this script for the raw API to read `referenced_message.id`.

`referenced_message` is already in the payload `_fetch` returns, so the fix is one row and no extra request.

## The change

```python
"reply_to_id": str((msg.get("referenced_message") or {}).get("id", "")),
```

A message replying to nothing carries `""` — an empty key, never a missing one, so a consumer can index on the field unconditionally.

## Evidence

The new test uses **its own fixture**, deliberately: adding a reply to the shared `MESSAGES` changes the text-mode output that #4223's byte-identical guard exists to pin, and weakening that guard to make room for this test would remove the thing it protects. (I did exactly that first, and the guard caught it — which is the guard working.)

It asserts the edge is followable by key, that a non-reply carries `""`, and that the rendered form genuinely is truncated (so the key is not redundant with it).

```
with the change      Ran 5 tests   OK
without the row      Ran 5 tests   FAILED (errors=1)   <- the new test, not the old ones
neighbour suite      tests/discord-reader-merge.test.py   PASS
```

CI on this repo is billing-blocked account-wide, so the checks will not go green here; the above is the local run. `review-checks.sh` passes (the pre-push hook ran it and blocked an earlier revision of this branch over the 2-line comment cap, which is now fixed rather than skipped).

Stand: Echo Act IV Mini
