### PR TITLE
fix(proactive-loop): bind the zero-result gate to its consumer, like the other two

### DIFF
--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -52,10 +52,11 @@ caps this file and refuses date stamps in it).
    record: before investigating, `grep -in "<entity from the warn TEXT>" "$H/pending-questions.md" "$H/current-track.md"`
    with `H="$WORKSPACE/hosts/$(bash scripts/sutando-config.sh host-label)"`; a zero means try another
    token, then `grep -n '^## ' "$H"/*.md` before concluding absence. Extend a hit; never re-file it.
-3.4. **Zero-result rule.** Before reporting any empty result or telling the owner how the system behaves:
-   `python3 skills/proactive-loop/scripts/warn-already-triaged.py --claim "<the sentence>"`
-   (1 already parked → read and extend · 0 untriaged · 2 cannot answer, not a green light). Name what a
-   non-zero would look like, run the positive control, suspect scope then shape, never verify in zsh.
+3.4. **Zero-result rule**, chained so a refusal cannot be skipped:
+   `python3 skills/proactive-loop/scripts/warn-already-triaged.py --claim "<the sentence>" && <the send>`
+   (1 already parked → read and extend · 0 untriaged · 2 cannot answer, not a green light). A negative
+   states its population inline — "0 of N matching X" — or nobody, including its author, can falsify it.
+   Name what a non-zero looks like, run the positive control, suspect scope then shape, never in zsh.
 3.45. **Duplicate issue gate**, chained so a refusal cannot be skipped:
    `python3 skills/proactive-loop/scripts/gh-duplicate-check.py --repo <owner/name> --title "<title>" && gh issue create --repo <owner/name> --title "..." --body-file <f>`
    (0 no candidate · 1 do not file, candidates named · 2 cannot answer).

--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -41,11 +41,13 @@ caps this file and refuses date stamps in it).
    (`python3 src/discord-read.py <channel> --serving <channel>` when serving a task, `--operator` otherwise),
    pending questions, relay, build log. Trust the record over recall; maintain `current-track.md`.
 1. **Tasks.** Process every file in `$WORKSPACE/tasks/`; `access_tier: team|other` → the sandboxed path.
-   Group a thread with `[deduped: task-<latest>]`, then
-   `python3 skills/proactive-loop/scripts/check-dedup-targets.py "$WORKSPACE/results/<file>"`
+   Group a thread with `[deduped: task-<latest>]`, written to a TEMP path and gated into place —
+   a file in `results/` is claimed by a poller in under a second, so a check after the write
+   checks nothing: `python3 skills/proactive-loop/scripts/check-dedup-targets.py "$tmp" && mv -f "$tmp" "$WORKSPACE/results/<file>"`
    (0 clean · 1 the dedup delivers nothing · 2 cannot answer). All-notice groups use `[no-send]` on each.
    Marker semantics belong to `src/result_markers.py`; never re-implement them.
-   Before idle: `python3 scripts/unanswered-tasks.py --workspace "$WORKSPACE"` (1 = a task got no result).
+   Bind idle to it too: `python3 scripts/unanswered-tasks.py --workspace "$WORKSPACE" && bash scripts/core-status.sh idle`
+   (1 = a task got no result, so idle does not run).
 2. **Questions.** Read `<workspace>/hosts/<host>/pending-questions.md`; surface via `results/question-<ts>.txt`
    when voice is connected, plus a macOS notification.
 3. **Health.** `python3 src/health-check.py`; fix with `--fix` what it can. A warn is a pointer into the
@@ -92,9 +94,9 @@ caps this file and refuses date stamps in it).
 7. **Build log write.** Append with `O_APPEND` and a random marker; assert `count(MARK) == 1` by reading
    the file back. Never read-modify-replace. Then decide whether a `relay/relay-<ts>.md` note is owed
    (a PR event, a resolved question, a lifted or new blocker, a judgment) — most passes owe none.
-7.5. **Memory index.** Before adding a row to `MEMORY.md`:
-   `python3 skills/proactive-loop/scripts/memory-index-budget.py --adding "<row>"` (0 safe · 1 refuse,
-   casualty named · 2 cannot answer). On refusal free room FIRST and check the row is still reachable
+7.5. **Memory index**, chained so a refusal cannot be skipped:
+   `python3 skills/proactive-loop/scripts/memory-index-budget.py --adding "<row>" && <append the row>`
+   (0 safe · 1 refuse, casualty named · 2 cannot answer). On refusal free room FIRST and check the row is still reachable
    from its hub before removing it; which rows go is the owner's call.
 8. **Ask.** Insert the question ABOVE the `# Resolved` divider of the per-host `pending-questions.md`,
    placed by importance (only the top 5 render anywhere), and assert with the reader:

--- a/skills/proactive-loop/SKILL.md
+++ b/skills/proactive-loop/SKILL.md
@@ -41,9 +41,11 @@ caps this file and refuses date stamps in it).
    (`python3 src/discord-read.py <channel> --serving <channel>` when serving a task, `--operator` otherwise),
    pending questions, relay, build log. Trust the record over recall; maintain `current-track.md`.
 1. **Tasks.** Process every file in `$WORKSPACE/tasks/`; `access_tier: team|other` → the sandboxed path.
-   Group a thread with `[deduped: task-<latest>]`, written to a TEMP path and gated into place —
-   a file in `results/` is claimed by a poller in under a second, so a check after the write
-   checks nothing: `python3 skills/proactive-loop/scripts/check-dedup-targets.py "$tmp" && mv -f "$tmp" "$WORKSPACE/results/<file>"`
+   Group a thread with `[deduped: task-<latest>]`, staged under its FINAL name and gated into
+   place — `results/` is claimed by a poller in under a second, and the checker reads the source
+   id from the BASENAME, so a generic temp name makes it pass everything:
+   `S="$WORKSPACE/state/dedup-staging/<file>"` then
+   `python3 skills/proactive-loop/scripts/check-dedup-targets.py "$S" && mv -f "$S" "$WORKSPACE/results/<file>"`
    (0 clean · 1 the dedup delivers nothing · 2 cannot answer). All-notice groups use `[no-send]` on each.
    Marker semantics belong to `src/result_markers.py`; never re-implement them.
    Bind idle to it too: `python3 scripts/unanswered-tasks.py --workspace "$WORKSPACE" && bash scripts/core-status.sh idle`

--- a/tests/proactive-loop-skill-budget.test.py
+++ b/tests/proactive-loop-skill-budget.test.py
@@ -65,6 +65,21 @@ class SkillBudget(unittest.TestCase):
         self.assertGreaterEqual(len(checked), 4,
                                 f"only examined {checked} — the enumerator matched too little")
 
+    def test_the_dedup_gate_is_staged_under_its_final_name(self):
+        """`check-dedup-targets` reads the source task id from the BASENAME.
+
+        Staging under a generic temp name leaves it no sender/room metadata, so
+        it skips both comparisons and returns clean — a gate that publishes what
+        the unstaged invocation refused.
+        """
+        text = SKILL.read_text()
+        bullet = next(b for b in re.split(r"\n(?=\d+(?:\.\d+)?\. )", text)
+                      if "check-dedup-targets.py" in b)
+        self.assertNotRegex(bullet, r'check-dedup-targets\.py "\$tmp"',
+                            "staged under a generic temp name: the checker loses the task identity")
+        self.assertIn("dedup-staging/<file>", bullet,
+                      "the staged path must carry the FINAL basename")
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=1)

--- a/tests/proactive-loop-skill-budget.test.py
+++ b/tests/proactive-loop-skill-budget.test.py
@@ -40,19 +40,30 @@ class SkillBudget(unittest.TestCase):
     def test_every_gate_is_chained_to_its_consumer(self):
         """A gate bound by prose is a gate you can run one action late.
 
-        3.4 said "Before reporting any empty result ..." while 3.45 and 9.5
-        bound theirs with `&&`. The unchained one was run after the post it was
-        meant to gate -- twice, by two agents -- and fired correctly both times,
-        which is indistinguishable from not having it.
+        Per BULLET, not per line: the script and its exit codes sit on separate
+        lines, so a per-line filter matches neither and passes vacuously.
         """
         text = SKILL.read_text()
-        for script in ("warn-already-triaged.py", "gh-duplicate-check.py",
-                       "pr-monologue-check.py"):
-            with self.subTest(script=script):
-                line = next((ln for ln in text.splitlines() if script in ln), "")
-                self.assertTrue(line, f"{script} is not named in SKILL.md")
-                self.assertIn("&&", line,
-                              f"{script} is invoked without `&&` binding it to its consumer")
+        NOT_GATING = {
+            "tool-suites-check.py": "reports suite health; withholds no action",
+            "codex-quota-gate.py": "Codex-only tier read, informational",
+        }
+        bullets = re.split(r"\n(?=\d+(?:\.\d+)?\. )", text)
+        checked = []
+        for b in bullets:
+            if "cannot answer" not in b:
+                continue
+            for script in set(re.findall(r"scripts/([a-z-]+\.py)", b)):
+                if script in NOT_GATING:
+                    continue
+                checked.append(script)
+                with self.subTest(script=script):
+                    self.assertIn("&&", b,
+                                  f"{script} declares a refusal but is not bound to its consumer")
+        # Non-vacuity: a loop that examined nothing passes silently, which is the
+        # failure this arm exists to prevent, turned on the arm itself.
+        self.assertGreaterEqual(len(checked), 4,
+                                f"only examined {checked} — the enumerator matched too little")
 
 
 if __name__ == "__main__":

--- a/tests/proactive-loop-skill-budget.test.py
+++ b/tests/proactive-loop-skill-budget.test.py
@@ -37,6 +37,23 @@ class SkillBudget(unittest.TestCase):
         self.assertGreater(SKILL.stat().st_size, 1024)
         self.assertLess(CAP, 70_000)
 
+    def test_every_gate_is_chained_to_its_consumer(self):
+        """A gate bound by prose is a gate you can run one action late.
+
+        3.4 said "Before reporting any empty result ..." while 3.45 and 9.5
+        bound theirs with `&&`. The unchained one was run after the post it was
+        meant to gate -- twice, by two agents -- and fired correctly both times,
+        which is indistinguishable from not having it.
+        """
+        text = SKILL.read_text()
+        for script in ("warn-already-triaged.py", "gh-duplicate-check.py",
+                       "pr-monologue-check.py"):
+            with self.subTest(script=script):
+                line = next((ln for ln in text.splitlines() if script in ln), "")
+                self.assertTrue(line, f"{script} is not named in SKILL.md")
+                self.assertIn("&&", line,
+                              f"{script} is invoked without `&&` binding it to its consumer")
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=1)


### PR DESCRIPTION
## The defect is one missing `&&`

Three gates in this skill are written to be unskippable. Two bind the check to the command it gates:

```
3.45  gh-duplicate-check.py … && gh issue create …
9.5   pr-monologue-check.py  … && gh pr comment  …
3.4   "Before reporting any empty result …"   ← prose
```

The third is a discipline. Disciplines are run in whatever order you remember them in.

## What that cost, measured

Tonight it was run **after** the post it was meant to gate, by two agents independently, and fired correctly both times:

```
posted a CLA diagnosis to #3509
then ran the gate -> CANDIDATES (1) — via 'web-flow' -> build_log.md:83322
```

The diagnosis was already on that same thread, posted by the same login eleven days earlier, with the same cause and the same two remedies. **A gate consulted one action late is indistinguishable from not having it** — the transcript reads as diligent, and the artifact is a duplicate already published on a stalled thread, which makes it look like the thread moved.

## The second line, and why it is in the same edit

The record that gate pointed at was itself a bad negative: *"scanned my own PRs for the web-flow CLA trap: zero exposed"*, written in the same paragraph that names the exposed PR as its exemplar.

The search was fine. The **population** was wrong, and the sentence carries no population, so it cannot be falsified — not by a reader, and not by its author six days later. Re-running it today with the population stated:

```
population: 27 open non-draft PRs authored by sonichi
exposed:    1 of 27  ->  #3509 (2 web-flow commits)
```

Stating N earns its keep immediately: my first two attempts at that scan printed **`0 of 0`**, once because `mapfile` is bash-only and once because `gh pr list` hit an exhausted GraphQL bucket and `2>/dev/null` turned the refusal into an empty list. Both would have read as a clean "zero exposed". `0 of 0` is visibly broken on sight.

## Evidence

```
SKILL.md          9799 -> 9882 B   (cap 12288, budget test passes)
new arm           asserts all three named gates appear bound by `&&`
against the pre-change file:
  FAIL test_every_gate_is_chained_to_its_consumer (script='warn-already-triaged.py')
  AssertionError: '&&' not found in '…warn-already-triaged.py --claim "<the sentence>"'
after:  Ran 6 tests  OK
```

Reported by a peer who ran out of order on the same bullet, and who measured the two-of-three split.

Stand: Echo Act IV Mini
