### PR TITLE
feat(health-check): preserved peer content nobody merged back is a warning

### DIFF
--- a/src/health-check.py
+++ b/src/health-check.py
@@ -3174,6 +3174,54 @@ def _commits_behind(repo: "Path", branch: str, git_bin: str = "git") -> "int | N
     return int(raw) if raw.isdigit() else None
 
 
+def check_sync_conflicts_unmerged(workspace: "Path | None" = None,
+                                  repo_root: "Path | None" = None,
+                                  run=None) -> dict:
+    """Peer content the sync preserved and nobody merged back.
+
+    `_resolve_conflicts_keep_ours` keeps OUR side and banks THEIRS under the
+    git dir, then reports the total. That report rides `sync-workspace.sh`'s
+    stdout at exit 0, and the cron that runs it is told to speak only on
+    failure -- so a true count lands where nothing reads it. Measured
+    2026-09-12: two hosts, 18 and 21 files, both agents read past the line in
+    the same hour while quoting other rows from the same output.
+
+    A count is not a sync failure, so this never fails: it warns, on a surface
+    that is read every pass. Same trade as `comm-sweep.sh stamp`, which warns
+    rather than refusing because refusing turns a quiet record problem into a
+    loud false one.
+    """
+    name = "sync-conflicts-unmerged"
+    ws = workspace or resolve_workspace()
+    repo = Path(repo_root) if repo_root else REPO_DIR
+    script = Path(repo) / "scripts" / "sync-conflicts-report.py"
+    if not script.is_file():
+        return {"name": name, "status": "ok",
+                "detail": "no sync-conflicts-report.py in this checkout — nothing to read"}
+    runner = run or subprocess.run
+    try:
+        r = runner([sys.executable, str(script), str(ws)],
+                   capture_output=True, text=True, timeout=60)
+    except Exception as exc:
+        return {"name": name, "status": "ok",
+                "detail": f"could not run the conflicts report ({type(exc).__name__}) — not asserting a count"}
+    out = (r.stdout or "") + (r.stderr or "")
+    if "no unmerged peer content" in out:
+        return {"name": name, "status": "ok", "detail": "no preserved peer content awaiting a merge"}
+    m = re.search(r"(\d+) file\(s\) hold peer content not in the live copy", out)
+    if not m:
+        # A shape this probe cannot parse is unobserved, never zero.
+        return {"name": name, "status": "ok",
+                "detail": "conflicts report produced no count this probe recognises — not asserting a count"}
+    n = int(m.group(1))
+    if n == 0:
+        return {"name": name, "status": "ok", "detail": "no preserved peer content awaiting a merge"}
+    return {"name": name, "status": "warn",
+            "detail": (f"{n} file(s) hold peer content the sync preserved and nothing merged back — "
+                       f"`python3 scripts/sync-conflicts-report.py \"{ws}\"` lists them with their "
+                       f"backup batch; keep-ours banked them at exit 0 and the sync cron reports only failures")}
+
+
 def check_skills_driver_code_drift(workspace: "Path | None" = None) -> dict:
     """Warn when a long-running skills process is executing code older than disk.
 
@@ -12516,6 +12564,7 @@ def run_all_checks() -> list[dict]:
     # Live checkout on its expected branch (PR-branch drift, 2026-07-29 incident)
     checks.append(check_live_checkout_branch())
     checks.append(check_skills_driver_code_drift())
+    checks.append(check_sync_conflicts_unmerged())
     checks.append(check_engine_revision_drift())
     onboarding_check = check_onboarding_status()
     if onboarding_check is not None:

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -3175,51 +3175,49 @@ def _commits_behind(repo: "Path", branch: str, git_bin: str = "git") -> "int | N
 
 
 def check_sync_conflicts_unmerged(workspace: "Path | None" = None,
-                                  repo_root: "Path | None" = None,
-                                  run=None) -> dict:
+                                  repo_root: "Path | None" = None) -> dict:
     """Peer content the sync preserved and nobody merged back.
 
-    `_resolve_conflicts_keep_ours` keeps OUR side and banks THEIRS under the
-    git dir, then reports the total. That report rides `sync-workspace.sh`'s
-    stdout at exit 0, and the cron that runs it is told to speak only on
-    failure -- so a true count lands where nothing reads it. Measured
-    2026-09-12: two hosts, 18 and 21 files, both agents read past the line in
-    the same hour while quoting other rows from the same output.
+    `_resolve_conflicts_keep_ours` keeps OUR side on a conflict and banks THEIRS
+    under the git dir. That happens at exit 0, and the sync cron is told to speak
+    only on failure, so the fact lands where nothing reads it. Measured on two
+    hosts the same hour: both agents read past the line while quoting other rows.
 
-    A count is not a sync failure, so this never fails: it warns, on a surface
-    that is read every pass. Same trade as `comm-sweep.sh stamp`, which warns
-    rather than refusing because refusing turns a quiet record problem into a
-    loud false one.
+    Counts the preserved files; it does NOT diff them against the live copy.
+    That diff is what `scripts/sync-conflicts-report.py` does and it costs 24s
+    over 892 MB here and over 120s on a peer -- a per-pass probe cannot run it,
+    and a probe whose only reachable arm is its timeout prints a tick forever.
     """
     name = "sync-conflicts-unmerged"
-    ws = workspace or resolve_workspace()
-    repo = Path(repo_root) if repo_root else REPO_DIR
-    script = Path(repo) / "scripts" / "sync-conflicts-report.py"
-    if not script.is_file():
-        return {"name": name, "status": "ok",
-                "detail": "no sync-conflicts-report.py in this checkout — nothing to read"}
-    runner = run or subprocess.run
+    ws = Path(workspace) if workspace else resolve_workspace()
     try:
-        r = runner([sys.executable, str(script), str(ws)],
-                   capture_output=True, text=True, timeout=60)
+        r = subprocess.run(git_argv("-C", str(ws), "rev-parse", "--git-dir"),
+                           capture_output=True, text=True, timeout=10)
+        if r.returncode != 0 or not r.stdout.strip():
+            return {"name": name, "status": "ok",
+                    "detail": f"{ws} is not a git checkout — no conflict backups to read"}
+        gitdir = Path(r.stdout.strip())
+        if not gitdir.is_absolute():
+            gitdir = ws / gitdir
     except Exception as exc:
         return {"name": name, "status": "ok",
-                "detail": f"could not run the conflicts report ({type(exc).__name__}) — not asserting a count"}
-    out = (r.stdout or "") + (r.stderr or "")
-    if "no unmerged peer content" in out:
-        return {"name": name, "status": "ok", "detail": "no preserved peer content awaiting a merge"}
-    m = re.search(r"(\d+) file\(s\) hold peer content not in the live copy", out)
-    if not m:
-        # A shape this probe cannot parse is unobserved, never zero.
+                "detail": f"could not resolve the vault git dir ({type(exc).__name__}) — not asserting a count"}
+    root = gitdir / "sutando-sync-conflicts"
+    if not root.is_dir():
+        return {"name": name, "status": "ok", "detail": "no conflict backups — keep-ours has discarded nothing"}
+    try:
+        batches = sorted(d for d in root.iterdir() if d.is_dir())
+        files = [f for d in batches for f in d.rglob("*") if f.is_file()]
+    except OSError as exc:
         return {"name": name, "status": "ok",
-                "detail": "conflicts report produced no count this probe recognises — not asserting a count"}
-    n = int(m.group(1))
-    if n == 0:
-        return {"name": name, "status": "ok", "detail": "no preserved peer content awaiting a merge"}
+                "detail": f"could not read {root} ({exc.__class__.__name__}) — not asserting a count"}
+    if not files:
+        return {"name": name, "status": "ok", "detail": "no preserved peer files awaiting a merge"}
+    oldest = batches[0].name if batches else "?"
     return {"name": name, "status": "warn",
-            "detail": (f"{n} file(s) hold peer content the sync preserved and nothing merged back — "
-                       f"`python3 scripts/sync-conflicts-report.py \"{ws}\"` lists them with their "
-                       f"backup batch; keep-ours banked them at exit 0 and the sync cron reports only failures")}
+            "detail": (f"{len(files)} peer file(s) preserved across {len(batches)} keep-ours batch(es), "
+                       f"oldest {oldest}, none merged back — some hold content absent from the live copy; "
+                       f"`python3 scripts/sync-conflicts-report.py \"{ws}\"` says which")}
 
 
 def check_skills_driver_code_drift(workspace: "Path | None" = None) -> dict:

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -3217,21 +3217,56 @@ def check_sync_conflicts_unmerged(workspace: "Path | None" = None,
     except OSError as exc:
         return {"name": name, "status": "ok",
                 "detail": f"could not read {root} ({exc.__class__.__name__}) — not asserting a count"}
-    # Retired was ruled on. The writer keys each copy `<batch>/<rel>@<digest>`;
-    # one (batch, rel) has one digest, so the prefix is exact and needs no re-hash.
+    # The digest is IN the writer's key so retiring one copy cannot silence a
+    # later, DIFFERENT one at the same path; the reporter owns that identity.
     try:
-        retired = {str(k).rsplit("@", 1)[0] for k in json.loads((root / ".retired.json").read_text())}
+        retired = set(json.loads((root / ".retired.json").read_text()))
     except Exception:
         retired = set()
-    live = [f for f in files if str(f.relative_to(root)) not in retired]
-    if not live:
+    entry_key = _sync_conflicts_entry_key()
+    if entry_key is None:
+        return {"name": name, "status": "warn",
+                "detail": (f"{len(files)} peer file(s) preserved across {len(batches)} keep-ours "
+                           "batch(es); the reporter's retirement key could not be loaded, so "
+                           "retirement is UNOBSERVED here rather than assumed — run "
+                           f"`python3 scripts/sync-conflicts-report.py \"{ws}\"`")}
+    live, unobserved = [], []
+    for batch in batches:
+        for f in sorted(x for x in batch.rglob("*") if x.is_file()):
+            try:
+                # errors="replace" matches the writer: a different decode is a
+                # different digest, and every copy would then read un-retired.
+                key = entry_key(batch.name, f.relative_to(batch), f.read_text(errors="replace"))
+            except OSError:
+                unobserved.append(f)
+                continue
+            if key not in retired:
+                live.append(f)
+    if not live and not unobserved:
         return {"name": name, "status": "ok",
                 "detail": "no preserved peer files outstanding — all retired or none kept"}
+    if not live:
+        return {"name": name, "status": "warn",
+                "detail": (f"{len(unobserved)} preserved peer file(s) could not be read, so their "
+                           "retirement is UNOBSERVED — not asserting they are retired")}
     oldest = batches[0].name if batches else "?"
     return {"name": name, "status": "warn",
             "detail": (f"{len(live)} peer file(s) preserved across {len(batches)} keep-ours batch(es), "
                        f"oldest {oldest}, not retired — whether each is still absent from the live copy "
                        f"is what `python3 scripts/sync-conflicts-report.py \"{ws}\"` computes")}
+
+
+def _sync_conflicts_entry_key():
+    """The reporter OWNS retirement identity; a second spelling here would drift."""
+    import importlib.util
+    path = Path(__file__).resolve().parents[1] / "scripts" / "sync-conflicts-report.py"
+    try:
+        spec = importlib.util.spec_from_file_location("_sync_conflicts_report", path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod._entry_key
+    except Exception:
+        return None
 
 
 def check_skills_driver_code_drift(workspace: "Path | None" = None) -> dict:

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -3217,13 +3217,13 @@ def check_sync_conflicts_unmerged(workspace: "Path | None" = None,
     except OSError as exc:
         return {"name": name, "status": "ok",
                 "detail": f"could not read {root} ({exc.__class__.__name__}) — not asserting a count"}
-    # Retired entries were ruled on; counting them re-raises a settled question.
+    # Retired was ruled on. The writer keys each copy `<batch>/<rel>@<digest>`;
+    # one (batch, rel) has one digest, so the prefix is exact and needs no re-hash.
     try:
-        retired = set(json.loads((root / ".retired.json").read_text()))
+        retired = {str(k).rsplit("@", 1)[0] for k in json.loads((root / ".retired.json").read_text())}
     except Exception:
         retired = set()
-    live = [f for f in files if f"{f.parent.parent.name}/{f.name}" not in retired
-            and str(f.relative_to(root)) not in retired]
+    live = [f for f in files if str(f.relative_to(root)) not in retired]
     if not live:
         return {"name": name, "status": "ok",
                 "detail": "no preserved peer files outstanding — all retired or none kept"}

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -3191,14 +3191,20 @@ def check_sync_conflicts_unmerged(workspace: "Path | None" = None,
     name = "sync-conflicts-unmerged"
     ws = Path(workspace) if workspace else resolve_workspace()
     try:
-        r = subprocess.run(git_argv("-C", str(ws), "rev-parse", "--git-dir"),
+        # `rev-parse` SEARCHES ANCESTORS, so a non-repo workspace answers about
+        # its parent; require the toplevel to BE the workspace, as the reporter does.
+        r = subprocess.run(git_argv("-C", str(ws), "rev-parse", "--show-toplevel", "--git-dir"),
                            capture_output=True, text=True, timeout=10)
-        if r.returncode != 0 or not r.stdout.strip():
+        lines = r.stdout.strip().splitlines()
+        if r.returncode != 0 or len(lines) < 2:
             return {"name": name, "status": "ok",
                     "detail": f"{ws} is not a git checkout — no conflict backups to read"}
-        gitdir = Path(r.stdout.strip())
+        if Path(lines[0]).resolve() != Path(ws).resolve():
+            return {"name": name, "status": "ok",
+                    "detail": f"{ws} is not a git top level (git resolved {lines[0]}) — not asserting a count"}
+        gitdir = Path(lines[1])
         if not gitdir.is_absolute():
-            gitdir = ws / gitdir
+            gitdir = Path(ws) / gitdir
     except Exception as exc:
         return {"name": name, "status": "ok",
                 "detail": f"could not resolve the vault git dir ({type(exc).__name__}) — not asserting a count"}
@@ -3211,13 +3217,21 @@ def check_sync_conflicts_unmerged(workspace: "Path | None" = None,
     except OSError as exc:
         return {"name": name, "status": "ok",
                 "detail": f"could not read {root} ({exc.__class__.__name__}) — not asserting a count"}
-    if not files:
-        return {"name": name, "status": "ok", "detail": "no preserved peer files awaiting a merge"}
+    # Retired entries were ruled on; counting them re-raises a settled question.
+    try:
+        retired = set(json.loads((root / ".retired.json").read_text()))
+    except Exception:
+        retired = set()
+    live = [f for f in files if f"{f.parent.parent.name}/{f.name}" not in retired
+            and str(f.relative_to(root)) not in retired]
+    if not live:
+        return {"name": name, "status": "ok",
+                "detail": "no preserved peer files outstanding — all retired or none kept"}
     oldest = batches[0].name if batches else "?"
     return {"name": name, "status": "warn",
-            "detail": (f"{len(files)} peer file(s) preserved across {len(batches)} keep-ours batch(es), "
-                       f"oldest {oldest}, none merged back — some hold content absent from the live copy; "
-                       f"`python3 scripts/sync-conflicts-report.py \"{ws}\"` says which")}
+            "detail": (f"{len(live)} peer file(s) preserved across {len(batches)} keep-ours batch(es), "
+                       f"oldest {oldest}, not retired — whether each is still absent from the live copy "
+                       f"is what `python3 scripts/sync-conflicts-report.py \"{ws}\"` computes")}
 
 
 def check_skills_driver_code_drift(workspace: "Path | None" = None) -> dict:

--- a/tests/health-check-sync-conflicts-unmerged.test.py
+++ b/tests/health-check-sync-conflicts-unmerged.test.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
-"""`sync-conflicts-unmerged` warns on preserved peer content nobody merged back.
+"""`sync-conflicts-unmerged` warns on peer content keep-ours preserved.
 
-The count already exists: `sync-workspace.sh` prints it at exit 0, and the cron
-running it is told to report only failures, so the number lands where nothing
-reads it. This probe moves it to a surface that is read every pass. It never
-fails — a count is not a sync failure, and an alarm that cries is the first one
-silenced.
+Every arm builds a REAL vault (git init + real backup directories) and calls the
+probe with no injection. An earlier revision passed a fake runner into all eight
+arms, so none executed the code the defect lived in — the probe's only reachable
+arm on real data was its subprocess timeout, and the suite could not see it.
 """
 from __future__ import annotations
 
@@ -25,59 +24,64 @@ try:
 except SystemExit:
     pass
 
-COUNT = "sync-conflicts: {n} file(s) hold peer content not in the live copy"
 
-
-def _run_returning(stdout: str, rc: int = 0):
-    def _run(*a, **k):
-        return subprocess.CompletedProcess(a[0] if a else [], rc, stdout, "")
-    return _run
+def _vault(td: str, batches: dict[str, list[str]] | None = None) -> Path:
+    """A real git checkout, optionally with real keep-ours backup batches."""
+    ws = Path(td) / "vault"
+    ws.mkdir(parents=True)
+    subprocess.run(["git", "-C", str(ws), "init", "-q", "-b", "main"], check=True)
+    for batch, rels in (batches or {}).items():
+        for rel in rels:
+            f = ws / ".git" / "sutando-sync-conflicts" / batch / rel
+            f.parent.mkdir(parents=True, exist_ok=True)
+            f.write_text("peer content\n")
+    return ws
 
 
 class SyncConflictsUnmerged(unittest.TestCase):
-    def _probe(self, stdout=None, run=None, repo=None):
+    def test_preserved_files_warn_and_name_the_counts_and_oldest_batch(self):
         with tempfile.TemporaryDirectory() as td:
-            return hc.check_sync_conflicts_unmerged(
-                Path(td), repo_root=repo or REPO,
-                run=run if run is not None else _run_returning(stdout or ""))
-
-    def test_a_nonzero_count_warns_and_names_the_number(self):
-        r = self._probe(COUNT.format(n=21))
+            ws = _vault(td, {
+                "20260802T000000Z-origin_host_A": ["memory/MEMORY.md", "notes/x.md"],
+                "20260903T000000Z-origin_host_B": ["memory/y.md"],
+            })
+            r = hc.check_sync_conflicts_unmerged(ws)
         self.assertEqual(r["status"], "warn", r)
-        self.assertIn("21", r["detail"])
+        self.assertIn("3 peer file(s)", r["detail"])
+        self.assertIn("2 keep-ours batch(es)", r["detail"])
+        self.assertIn("20260802T000000Z-origin_host_A", r["detail"])   # oldest, not newest
         self.assertIn("sync-conflicts-report.py", r["detail"])
 
-    def test_the_clean_case_is_ok(self):
-        self.assertEqual(self._probe("sync-conflicts: no unmerged peer content")["status"], "ok")
-
-    def test_an_explicit_zero_is_ok(self):
-        self.assertEqual(self._probe(COUNT.format(n=0))["status"], "ok")
-
-    def test_an_unparseable_report_is_unobserved_never_zero(self):
-        r = self._probe("sync-conflicts: some future wording")
-        self.assertEqual(r["status"], "ok", r)
-        self.assertIn("not asserting a count", r["detail"])
-
-    def test_a_reporter_that_cannot_run_never_fails_the_probe(self):
-        def boom(*a, **k):
-            raise subprocess.TimeoutExpired(["python3"], 60)
-        r = self._probe(run=boom)
-        self.assertEqual(r["status"], "ok", r)
-        self.assertIn("not asserting a count", r["detail"])
-
-    def test_a_checkout_without_the_reporter_is_ok(self):
+    def test_no_backup_root_is_ok(self):
         with tempfile.TemporaryDirectory() as td:
-            r = hc.check_sync_conflicts_unmerged(Path(td), repo_root=Path(td))
-            self.assertEqual(r["status"], "ok", r)
+            self.assertEqual(hc.check_sync_conflicts_unmerged(_vault(td))["status"], "ok")
 
-    def test_the_default_repo_root_resolves(self):
-        # Every arm above passes repo_root=, so the default branch was never
-        # exercised and shipped a NameError that only a full run caught.
+    def test_an_empty_backup_root_is_ok(self):
         with tempfile.TemporaryDirectory() as td:
-            r = hc.check_sync_conflicts_unmerged(Path(td), run=_run_returning(COUNT.format(n=2)))
+            ws = _vault(td)
+            (ws / ".git" / "sutando-sync-conflicts").mkdir(parents=True)
+            r = hc.check_sync_conflicts_unmerged(ws)
+        self.assertEqual(r["status"], "ok", r)
+
+    def test_a_non_git_workspace_is_ok(self):
+        with tempfile.TemporaryDirectory() as td:
+            plain = Path(td) / "plain"
+            plain.mkdir()
+            r = hc.check_sync_conflicts_unmerged(plain)
+        self.assertEqual(r["status"], "ok", r)
+
+    def test_it_does_not_diff_and_so_stays_fast_on_a_large_tree(self):
+        # The predecessor diffed contents: 24s over 892MB here, timing out on a
+        # peer, so its `except` arm was the only one real data reached.
+        with tempfile.TemporaryDirectory() as td:
+            ws = _vault(td, {"20260802T000000Z-origin_host_A": [f"n/{i}.md" for i in range(400)]})
+            import time
+            t0 = time.monotonic()
+            r = hc.check_sync_conflicts_unmerged(ws)
+            elapsed = time.monotonic() - t0
         self.assertEqual(r["status"], "warn", r)
-        self.assertIn("2", r["detail"])
-
+        self.assertIn("400 peer file(s)", r["detail"])
+        self.assertLess(elapsed, 5.0, f"probe took {elapsed:.1f}s on 400 files")
 
     def test_the_probe_is_registered_in_the_run(self):
         src = (REPO / "src" / "health-check.py").read_text()

--- a/tests/health-check-sync-conflicts-unmerged.test.py
+++ b/tests/health-check-sync-conflicts-unmerged.test.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""`sync-conflicts-unmerged` warns on preserved peer content nobody merged back.
+
+The count already exists: `sync-workspace.sh` prints it at exit 0, and the cron
+running it is told to report only failures, so the number lands where nothing
+reads it. This probe moves it to a surface that is read every pass. It never
+fails — a count is not a sync failure, and an alarm that cries is the first one
+silenced.
+"""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location("hc", REPO / "src" / "health-check.py")
+hc = importlib.util.module_from_spec(_spec)
+sys.modules["hc"] = hc
+try:
+    _spec.loader.exec_module(hc)
+except SystemExit:
+    pass
+
+COUNT = "sync-conflicts: {n} file(s) hold peer content not in the live copy"
+
+
+def _run_returning(stdout: str, rc: int = 0):
+    def _run(*a, **k):
+        return subprocess.CompletedProcess(a[0] if a else [], rc, stdout, "")
+    return _run
+
+
+class SyncConflictsUnmerged(unittest.TestCase):
+    def _probe(self, stdout=None, run=None, repo=None):
+        with tempfile.TemporaryDirectory() as td:
+            return hc.check_sync_conflicts_unmerged(
+                Path(td), repo_root=repo or REPO,
+                run=run if run is not None else _run_returning(stdout or ""))
+
+    def test_a_nonzero_count_warns_and_names_the_number(self):
+        r = self._probe(COUNT.format(n=21))
+        self.assertEqual(r["status"], "warn", r)
+        self.assertIn("21", r["detail"])
+        self.assertIn("sync-conflicts-report.py", r["detail"])
+
+    def test_the_clean_case_is_ok(self):
+        self.assertEqual(self._probe("sync-conflicts: no unmerged peer content")["status"], "ok")
+
+    def test_an_explicit_zero_is_ok(self):
+        self.assertEqual(self._probe(COUNT.format(n=0))["status"], "ok")
+
+    def test_an_unparseable_report_is_unobserved_never_zero(self):
+        r = self._probe("sync-conflicts: some future wording")
+        self.assertEqual(r["status"], "ok", r)
+        self.assertIn("not asserting a count", r["detail"])
+
+    def test_a_reporter_that_cannot_run_never_fails_the_probe(self):
+        def boom(*a, **k):
+            raise subprocess.TimeoutExpired(["python3"], 60)
+        r = self._probe(run=boom)
+        self.assertEqual(r["status"], "ok", r)
+        self.assertIn("not asserting a count", r["detail"])
+
+    def test_a_checkout_without_the_reporter_is_ok(self):
+        with tempfile.TemporaryDirectory() as td:
+            r = hc.check_sync_conflicts_unmerged(Path(td), repo_root=Path(td))
+            self.assertEqual(r["status"], "ok", r)
+
+    def test_the_default_repo_root_resolves(self):
+        # Every arm above passes repo_root=, so the default branch was never
+        # exercised and shipped a NameError that only a full run caught.
+        with tempfile.TemporaryDirectory() as td:
+            r = hc.check_sync_conflicts_unmerged(Path(td), run=_run_returning(COUNT.format(n=2)))
+        self.assertEqual(r["status"], "warn", r)
+        self.assertIn("2", r["detail"])
+
+
+    def test_the_probe_is_registered_in_the_run(self):
+        src = (REPO / "src" / "health-check.py").read_text()
+        self.assertEqual(src.count("checks.append(check_sync_conflicts_unmerged())"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)

--- a/tests/health-check-sync-conflicts-unmerged.test.py
+++ b/tests/health-check-sync-conflicts-unmerged.test.py
@@ -117,12 +117,26 @@ class SyncConflictsUnmerged(unittest.TestCase):
         self.assertIn("OSError", r["detail"])
 
     def test_a_retired_entry_is_not_counted_again(self):
-        # `--retire` is a ruling. Counting it re-raises a settled question.
+        """The ledger is written by the REPORTER, so the fixture runs it.
+
+        An earlier version fabricated a list of bare paths; the real writer
+        stores a dict keyed `<batch>/<rel>@<digest>`, so the test agreed with
+        the probe's wrong assumption instead of with the producer.
+        """
         with tempfile.TemporaryDirectory() as td:
             ws = _vault(td, {"20260802T000000Z-origin_host_A": ["memory/x.md"]})
-            root = ws / ".git" / "sutando-sync-conflicts"
-            (root / ".retired.json").write_text(
-                json.dumps(["20260802T000000Z-origin_host_A/memory/x.md"]))
+            reporter = REPO / "scripts" / "sync-conflicts-report.py"
+            before = hc.check_sync_conflicts_unmerged(ws)
+            self.assertEqual(before["status"], "warn", before)
+            rc = subprocess.run(
+                [sys.executable, str(reporter), str(ws), "--retire",
+                 "20260802T000000Z-origin_host_A/memory/x.md"],
+                capture_output=True, text=True)
+            ledger = ws / ".git" / "sutando-sync-conflicts" / ".retired.json"
+            self.assertTrue(ledger.is_file(), f"reporter wrote no ledger: {rc.stdout}{rc.stderr}")
+            keys = list(json.loads(ledger.read_text()))
+            self.assertTrue(any("@" in k for k in keys),
+                            f"fixture precondition: the real key carries a digest, got {keys}")
             r = hc.check_sync_conflicts_unmerged(ws)
         self.assertEqual(r["status"], "ok", r)
         self.assertIn("retired", r["detail"])

--- a/tests/health-check-sync-conflicts-unmerged.test.py
+++ b/tests/health-check-sync-conflicts-unmerged.test.py
@@ -83,6 +83,38 @@ class SyncConflictsUnmerged(unittest.TestCase):
         self.assertIn("400 peer file(s)", r["detail"])
         self.assertLess(elapsed, 5.0, f"probe took {elapsed:.1f}s on 400 files")
 
+    def test_an_unreadable_backup_root_is_unobserved_never_zero(self):
+        # Real permissions, real OSError: iterdir on a 000 directory.
+        with tempfile.TemporaryDirectory() as td:
+            ws = _vault(td, {"20260802T000000Z-origin_host_A": ["memory/x.md"]})
+            root = ws / ".git" / "sutando-sync-conflicts"
+            root.chmod(0o000)
+            try:
+                r = hc.check_sync_conflicts_unmerged(ws)
+            finally:
+                root.chmod(0o755)
+        self.assertEqual(r["status"], "ok", r)
+        self.assertIn("not asserting a count", r["detail"])
+
+    def test_a_git_call_that_raises_is_unobserved_never_zero(self):
+        # Real git ERRORS (non-zero) rather than raising, so the only way to
+        # reach this guard is to make the call itself throw.
+        with tempfile.TemporaryDirectory() as td:
+            ws = _vault(td, {"20260802T000000Z-origin_host_A": ["memory/x.md"]})
+            real = hc.subprocess.run
+
+            def boom(*a, **k):
+                raise OSError("git exploded")
+
+            hc.subprocess.run = boom
+            try:
+                r = hc.check_sync_conflicts_unmerged(ws)
+            finally:
+                hc.subprocess.run = real
+        self.assertEqual(r["status"], "ok", r)
+        self.assertIn("not asserting a count", r["detail"])
+        self.assertIn("OSError", r["detail"])
+
     def test_the_probe_is_registered_in_the_run(self):
         src = (REPO / "src" / "health-check.py").read_text()
         self.assertEqual(src.count("checks.append(check_sync_conflicts_unmerged())"), 1)

--- a/tests/health-check-sync-conflicts-unmerged.test.py
+++ b/tests/health-check-sync-conflicts-unmerged.test.py
@@ -167,5 +167,85 @@ class SyncConflictsUnmerged(unittest.TestCase):
         self.assertEqual(src.count("checks.append(check_sync_conflicts_unmerged())"), 1)
 
 
+
+
+class RetirementIdentityIsTheCopy(unittest.TestCase):
+    """Retirement identifies one preserved COPY, not a path.
+
+    The production backup writer can write a destination that already exists, so
+    the same path holds different content over time. Keying retirement on the
+    path alone makes the probe report a NEVER-retired copy as retired — and this
+    warning is the only notice that new peer content was preserved.
+    """
+
+    BATCH = "20260912T000000Z-batch"
+    REL = "notes/x.md"
+    ORIGINAL = "peer content that nobody merged back\n"
+    REPLACED = "DIFFERENT peer content that nobody retired\n"
+
+    def setUp(self):
+        self.td = tempfile.mkdtemp()
+        self.ws = _vault(self.td)
+        self.saved = (self.ws / ".git" / "sutando-sync-conflicts"
+                      / self.BATCH / self.REL)
+        self.saved.parent.mkdir(parents=True, exist_ok=True)
+        self.saved.write_text(self.ORIGINAL)
+
+    def reporter(self, *extra):
+        """The REAL CLI — a hand-written ledger would not prove the keys agree."""
+        return subprocess.run(
+            [sys.executable, str(REPO / "scripts" / "sync-conflicts-report.py"),
+             str(self.ws), *extra], capture_output=True, text=True).returncode
+
+    def retire(self):
+        rc = self.reporter("--retire", f"{self.BATCH}/{self.REL}")
+        self.assertEqual(rc, 0, "the real --retire CLI did not succeed")
+
+    def status(self):
+        return hc.check_sync_conflicts_unmerged(workspace=self.ws)["status"]
+
+    def test_the_probe_and_the_reporter_agree_before_any_retirement(self):
+        self.assertEqual((self.status(), self.reporter()), ("warn", 1))
+
+    def test_retiring_the_copy_clears_the_warning(self):
+        self.retire()
+        self.assertEqual((self.status(), self.reporter()), ("ok", 0))
+
+    def test_REACTIVATION_changed_content_at_a_retired_path_warns_again(self):
+        """The false clean: path-keyed retirement reports content nobody retired
+        as retired, silencing the only warning that it was preserved."""
+        self.retire()
+        self.saved.write_text(self.REPLACED)
+        self.assertEqual(
+            self.reporter(), 1, "fixture: the reporter must see the new bytes")
+        self.assertEqual(
+            self.status(), "warn",
+            "changed content at a retired path read as retired — the probe "
+            "cleared a warning about bytes nobody has ever retired")
+
+    def test_RESTORED_content_is_retired_again_without_a_second_retire(self):
+        """The other direction: identity is the bytes, so putting the retired
+        copy back must not need re-retiring. Without this arm the reactivation
+        arm could pass by never clearing again."""
+        self.retire()
+        self.saved.write_text(self.REPLACED)
+        self.saved.write_text(self.ORIGINAL)
+        self.assertEqual((self.status(), self.reporter()), ("ok", 0))
+
+    def test_an_unreadable_copy_is_UNOBSERVED_not_retired(self):
+        """Bounding the hash cost must not assert an unchecked copy is retired."""
+        self.retire()
+        self.saved.write_bytes(b"\xff\xfe raw bytes")
+        self.assertIn(self.status(), ("warn", "ok"))
+
+    def test_the_probe_does_not_respell_the_retirement_key(self):
+        src = (REPO / "src" / "health-check.py").read_text()
+        self.assertNotIn('rsplit("@"', src,
+                         "stripping the digest keys retirement on the path")
+        self.assertIn("_sync_conflicts_entry_key", src)
+        self.assertNotIn("sha256", src.split("def check_sync_conflicts_unmerged")[1][:2000],
+                         "a second digest spelling is how the two readers drift")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=1)

--- a/tests/health-check-sync-conflicts-unmerged.test.py
+++ b/tests/health-check-sync-conflicts-unmerged.test.py
@@ -9,6 +9,7 @@ arm on real data was its subprocess timeout, and the suite could not see it.
 from __future__ import annotations
 
 import importlib.util
+import json
 import subprocess
 import sys
 import tempfile
@@ -114,6 +115,38 @@ class SyncConflictsUnmerged(unittest.TestCase):
         self.assertEqual(r["status"], "ok", r)
         self.assertIn("not asserting a count", r["detail"])
         self.assertIn("OSError", r["detail"])
+
+    def test_a_retired_entry_is_not_counted_again(self):
+        # `--retire` is a ruling. Counting it re-raises a settled question.
+        with tempfile.TemporaryDirectory() as td:
+            ws = _vault(td, {"20260802T000000Z-origin_host_A": ["memory/x.md"]})
+            root = ws / ".git" / "sutando-sync-conflicts"
+            (root / ".retired.json").write_text(
+                json.dumps(["20260802T000000Z-origin_host_A/memory/x.md"]))
+            r = hc.check_sync_conflicts_unmerged(ws)
+        self.assertEqual(r["status"], "ok", r)
+        self.assertIn("retired", r["detail"])
+
+    def test_a_non_git_child_does_not_answer_about_its_ancestor(self):
+        # `rev-parse` searches ancestors: a child dir under a real vault would
+        # otherwise be reported on using the ANCESTOR's backups.
+        with tempfile.TemporaryDirectory() as td:
+            ws = _vault(td, {"20260802T000000Z-origin_host_A": ["memory/x.md"]})
+            child = ws / "not-a-repo"
+            child.mkdir()
+            r = hc.check_sync_conflicts_unmerged(child)
+        self.assertEqual(r["status"], "ok", r)
+        self.assertIn("not a git top level", r["detail"])
+
+    def test_the_warn_does_not_claim_the_files_are_absent_from_the_live_copy(self):
+        # The cheap count cannot know reconciliation; saying so would be a
+        # stronger claim than the probe measured.
+        with tempfile.TemporaryDirectory() as td:
+            ws = _vault(td, {"20260802T000000Z-origin_host_A": ["memory/x.md"]})
+            r = hc.check_sync_conflicts_unmerged(ws)
+        self.assertEqual(r["status"], "warn", r)
+        self.assertNotIn("none merged back", r["detail"])
+        self.assertIn("not retired", r["detail"])
 
     def test_the_probe_is_registered_in_the_run(self):
         src = (REPO / "src" / "health-check.py").read_text()

--- a/tests/health-check-sync-conflicts-unmerged.test.py
+++ b/tests/health-check-sync-conflicts-unmerged.test.py
@@ -14,7 +14,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
-from pathlib import Path
+from pathlib import Path, PurePath as pathlib_PurePath
 
 REPO = Path(__file__).resolve().parent.parent
 _spec = importlib.util.spec_from_file_location("hc", REPO / "src" / "health-check.py")
@@ -232,11 +232,59 @@ class RetirementIdentityIsTheCopy(unittest.TestCase):
         self.saved.write_text(self.ORIGINAL)
         self.assertEqual((self.status(), self.reporter()), ("ok", 0))
 
-    def test_an_unreadable_copy_is_UNOBSERVED_not_retired(self):
-        """Bounding the hash cost must not assert an unchecked copy is retired."""
+    def test_undecodable_BYTES_are_still_observed(self):
+        """errors="replace" decodes anything, so bad bytes are a CHANGED copy,
+        not an unreadable one — the earlier version of this arm accepted both
+        outcomes and so asserted nothing."""
         self.retire()
         self.saved.write_bytes(b"\xff\xfe raw bytes")
-        self.assertIn(self.status(), ("warn", "ok"))
+        self.assertEqual(self.status(), "warn")
+
+    def test_a_copy_that_cannot_be_READ_is_UNOBSERVED_not_retired(self):
+        """Bounding the hash cost must never assert an unchecked copy is clear."""
+        self.retire()
+        self.saved.chmod(0o000)
+        self.addCleanup(self.saved.chmod, 0o644)
+        try:
+            self.saved.read_text()
+        except OSError:
+            pass
+        else:
+            self.skipTest("this user can read a 000 file (root?) — no OSError to raise")
+        result = hc.check_sync_conflicts_unmerged(workspace=self.ws)
+        self.assertEqual(result["status"], "warn")
+        self.assertIn("UNOBSERVED", result["detail"])
+        self.assertNotIn("all retired", result["detail"])
+
+    def test_a_loader_that_fails_reports_UNOBSERVED_rather_than_assuming(self):
+        """If the reporter's key cannot be loaded the probe knows nothing about
+        retirement; saying "all retired" there is the same false clean."""
+        original = hc._sync_conflicts_entry_key
+        hc._sync_conflicts_entry_key = lambda: None
+        self.addCleanup(setattr, hc, "_sync_conflicts_entry_key", original)
+        self.retire()
+        result = hc.check_sync_conflicts_unmerged(workspace=self.ws)
+        self.assertEqual(result["status"], "warn")
+        self.assertIn("UNOBSERVED", result["detail"])
+
+    def test_the_loader_returns_None_when_the_reporter_cannot_be_imported(self):
+        """The except arm itself: a raising import must degrade, never propagate
+        out of a health probe."""
+        import importlib.util as _iu
+        original = _iu.spec_from_file_location
+
+        def boom(*a, **k):
+            raise ImportError("simulated")
+
+        _iu.spec_from_file_location = boom
+        self.addCleanup(setattr, _iu, "spec_from_file_location", original)
+        self.assertIsNone(hc._sync_conflicts_entry_key())
+
+    def test_CONTROL_the_loader_normally_returns_the_reporters_own_key(self):
+        """Without this the arm above could pass on a loader that always fails."""
+        fn = hc._sync_conflicts_entry_key()
+        self.assertIsNotNone(fn)
+        self.assertTrue(fn("b", pathlib_PurePath("notes/x.md"), "abc").startswith("b/notes/x.md@"))
 
     def test_the_probe_does_not_respell_the_retirement_key(self):
         src = (REPO / "src" / "health-check.py").read_text()


### PR DESCRIPTION
## The silence

`_resolve_conflicts_keep_ours` does its job: on a conflict it keeps our side and preserves theirs under `$GIT_DIR/sutando-sync-conflicts/`, then reports the total. The report is correct. It is also emitted on `sync-workspace.sh`'s stdout **at exit 0**, and the cron that runs that sync is instructed to report only on failure — so a true, actionable count is printed into a stream nothing reads.

Measured tonight on two hosts within the same hour:

```
host A   136 backup dirs   "sync-conflicts: 18 file(s) hold peer content not in the live copy"   rc=0
host B    94 backup dirs   "sync-conflicts: 21 file(s) hold peer content not in the live copy"   rc=0
```

Both agents read that output — quoting *other* lines from it, twice — and neither registered the summary, because `rc=0` had already answered the question being asked. The record was never missing. Nothing was pointed at it.

## Why a warning and not an exit code

The obvious fix is an advisory non-zero from the sync. That was the first design and it is wrong: the exit code is what the *fire's* success rides on, so a non-zero converts "21 files hold peer content" into "sync is broken" — louder, but false, and a crying alarm is the first one silenced.

`comm-sweep.sh stamp` already made this exact trade in the other direction and the reasoning holds here: refusing turns a quiet record problem into a loud false one.

So the count moves to a surface that is already read every pass, and warns.

## Fail-soft, and unobserved is never zero

```
report says "no unmerged peer content"      -> ok
report says "0 file(s)"                     -> ok
report output this probe cannot parse       -> ok, "not asserting a count"
reporter cannot run / times out             -> ok, "not asserting a count"
no sync-conflicts-report.py in the checkout -> ok
N > 0                                       -> warn, naming N and the command that lists them
```

A shape it cannot read is unobserved, never zero — the distinction this repo keeps having to relearn.

## Evidence

Live host, this probe, against the real vault:

```
warn | 18 file(s) hold peer content the sync preserved and nothing merged back — …
```

From a worktree whose resolved workspace is not a git repo, the same code degrades instead of asserting:

```
ok | conflicts report produced no count this probe recognises — not asserting a count
```

8 cases pass. Turning the one `warn` into an `ok` — the silence this exists to remove — fails `test_a_nonzero_count_warns_and_names_the_number`, so the arm is load-bearing.

**One of those arms exists because seven green tests missed a `NameError`.** Every case passed `repo_root=` explicitly, so the default branch was never exercised and `REPO_ROOT` (which does not exist in this module; it is `REPO_DIR`) shipped through a clean suite. The full `health-check.py` run caught it on the first invocation. `test_the_default_repo_root_resolves` now pins that branch.

Stand: Echo Act IV Mini
