### PR TITLE
fix(model-switch): menu bar Sonnet 5 choice targets the 1M context id

### DIFF
--- a/skills/model-switch/manifest.json
+++ b/skills/model-switch/manifest.json
@@ -9,6 +9,6 @@
     "source_repo": "https://github.com/sonichi/sutando"
   },
   "config": {
-    "MODEL_SWITCH_CHOICES": "default=Default (auto-fallback);opus=Opus 5;sonnet=Sonnet 5;haiku=Haiku 4.5;claude-fable-5-1[1m]=Fable 5.1"
+    "MODEL_SWITCH_CHOICES": "default=Default (auto-fallback);opus=Opus 5;claude-sonnet-5[1m]=Sonnet 5 1M;haiku=Haiku 4.5;claude-fable-5-1[1m]=Fable 5.1"
   }
 }

--- a/skills/model-switch/manifest.json
+++ b/skills/model-switch/manifest.json
@@ -9,6 +9,6 @@
     "source_repo": "https://github.com/sonichi/sutando"
   },
   "config": {
-    "MODEL_SWITCH_CHOICES": "default=Default (auto-fallback);opus=Opus 5;claude-sonnet-5[1m]=Sonnet 5 1M;haiku=Haiku 4.5;claude-fable-5-1[1m]=Fable 5.1"
+    "MODEL_SWITCH_CHOICES": "default=Default (auto-fallback);opus=Opus 5;claude-sonnet-5[1m]=Sonnet 5 (1M context);haiku=Haiku 4.5;claude-fable-5-1[1m]=Fable 5.1"
   }
 }


### PR DESCRIPTION
## Summary
- Chi asked (owner DM): "the model in the menu bar app for sonnet 5 should be changed into sonnet 5 1M".
- `skills/model-switch/manifest.json`'s `MODEL_SWITCH_CHOICES` mapped the menu's "Sonnet 5" entry to the bare `sonnet` alias, which the CLI resolves to its default (128k) context.
- Changed the choice's id to the full `claude-sonnet-5[1m]` id and its label to "Sonnet 5 1M" — same shape as the existing `claude-fable-5-1[1m]=Fable 5.1` entry, and `[1m]` is already accepted by `switch-model.sh`'s id regex (`^(default|opus|sonnet|haiku|fable|claude-[a-z0-9.-]+(\[1m\])?)$`).

## Before / after
```diff
- "MODEL_SWITCH_CHOICES": "default=Default (auto-fallback);opus=Opus 5;sonnet=Sonnet 5;haiku=Haiku 4.5;claude-fable-5-1[1m]=Fable 5.1"
+ "MODEL_SWITCH_CHOICES": "default=Default (auto-fallback);opus=Opus 5;claude-sonnet-5[1m]=Sonnet 5 1M;haiku=Haiku 4.5;claude-fable-5-1[1m]=Fable 5.1"
```

## Test plan
- [x] `bash tests/app-model-submenu.test.sh` — 7/7 pass (unchanged, config-shape agnostic)
- [x] `bash tests/switch-model.test.sh` — 33/33 pass, including case 28 ("a full id is matched against the CLI's display name") which is the exact shape this entry now uses

🤖 Generated with [Claude Code](https://claude.com/claude-code)