### PR TITLE
fix(health-check): two spellings of one commit read as driver drift

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -3209,17 +3209,34 @@ def check_skills_driver_code_drift(workspace: "Path | None" = None) -> dict:
         return {"name": name, "status": "ok", "detail": "could not read skills HEAD — not asserting drift"}
     # Never compare two abbreviations: each writer picks its own length, so they
     # agree until a colliding object lands and `--short` grows. Resolve both.
+    def _git(*args, timeout=10):
+        return subprocess.run(git_argv("-C", str(skills), *args),
+                              capture_output=True, text=True, timeout=timeout)
+
     def _oid(rev):
-        """(state, oid) — 'ok' | 'absent' | 'unknown'. Absent is a finding;
-        ambiguous or unrunnable is unobserved, and the two must not merge."""
+        """(state, oid) — 'ok' | 'absent' | 'unknown'.
+
+        A nonzero exit does not establish absence: an unreadable loose object,
+        a signal, or exit 128 all fail while the commit is right there. Absence
+        is established POSITIVELY, by asking how many objects carry the prefix.
+        """
         try:
-            r = subprocess.run(git_argv("-C", str(skills), "rev-parse", "--verify", f"{rev}^{{commit}}"),
-                               capture_output=True, text=True, timeout=10)
+            r = _git("rev-parse", "--verify", f"{rev}^{{commit}}")
+            if r.returncode == 0 and r.stdout.strip():
+                return ("ok", r.stdout.strip())
+            # --disambiguate takes an object PREFIX. A symbolic name like HEAD
+            # matches nothing, which would read as absence rather than a failure.
+            if not _re.fullmatch(r"[0-9a-fA-F]{4,40}", rev or ""):
+                return ("unknown", "")
+            d = _git("rev-parse", f"--disambiguate={rev}")
         except Exception:
             return ("unknown", "")
-        if r.returncode == 0:
-            return ("ok", r.stdout.strip())
-        return ("unknown", "") if "ambiguous" in (r.stderr or "").lower() else ("absent", "")
+        if d.returncode != 0:
+            return ("unknown", "")
+        n = len([ln for ln in d.stdout.split() if ln.strip()])
+        # 0 candidates is the only positively-established absence. One candidate
+        # that would not resolve means present-but-unreadable; >1 is ambiguous.
+        return ("absent", "") if n == 0 else ("unknown", "")
     head_state, head_oid = _oid("HEAD")
     if head_state != "ok":
         return {"name": name, "status": "ok",
@@ -3229,8 +3246,9 @@ def check_skills_driver_code_drift(workspace: "Path | None" = None) -> dict:
     # nothing about the driver; only a resolvable, different commit does.
     if run_state == "unknown":
         return {"name": name, "status": "ok",
-                "detail": (f"could not identify the driver stamp {running} (ambiguous prefix or git "
-                           f"unavailable) — INCONCLUSIVE, not asserting drift or a re-arm")}
+                "detail": (f"could not identify the driver stamp {running} (ambiguous prefix, "
+                           f"unreadable object, or git unavailable) — INCONCLUSIVE, not asserting "
+                           f"drift or a re-arm")}
     same = run_oid == head_oid
     if same:
         return {"name": name, "status": "ok",

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -3231,7 +3231,9 @@ def check_skills_driver_code_drift(workspace: "Path | None" = None) -> dict:
             d = _git("rev-parse", f"--disambiguate={rev}")
         except Exception:
             return ("unknown", "")
-        if d.returncode != 0:
+        # rc 0 with nothing on stdout and a complaint on stderr is a FAILED
+        # read, not an empty candidate set: an unreadable object dir does this.
+        if d.returncode != 0 or (not d.stdout.strip() and d.stderr.strip()):
             return ("unknown", "")
         n = len([ln for ln in d.stdout.split() if ln.strip()])
         # 0 candidates is the only positively-established absence. One candidate

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -3207,16 +3207,22 @@ def check_skills_driver_code_drift(workspace: "Path | None" = None) -> dict:
         return {"name": name, "status": "ok", "detail": "no stamp recorded yet — driver has not logged a version"}
     if not head:
         return {"name": name, "status": "ok", "detail": "could not read skills HEAD — not asserting drift"}
-    # Two writers, two spellings: the driver stamps its own prefix and `--short`
-    # grows to stay unambiguous, so equal commits compare unequal as strings.
-    try:
-        rp = subprocess.run(git_argv("-C", str(skills), "rev-parse", f"{running}^{{commit}}", "HEAD^{commit}"),
-                            capture_output=True, text=True, timeout=10)
-        full = rp.stdout.split() if rp.returncode == 0 else []
-    except Exception:
-        full = []
-    # String equality stays as the fallback for when rev-parse cannot answer.
-    same = running == head or (len(full) == 2 and full[0] == full[1])
+    # Never compare two abbreviations: each writer picks its own length, so they
+    # agree until a colliding object lands and `--short` grows. Resolve both.
+    def _oid(rev):
+        try:
+            r = subprocess.run(git_argv("-C", str(skills), "rev-parse", "--verify", "--quiet", f"{rev}^{{commit}}"),
+                               capture_output=True, text=True, timeout=10)
+            return r.stdout.strip() if r.returncode == 0 else ""
+        except Exception:
+            return ""
+    head_oid = _oid("HEAD")
+    if not head_oid:
+        return {"name": name, "status": "ok",
+                "detail": "could not resolve HEAD in the skills checkout — not asserting drift"}
+    # An unresolvable STAMP is a finding, not an unanswerable: the driver is on
+    # code this checkout does not have. Only an unreadable HEAD is unanswerable.
+    same = _oid(running) == head_oid
     if same:
         return {"name": name, "status": "ok",
                 "detail": f"content-driver running {running}, matches skills HEAD ({head})"}

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -3210,19 +3210,28 @@ def check_skills_driver_code_drift(workspace: "Path | None" = None) -> dict:
     # Never compare two abbreviations: each writer picks its own length, so they
     # agree until a colliding object lands and `--short` grows. Resolve both.
     def _oid(rev):
+        """(state, oid) — 'ok' | 'absent' | 'unknown'. Absent is a finding;
+        ambiguous or unrunnable is unobserved, and the two must not merge."""
         try:
-            r = subprocess.run(git_argv("-C", str(skills), "rev-parse", "--verify", "--quiet", f"{rev}^{{commit}}"),
+            r = subprocess.run(git_argv("-C", str(skills), "rev-parse", "--verify", f"{rev}^{{commit}}"),
                                capture_output=True, text=True, timeout=10)
-            return r.stdout.strip() if r.returncode == 0 else ""
         except Exception:
-            return ""
-    head_oid = _oid("HEAD")
-    if not head_oid:
+            return ("unknown", "")
+        if r.returncode == 0:
+            return ("ok", r.stdout.strip())
+        return ("unknown", "") if "ambiguous" in (r.stderr or "").lower() else ("absent", "")
+    head_state, head_oid = _oid("HEAD")
+    if head_state != "ok":
         return {"name": name, "status": "ok",
-                "detail": "could not resolve HEAD in the skills checkout — not asserting drift"}
-    # An unresolvable STAMP is a finding, not an unanswerable: the driver is on
-    # code this checkout does not have. Only an unreadable HEAD is unanswerable.
-    same = _oid(running) == head_oid
+                "detail": f"HEAD in the skills checkout is {head_state} — not asserting drift"}
+    run_state, run_oid = _oid(running)
+    # Unobserved is not stale. An ambiguous prefix or an unrunnable git says
+    # nothing about the driver; only a resolvable, different commit does.
+    if run_state == "unknown":
+        return {"name": name, "status": "ok",
+                "detail": (f"could not identify the driver stamp {running} (ambiguous prefix or git "
+                           f"unavailable) — INCONCLUSIVE, not asserting drift or a re-arm")}
+    same = run_oid == head_oid
     if same:
         return {"name": name, "status": "ok",
                 "detail": f"content-driver running {running}, matches skills HEAD ({head})"}

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -3207,8 +3207,19 @@ def check_skills_driver_code_drift(workspace: "Path | None" = None) -> dict:
         return {"name": name, "status": "ok", "detail": "no stamp recorded yet — driver has not logged a version"}
     if not head:
         return {"name": name, "status": "ok", "detail": "could not read skills HEAD — not asserting drift"}
-    if running == head:
-        return {"name": name, "status": "ok", "detail": f"content-driver running {running}, matches skills HEAD"}
+    # Two writers, two spellings: the driver stamps its own prefix and `--short`
+    # grows to stay unambiguous, so equal commits compare unequal as strings.
+    try:
+        rp = subprocess.run(git_argv("-C", str(skills), "rev-parse", f"{running}^{{commit}}", "HEAD^{commit}"),
+                            capture_output=True, text=True, timeout=10)
+        full = rp.stdout.split() if rp.returncode == 0 else []
+    except Exception:
+        full = []
+    # String equality stays as the fallback for when rev-parse cannot answer.
+    same = running == head or (len(full) == 2 and full[0] == full[1])
+    if same:
+        return {"name": name, "status": "ok",
+                "detail": f"content-driver running {running}, matches skills HEAD ({head})"}
     return {"name": name, "status": "warn",
             "detail": (f"content-driver is running {running} but skills HEAD is {head} — the pull did not reach "
                        f"the process, which froze its code at launch. Merged skill fixes are NOT in effect. "

--- a/tests/health-check-skills-driver-drift.test.py
+++ b/tests/health-check-skills-driver-drift.test.py
@@ -328,6 +328,26 @@ def main() -> int:
             check("Re-arm" not in r["detail"],
                   f"m) and it does not advise a re-arm, got {r['detail']}")
 
+    # n) HEAD that ABBREVIATES but will not RESOLVE: `--short` reads the ref,
+    #    `--verify` needs the object, so an unreadable one separates the two.
+    with tempfile.TemporaryDirectory() as td:
+        ws, head = _mk_ws(td, log_lines=["placeholder"])
+        sk = ws / "skill-repos" / "sutando-skills"
+        full = _git(sk, "rev-parse", "HEAD")
+        (ws / "state" / "content-driver.log").write_text(f"[v=e1e1f151715f@{head}] driver started\n")
+        loose = sk / ".git" / "objects" / full[:2] / full[2:]
+        check(loose.is_file(), "n) fixture precondition: HEAD's commit is a loose object")
+        if loose.is_file():
+            loose.chmod(0o000)
+            try:
+                r = hc.check_skills_driver_code_drift(ws)
+            finally:
+                loose.chmod(0o444)
+            check(r["status"] == "ok" and "HEAD in the skills checkout is" in r["detail"],
+                  f"n) an unresolvable HEAD is unanswerable, not drift, got {r}")
+            check("Re-arm" not in r["detail"],
+                  f"n) and it advises no re-arm, got {r['detail']}")
+
     print()
     if FAILS:
         print(f"{len(FAILS)} FAILED")

--- a/tests/health-check-skills-driver-drift.test.py
+++ b/tests/health-check-skills-driver-drift.test.py
@@ -348,6 +348,32 @@ def main() -> int:
             check("Re-arm" not in r["detail"],
                   f"n) and it advises no re-arm, got {r['detail']}")
 
+    # o) an unreadable OBJECT DIRECTORY: --verify fails and --disambiguate exits
+    #    ZERO with empty stdout, which reads as "no such object" unless stderr is read.
+    with tempfile.TemporaryDirectory() as td:
+        ws, head = _mk_ws(td, log_lines=["placeholder"])
+        sk = ws / "skill-repos" / "sutando-skills"
+        full = _git(sk, "rev-parse", "HEAD")
+        (sk / "f.txt").write_text("second\n")
+        _git(sk, "add", "f.txt"); _git(sk, "commit", "-q", "-m", "second")
+        (ws / "state" / "content-driver.log").write_text(
+            f"[v=e1e1f151715f@{full[:7]}] driver started\n")
+        objdir = sk / ".git" / "objects" / full[:2]
+        check(objdir.is_dir(), "o) fixture precondition: the stamped object has its own dir")
+        if objdir.is_dir():
+            objdir.chmod(0o000)
+            try:
+                dis = _git(sk, "rev-parse", f"--disambiguate={full[:7]}", check=False)
+                check("Permission denied" in dis or dis == "",
+                      f"o) fixture precondition: git cannot read the object dir, got {dis[:60]!r}")
+                r = hc.check_skills_driver_code_drift(ws)
+            finally:
+                objdir.chmod(0o755)
+            check(r["status"] == "ok" and "INCONCLUSIVE" in r["detail"],
+                  f"o) an unreadable object DIR is INCONCLUSIVE, not absent, got {r}")
+            check("Re-arm" not in r["detail"],
+                  f"o) and it advises no re-arm, got {r['detail']}")
+
     print()
     if FAILS:
         print(f"{len(FAILS)} FAILED")

--- a/tests/health-check-skills-driver-drift.test.py
+++ b/tests/health-check-skills-driver-drift.test.py
@@ -49,9 +49,10 @@ def check(cond: bool, msg: str) -> None:
         FAILS.append(msg)
 
 
-def _git(repo: Path, *args: str) -> str:
-    return subprocess.run(["git", "-C", str(repo), *args], check=True,
-                          capture_output=True, text=True).stdout.strip()
+def _git(repo: Path, *args: str, check: bool = True) -> str:
+    r = subprocess.run(["git", "-C", str(repo), *args], check=check,
+                       capture_output=True, text=True)
+    return (r.stdout + r.stderr).strip() if not check else r.stdout.strip()
 
 
 def _mk_ws(td: str, *, skills: bool = True, log_lines: list[str] | None = None) -> tuple[Path, str]:
@@ -297,6 +298,35 @@ def main() -> int:
               f"l) an unrunnable stamp lookup is INCONCLUSIVE, got {r}")
         check("Re-arm" not in r["detail"],
               f"l) and it does not advise a re-arm, got {r['detail']}")
+
+    # m) an UNREADABLE object is present-but-unresolvable, not absent. HEAD is a
+    #    SECOND commit and stays readable, so only the stamp lookup fails.
+    with tempfile.TemporaryDirectory() as td:
+        ws, _h = _mk_ws(td, log_lines=["placeholder"])
+        sk = ws / "skill-repos" / "sutando-skills"
+        stamp_full = _git(sk, "rev-parse", "HEAD")
+        (sk / "f.txt").write_text("second\n")
+        _git(sk, "add", "f.txt"); _git(sk, "commit", "-q", "-m", "second")
+        (ws / "state" / "content-driver.log").write_text(
+            f"[v=e1e1f151715f@{stamp_full[:7]}] driver started\n")
+        loose = sk / ".git" / "objects" / stamp_full[:2] / stamp_full[2:]
+        check(loose.is_file(), "m) fixture precondition: the stamped commit is a loose object")
+        if loose.is_file():
+            r_before = hc.check_skills_driver_code_drift(ws)
+            check(r_before["status"] == "warn",
+                  f"m) control: a readable OLDER commit does warn, got {r_before}")
+            loose.chmod(0o000)
+            try:
+                probe = _git(sk, "rev-parse", "--verify", f"{stamp_full[:7]}^{{commit}}", check=False)
+                check("Permission denied" in probe,
+                      f"m) fixture precondition: git cannot read it, got {probe[:60]!r}")
+                r = hc.check_skills_driver_code_drift(ws)
+            finally:
+                loose.chmod(0o444)
+            check(r["status"] == "ok" and "INCONCLUSIVE" in r["detail"],
+                  f"m) an unreadable stamp is INCONCLUSIVE, not drift, got {r}")
+            check("Re-arm" not in r["detail"],
+                  f"m) and it does not advise a re-arm, got {r['detail']}")
 
     print()
     if FAILS:

--- a/tests/health-check-skills-driver-drift.test.py
+++ b/tests/health-check-skills-driver-drift.test.py
@@ -247,6 +247,57 @@ def main() -> int:
                   "h) inverting the `same` predicate breaks the healthy case "
                   f"(the comparison is exercised, not merely present), got {rm}")
 
+    # k) ambiguity is the property under test, not the prefix length — 4 chars
+    #    needs a few hundred objects and takes the identical code path.
+    with tempfile.TemporaryDirectory() as td:
+        ws, _h = _mk_ws(td, log_lines=["placeholder"])
+        sk = ws / "skill-repos" / "sutando-skills"
+        seen, prefix = {}, None
+        for i in range(4000):
+            oid = subprocess.run(["git", "-C", str(sk), "hash-object", "-w", "--stdin"],
+                                 input=f"blob{i}\n", capture_output=True, text=True,
+                                 check=True).stdout.strip()
+            if oid[:4] in seen and seen[oid[:4]] != oid:
+                prefix = oid[:4]
+                break
+            seen[oid[:4]] = oid
+        check(prefix is not None, "k) fixture precondition: two real objects share a prefix")
+        if prefix:
+            amb = subprocess.run(["git", "-C", str(sk), "rev-parse", "--verify", f"{prefix}^{{commit}}"],
+                                 capture_output=True, text=True)
+            check(amb.returncode != 0 and "ambiguous" in amb.stderr.lower(),
+                  f"k) fixture precondition: git calls {prefix!r} ambiguous, got {amb.stderr.strip()[:70]!r}")
+            (ws / "state" / "content-driver.log").write_text(f"[v=e1e1f151715f@{prefix}] driver started\n")
+            r = hc.check_skills_driver_code_drift(ws)
+            check(r["status"] == "ok" and "INCONCLUSIVE" in r["detail"],
+                  f"k) an ambiguous stamp is INCONCLUSIVE, got {r}")
+            check("Re-arm" not in r["detail"],
+                  f"k) and it does not advise a re-arm, got {r['detail']}")
+
+    # l) the stamp is the THIRD git call; killing an earlier one tests the
+    #    HEAD branch instead, which is a different arm.
+    with tempfile.TemporaryDirectory() as td:
+        ws, head = _mk_ws(td, log_lines=["placeholder"])
+        (ws / "state" / "content-driver.log").write_text(f"[v=e1e1f151715f@{head}] driver started\n")
+        real_run, calls = subprocess.run, {"n": 0}
+
+        def flaky(*a, **k):
+            calls["n"] += 1
+            argv = a[0] if a else k.get("args", [])
+            if "--verify" in argv and head in " ".join(argv):
+                raise subprocess.TimeoutExpired(["git"], 10)
+            return real_run(*a, **k)
+
+        hc.subprocess.run = flaky
+        try:
+            r = hc.check_skills_driver_code_drift(ws)
+        finally:
+            hc.subprocess.run = real_run
+        check(r["status"] == "ok" and "INCONCLUSIVE" in r["detail"],
+              f"l) an unrunnable stamp lookup is INCONCLUSIVE, got {r}")
+        check("Re-arm" not in r["detail"],
+              f"l) and it does not advise a re-arm, got {r['detail']}")
+
     print()
     if FAILS:
         print(f"{len(FAILS)} FAILED")

--- a/tests/health-check-skills-driver-drift.test.py
+++ b/tests/health-check-skills-driver-drift.test.py
@@ -21,7 +21,7 @@ Covers:
   j) real-Git control: the probe's git argv is never a bare "git"
   j2) absent-CLT control: no runnable git -> ok degrade
   h) POSITIVE CONTROL + MUTATION: the equality test is exercised, not just
-     read. Inverting `running == head` in the source must break arm (a) —
+     read. Inverting the `same` predicate in the source must break arm (a) —
      without this, deleting the comparison passes every other arm.
 
 Run: python3 tests/health-check-skills-driver-drift.test.py
@@ -85,6 +85,37 @@ def main() -> int:
         r = hc.check_skills_driver_code_drift(ws)
         check(r["status"] == "ok" and head in r["detail"],
               f"a) stamp matches skills HEAD -> ok naming it, got {r}")
+
+    # a2) one commit, two abbreviation lengths: the driver writes its own prefix
+    #     and `--short` grows, so `==` called this drift and demanded a re-arm.
+    with tempfile.TemporaryDirectory() as td:
+        ws, head = _mk_ws(td, log_lines=["placeholder"])
+        sk = ws / "skill-repos" / "sutando-skills"
+        stamped = _git(sk, "rev-parse", "--short=9", "HEAD")
+        # The stamp must differ in LENGTH from `--short HEAD`, or the string
+        # compare already agrees and this arm passes against the unfixed probe.
+        check(stamped != head and stamped.startswith(head),
+              f"a2) fixture precondition: stamp is a longer spelling of head, got {stamped!r} vs {head!r}")
+        (ws / "state" / "content-driver.log").write_text(f"[v=e1e1f151715f@{stamped}] driver started\n")
+        r = hc.check_skills_driver_code_drift(ws)
+        check(r["status"] == "ok",
+              f"a2) another spelling of HEAD is NOT drift, got {r}")
+        check(stamped in r["detail"],
+              f"a2) the ok still names what the driver stamped, got {r['detail']}")
+
+    # a3) control for a2: a real other commit at the SAME short length must
+    #     still warn, so a2 cannot be satisfied by never warning.
+    with tempfile.TemporaryDirectory() as td:
+        ws, head = _mk_ws(td, log_lines=["placeholder"])
+        sk = ws / "skill-repos" / "sutando-skills"
+        (sk / "f.txt").write_text("y\n")
+        _git(sk, "add", "f.txt")
+        _git(sk, "commit", "-q", "-m", "second")
+        stale = _git(sk, "rev-parse", "--short=7", "HEAD~1")
+        (ws / "state" / "content-driver.log").write_text(f"[v=e1e1f151715f@{stale}] driver started\n")
+        r = hc.check_skills_driver_code_drift(ws)
+        check(r["status"] == "warn",
+              f"a3) a genuinely older commit still warns, got {r}")
 
     # b) the case the probe exists for.
     with tempfile.TemporaryDirectory() as td:
@@ -198,12 +229,12 @@ def main() -> int:
     # h) POSITIVE CONTROL + MUTATION. Arm (a) must depend on the equality test.
     #    Invert it in the source, load THAT, and prove the healthy case breaks.
     src = HC_SRC.read_text()
-    target = "    if running == head:"
+    target = "    if same:"
     check(src.count(target) == 1,
           "h) the mutated predicate is present exactly once (update the arm if it moved)")
     if src.count(target) == 1:
         with tempfile.TemporaryDirectory() as td:
-            mutated = src.replace(target, "    if running != head:", 1)
+            mutated = src.replace(target, "    if not same:", 1)
             mpath = Path(td) / "hc_mutant.py"
             mpath.write_text(mutated)
             mspec = importlib.util.spec_from_file_location("hc_mut", mpath)
@@ -213,7 +244,7 @@ def main() -> int:
             (ws / "state" / "content-driver.log").write_text(f"[v=e1e1f151715f@{head}] x\n")
             rm = mhc.check_skills_driver_code_drift(ws)
             check(rm["status"] != "ok",
-                  "h) inverting `running == head` breaks the healthy case "
+                  "h) inverting the `same` predicate breaks the healthy case "
                   f"(the comparison is exercised, not merely present), got {rm}")
 
     print()


### PR DESCRIPTION
## The defect

`skills-driver-code-drift` decides whether the content driver is running stale code by comparing two abbreviated SHAs with `==`:

```python
running = _re.findall(r"v=[0-9a-f]+@([0-9a-f]+)", log.read_text(...))[-1]   # the driver's own prefix
head    = git rev-parse --short HEAD                                        # git's, adaptive length
if running == head: ok
```

Those abbreviations come from **different writers with different rules**. The driver stamps its prefix once at launch; `--short` grows whenever 7 characters stop being unambiguous in the repo. Once the lengths diverge the strings can never match, and the probe reports drift for a driver that is already on HEAD.

## Observed, on this host

```
driver stamp          v=89edfce4f628@22ada4a      (7)
git rev-parse --short 22ada4a9                    (8)

git rev-parse 22ada4a   -> 22ada4a96606120146635140fd63c9b99a120a81
git rev-parse 22ada4a9  -> 22ada4a96606120146635140fd63c9b99a120a81   ← same commit
```

The warning told the operator to `TaskStop + Monitor` the driver and confirm the stamp moves to `22ada4a9`. Re-arming would have changed nothing, and the stamp cannot move to `22ada4a9` because the driver writes 7 characters.

**A false warn is worse than a missing one here.** It is permanent, its remedy is a no-op, and it occupies the line that a real drift would have to appear on — so the reader learns to skip exactly that line.

## The change

One `rev-parse` resolves both spellings; commits are compared instead of strings. String equality is kept as the fallback for when `rev-parse` cannot answer, and both arms collapse into a single `same` predicate — one decision to mutate, rather than two routes to the same verdict.

## Evidence

Before and after, against this host's real log and checkout:

```
main       warn   content-driver is running 22ada4a but skills HEAD is 22ada4a9 — the pull did not reach…
branch     ok     content-driver running 22ada4a, matches skills HEAD (22ada4a9)
```

The suite gains `a2` (a differing-length spelling of HEAD is not drift) and `a3` (its control: a genuinely older commit still warns, so `a2` cannot be satisfied by never warning).

**`a2` is pinned to fail without the fix**, and this took two attempts worth reporting: my first version stamped `--short=7` while the fixture's `--short HEAD` was also 7, so the strings already matched and the arm passed against unfixed code — it asserted nothing. The fixture now stamps a *longer* spelling, and the precondition check makes that explicit rather than incidental.

```
with the fix       all ok
without the fix    FAIL a2) another spelling of HEAD is NOT drift  → status 'warn'
```

`h)` is the existing mutation arm; its target moved from `running == head` to `same` (the suite anticipates this: *"update the arm if it moved"*), and inverting the new predicate still breaks the healthy case.

Nine neighbouring `health-check-*` suites run from this branch and from `main` — each tree executing its own copy — are PASS/PASS. CI on this repo is billing-blocked account-wide, so checks will not go green here; the above is the local run. `review-checks.sh` passes (the pre-push hook blocked an earlier revision over the 2-line comment cap; fixed, not skipped).

Stand: Echo Act IV Mini
