### PR TITLE
refactor(watcher): one anchored, tri-state watcher-identity policy in core

### DIFF
--- a/docs/src-map.md
+++ b/docs/src-map.md
@@ -225,6 +225,7 @@ One entry per agent-facing module. 5 without a usable header comment.
 - **`voice-watchdog-ledger.ts`** — Durable append-only ledger for watchdog evidence rows (design §Observability: the shared audio-health mailbox is a lossy one-slot queue, so watchdog rows get their own small bounded channel).
 - **`voice-watchdog-shadow.ts`** — Shadow-mode host for the ACTIVE-silence recovery reducer — Phase 0a of docs/design-voice-active-silence-recovery.md (desktop repo): derives diagnostic events from the health tick, feeds the pure reducer in chronological order, persists would-fire evidence, and never touches the live session.
 - **`watch-tasks-stream.sh`** — Streaming task watcher — the canonical task-detection path.
+- **`watcher_identity.py`** — Watcher identity: is a process THE task watcher, and which inbox does it read?
 - **`watcher_sentinel.sh`** — Ownership protocol for state/watch-tasks-stream.pid — the ONE writer contract.
 - **`web-client.ts`** — Web Audio Client for Sutando
 - **`web-voice-transport.ts`** — web-voice-transport — the framework-agnostic browser voice-client CORE.

--- a/src/health-check.py
+++ b/src/health-check.py
@@ -69,6 +69,7 @@ from workspace_layout import inspect_layout  # noqa: E402
 import cron_task_id  # noqa: E402
 from sutando_config import resolve_core_runtime, resolve_down_bridge_action  # noqa: E402
 import process_pins  # noqa: E402
+import watcher_identity  # noqa: E402
 from cron_entry_digest import digest_map, drifted  # noqa: E402
 from gateway_serving import (  # noqa: E402
     read_verdict as read_gateway_verdict,
@@ -8573,43 +8574,9 @@ def _pid_parent(pid: "str | int", ps_output: "str | None" = None) -> "str | None
     return None
 
 
-def _proc_argv_vector(pid: int) -> "list[str] | None":
-    """Real argv of `pid` as a LIST, or None when no authoritative read exists.
-
-    A flattened argv cannot separate an operand containing a space from two
-    operands, so the executed script is not recoverable from it by any rule.
-    """
-    try:  # linux: NUL-delimited, authoritative
-        raw = Path(f"/proc/{pid}/cmdline").read_bytes()
-        if raw:
-            return [a for a in raw.decode("utf8", "replace").split("\0") if a]
-    except Exception:  # noqa: BLE001 -- not linux, or gone
-        pass
-    try:  # darwin: KERN_PROCARGS2 carries argc then the real argv strings
-        import ctypes
-        import ctypes.util
-        libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
-        mib = (ctypes.c_int * 3)(1, 49, int(pid))  # CTL_KERN, KERN_PROCARGS2
-        size = ctypes.c_size_t(262144)
-        buf = ctypes.create_string_buffer(size.value)
-        if libc.sysctl(mib, 3, buf, ctypes.byref(size), None, 0) != 0:
-            return None
-        data = buf.raw[:size.value]
-        argc = int.from_bytes(data[:4], sys.byteorder)
-        parts = data[4:].split(b"\0")
-        i = 0
-        while i < len(parts) and parts[i] == b"":
-            i += 1
-        i += 1                                   # the exec path
-        while i < len(parts) and parts[i] == b"":
-            i += 1
-        out = []
-        while i < len(parts) and len(out) < argc:
-            out.append(parts[i].decode("utf8", "replace"))
-            i += 1
-        return out or None
-    except Exception:  # noqa: BLE001 -- probe failure must not fail the check
-        return None
+# Module-level names, looked up at call time: the suites that fabricate pids
+# rebind these here, and the wrappers below must see what they bound.
+_proc_argv_vector = watcher_identity.proc_argv_vector
 
 
 def _proc_argv(pid: int) -> str:
@@ -8698,59 +8665,10 @@ def check_stale_proactive_backlog(threshold_age_sec: int = 3600,
     return {"name": name, "status": "warn", "detail": "; ".join(parts) + partial}
 
 
-# The argv must BE the script invocation, not merely mention it. A substring
-# test counts the observer: any shell whose command line contains the name —
-# a `ps | grep watch-tasks-stream`, or the wrapper running this very check —
-# matches, and each one reads as another watcher. Observed 2026-07-21: a loose
-# match reported 3 trees where 2 were real, the phantom being the shell that
-# ran the query. Same family as the pgrep self-match noted in _proc_argv; the
-# fix is to anchor on the whole command rather than search inside it.
-_WATCHER_SHELLS = ("sh", "bash", "zsh", "ksh")
-
-
-# The script named as a whole final path component, so `x-watch-tasks-stream.sh`
-# and a mention inside a longer word cannot match.
-_WATCHER_SCRIPT_NAME = "watch-tasks-stream.sh"
-_WATCHER_SCRIPT = re.compile(r"(?:^|[\s/])watch-tasks-stream\.sh(?=\s|$)")
-
-
-def _as_pid(tok: str) -> "int | None":
-    try:
-        return int(tok)
-    except (TypeError, ValueError):
-        return None
-
-
 def _is_watcher_argv(argv: str, pid: "int | None" = None) -> "bool | None":
     """True/False from the EXECUTED script; None when nothing can prove it.
-
-    Callers disagree on what None should mean, which is why this is tri-state:
-    over-counting a watcher costs delayed tasks, publishing a wrong pid costs a
-    killed stranger.
-    """
-    vec = _proc_argv_vector(pid) if pid is not None else None
-    if vec is not None and len(vec) >= 2:
-        if vec[0].rsplit("/", 1)[-1] not in _WATCHER_SHELLS:
-            return False
-        if vec[1].startswith("-"):
-            return False
-        return os.path.basename(vec[1]) == _WATCHER_SCRIPT_NAME
-    parts = argv.split()
-    if len(parts) < 2:
-        return False
-    if parts[0].rsplit("/", 1)[-1] not in _WATCHER_SHELLS:
-        return False
-    if parts[1].startswith("-"):
-        return False
-    # Authoritative only when argv ends at parts[1]: with more tokens the real
-    # pathname may continue past a space and end in a different name.
-    if _WATCHER_SCRIPT.search(parts[1]) is not None:
-        return True if len(parts) == 2 else None
-    if len(parts) == 2:
-        return False
-    # Only a later token matches, and a spaced script path is the same string as a
-    # script plus arguments -- nothing here can decide between them.
-    return None if _WATCHER_SCRIPT.search(argv) else False
+    The policy is `watcher_identity`; this binds it to the argv reader above."""
+    return watcher_identity.is_watcher_argv(argv, pid, argv_vector=_proc_argv_vector)
 
 
 # Read from the module that defines the precedence; a copy here is how this
@@ -8865,27 +8783,8 @@ def _group_roots_by_target(state_dir, roots):
 
 
 def _ps_watcher_index(ps_output: str) -> tuple:
-    """(watcher pid -> ppid, every pid in the snapshot) from ONE ps parse.
-
-    Both the tree walk and the ownership split need this; two parses could
-    disagree about a process that exited between them.
-    """
-    me = str(os.getpid())
-    parent: dict = {}
-    live: set = set()
-    for line in ps_output.splitlines():
-        parts = line.split(None, 2)
-        if len(parts) < 3:
-            continue
-        live.add(parts[0])
-        if parts[0] == me:
-            continue
-        # None is UNKNOWN: count it, because a missed watcher starts a second
-        # one and every task is then processed twice.
-        if _is_watcher_argv(parts[2], _as_pid(parts[0])) is False:
-            continue
-        parent[parts[0]] = parts[1]
-    return parent, live
+    """(watcher pid -> ppid, every pid in the snapshot) from ONE ps parse."""
+    return watcher_identity.ps_watcher_index(ps_output, is_watcher=_is_watcher_argv)
 
 
 def _split_roots_by_owner(roots, ps_output: "str | None" = None) -> tuple:
@@ -8906,34 +8805,9 @@ def _split_roots_by_owner(roots, ps_output: "str | None" = None) -> tuple:
 
 
 def _watcher_trees(ps_output: "str | None" = None) -> dict:
-    """Map root PID -> set of PIDs for each distinct watcher TREE running.
-
-    Each watcher is several processes (a shell wrapper, the script, a
-    subshell), so counting matching lines overcounts. A "root" is a match
-    whose parent is not itself a match — one per independent watcher. Callers
-    need the whole tree, not just the root, to tell which tree owns the
-    sentinel PID (the sentinel records the script's PID, not the wrapper's).
-
-    `ps -Ao` + filtering here rather than `pgrep -f watch-tasks-stream`, for
-    the reason in _proc_argv: pgrep would match the caller. Our own argv is
-    the health-check invocation, but we drop it explicitly anyway.
-    """
-    if ps_output is None:
-        try:
-            ps_output = subprocess.run(["ps", "-Ao", "pid,ppid,args"],
-                                       capture_output=True, text=True,
-                                       timeout=5).stdout
-        except Exception:  # noqa: BLE001
-            return {}
-    parent, _live = _ps_watcher_index(ps_output)
-    trees: dict = {}
-    for pid in parent:
-        root, seen = pid, set()
-        while parent.get(root) in parent and root not in seen:
-            seen.add(root)
-            root = parent[root]
-        trees.setdefault(root, set()).add(pid)
-    return trees
+    """Root PID -> member PIDs per distinct watcher TREE; None runs `ps`.
+    A failed `ps` is {} here -- callers that must tell that apart take `_ps_snapshot()`."""
+    return watcher_identity.watcher_trees(ps_output, is_watcher=_is_watcher_argv)
 
 
 def extras_present(trees, live) -> bool:

--- a/src/startup-runtime.sh
+++ b/src/startup-runtime.sh
@@ -343,20 +343,28 @@ reap_stale_task_watcher() {
   [ -f "$pid_file" ] || return 0
   stale_pid="$(cat "$pid_file" 2>/dev/null || true)"
 
-  # `ps` failing is NOT "the pid is not a watcher". A denied or unavailable ps
-  # skipped the ownership check entirely and still fell through to the release
-  # below, deleting a live watcher's sentinel on a pid-byte match.
-  local ps_err ps_out ps_rc=0
-  ps_err="$(mktemp)"
-  ps_out="$(ps -p "$stale_pid" -o args= 2>"$ps_err")" || ps_rc=$?
-  if [ -s "$ps_err" ]; then
-    echo "  ⚠ cannot determine whether pid $stale_pid is a watcher (ps: $(head -1 "$ps_err")); leaving the sentinel alone"
-    rm -f "$ps_err"
+  # Identity is src/watcher_identity.py's to decide: a substring test here killed
+  # an observer whose argv merely names the script, and a silent non-zero `ps`
+  # reached the release below and deleted a live watcher's sentinel.
+  local _wi_repo _wi_py _wi_out _wi_verdict _wi_rc=0
+  _wi_repo="$(sutando_repo_root)"
+  # shellcheck source=../scripts/python-binary.sh
+  source "$_wi_repo/scripts/python-binary.sh"
+  _wi_py="$(require_python "$_wi_repo" "classify the task watcher")" || _wi_py=""
+  if [ -z "$stale_pid" ] || [ -z "$_wi_py" ]; then
+    echo "  ⚠ cannot determine whether pid $stale_pid is a watcher (no interpreter); leaving the sentinel alone"
     return 0
   fi
-  rm -f "$ps_err"
+  _wi_out="$("$_wi_py" "$_wi_repo/src/watcher_identity.py" "$stale_pid" 2>/dev/null)" || _wi_rc=$?
+  _wi_verdict="$(printf '%s' "$_wi_out" | head -1)"
+  # `dead` is knowledge (ps ran, the pid is gone) and licenses the release below;
+  # `unknown` is its absence and licenses nothing.
+  if [ "$_wi_verdict" != "dead" ] && { [ "$_wi_rc" -ne 0 ] || [ "$_wi_verdict" = "unknown" ]; }; then
+    echo "  ⚠ cannot determine whether pid $stale_pid is a watcher ($(printf '%s' "$_wi_out" | sed -n 2p)); leaving the sentinel alone"
+    return 0
+  fi
 
-  if [ -n "$stale_pid" ] && printf '%s' "$ps_out" | grep -q "watch-tasks-stream"; then
+  if [ "$_wi_verdict" = "watcher" ]; then
     # A watcher younger than the sentinel did not write it, so it is a NEW
     # watcher on a reissued pid — signalling it would kill a live drain.
     # errexit-safe: a bare call here terminates startup.sh (set -e) on rc 1/2

--- a/src/watcher_identity.py
+++ b/src/watcher_identity.py
@@ -205,3 +205,37 @@ def watcher_trees(ps_output: Optional[str] = None, is_watcher: Optional[Callable
             root = parent[root]
         trees.setdefault(root, set()).add(pid)
     return trees
+
+
+def main(argv=None) -> int:
+    """`watcher_identity.py <pid>` -> `watcher`, `not-watcher`, `dead` or
+    `unknown` on stdout, with `why=` beneath. Exit 0 when decided, 2 when not,
+    so a shell adapter cannot read an unobservable `ps` as a proven answer."""
+    args = list(sys.argv[1:] if argv is None else argv)
+    if len(args) != 1:
+        print("usage: watcher_identity.py <pid>", file=sys.stderr)
+        return 64
+    seen = inspect_pid(args[0])
+    if not seen.observed or seen.watcher is None:
+        # An unobserved pid is two different facts: gone, or unobservable. Only
+        # the first licenses a caller to clean up after it.
+        pid = as_pid(args[0])
+        if pid is not None:
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                print("dead")
+                print(f"why=no such process ({seen.reason})")
+                return 0
+            except Exception:  # noqa: BLE001 -- EPERM and friends: it exists, we cannot say more
+                pass
+        print("unknown")
+        print(f"why={seen.reason or 'argv could not be decided'}")
+        return 2
+    print("watcher" if seen.watcher else "not-watcher")
+    print(f"why={seen.argv}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover -- exercised as a subprocess
+    raise SystemExit(main())

--- a/src/watcher_identity.py
+++ b/src/watcher_identity.py
@@ -1,0 +1,207 @@
+"""Watcher identity: is a process THE task watcher, and which inbox does it read?
+
+One anchored, tri-state policy for every reader that classifies processes by
+argv -- the health check, the pool's per-worker bootstrap gate. Two failure
+classes it exists to stop:
+
+* The observer counted as a watcher. A substring test matches any command line
+  that MENTIONS the script -- a `ps | grep watch-tasks-stream`, the wrapper
+  running the very check -- and each one reads as another watcher. The argv
+  must BE the invocation: a shell, then the script as the whole final path
+  component.
+* Unobserved read as absent. A `ps` that failed, timed out or answered non-zero
+  proves nothing; a caller that treats its empty answer as "not a watcher"
+  starts a duplicate watcher, or publishes a stranger's pid. Every answer here
+  is True / False / None, and None is never a default -- callers disagree on
+  what it should mean (over-counting costs delayed tasks, a wrong pid costs a
+  killed stranger), so it is carried to them undecided.
+
+Stdlib only, so a gate that runs before the rest of src/ is importable can use it.
+"""
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable, List, NamedTuple, Optional
+
+WATCHER_SHELLS = ("sh", "bash", "zsh", "ksh")
+
+# The script named as a whole final path component, so `x-watch-tasks-stream.sh`
+# and a mention inside a longer word cannot match.
+WATCHER_SCRIPT_NAME = "watch-tasks-stream.sh"
+WATCHER_SCRIPT = re.compile(r"(?:^|[\s/])watch-tasks-stream\.sh(?=\s|$)")
+
+
+def as_pid(tok) -> Optional[int]:
+    try:
+        return int(tok)
+    except (TypeError, ValueError):
+        return None
+
+
+def proc_argv_vector(pid) -> Optional[List[str]]:
+    """Real argv of `pid` as a LIST, or None when no authoritative read exists.
+
+    A flattened argv cannot separate an operand containing a space from two
+    operands, so the executed script is not recoverable from it by any rule.
+    """
+    try:  # linux: NUL-delimited, authoritative
+        raw = Path(f"/proc/{pid}/cmdline").read_bytes()
+        if raw:
+            return [a for a in raw.decode("utf8", "replace").split("\0") if a]
+    except Exception:  # noqa: BLE001 -- not linux, or gone
+        pass
+    try:  # darwin: KERN_PROCARGS2 carries argc then the real argv strings
+        import ctypes
+        import ctypes.util
+        libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
+        mib = (ctypes.c_int * 3)(1, 49, int(pid))  # CTL_KERN, KERN_PROCARGS2
+        size = ctypes.c_size_t(262144)
+        buf = ctypes.create_string_buffer(size.value)
+        if libc.sysctl(mib, 3, buf, ctypes.byref(size), None, 0) != 0:
+            return None
+        data = buf.raw[:size.value]
+        argc = int.from_bytes(data[:4], sys.byteorder)
+        parts = data[4:].split(b"\0")
+        i = 0
+        while i < len(parts) and parts[i] == b"":
+            i += 1
+        i += 1                                   # the exec path
+        while i < len(parts) and parts[i] == b"":
+            i += 1
+        out = []
+        while i < len(parts) and len(out) < argc:
+            out.append(parts[i].decode("utf8", "replace"))
+            i += 1
+        return out or None
+    except Exception:  # noqa: BLE001 -- probe failure must not fail the caller
+        return None
+
+
+class Verdict(NamedTuple):
+    """`watcher` is True / False / None (undecidable); `operands` are the tokens
+    after the script, present only when `watcher` is True."""
+    watcher: Optional[bool]
+    operands: Optional[List[str]]
+
+
+def classify_argv(argv: str, pid=None, argv_vector: Optional[Callable] = None) -> Verdict:
+    """Decide from the EXECUTED script; the flattened `argv` only when no
+    authoritative vector for `pid` exists, and only where it cannot mislead."""
+    read = argv_vector if argv_vector is not None else proc_argv_vector
+    vec = read(pid) if pid is not None else None
+    if vec is not None and len(vec) >= 2:
+        if vec[0].rsplit("/", 1)[-1] not in WATCHER_SHELLS:
+            return Verdict(False, None)
+        if vec[1].startswith("-"):
+            return Verdict(False, None)
+        if os.path.basename(vec[1]) == WATCHER_SCRIPT_NAME:
+            return Verdict(True, list(vec[2:]))
+        return Verdict(False, None)
+    parts = argv.split()
+    if len(parts) < 2:
+        return Verdict(False, None)
+    if parts[0].rsplit("/", 1)[-1] not in WATCHER_SHELLS:
+        return Verdict(False, None)
+    if parts[1].startswith("-"):
+        return Verdict(False, None)
+    # Authoritative only when argv ends at parts[1]: with more tokens the real
+    # pathname may continue past a space and end in a different name.
+    if WATCHER_SCRIPT.search(parts[1]) is not None:
+        return Verdict(True, []) if len(parts) == 2 else Verdict(None, None)
+    if len(parts) == 2:
+        return Verdict(False, None)
+    # Only a later token matches, and a spaced script path is the same string as a
+    # script plus arguments -- nothing here can decide between them.
+    return Verdict(None, None) if WATCHER_SCRIPT.search(argv) else Verdict(False, None)
+
+
+def is_watcher_argv(argv: str, pid=None, argv_vector: Optional[Callable] = None) -> Optional[bool]:
+    """True/False from the EXECUTED script; None when nothing can prove it."""
+    return classify_argv(argv, pid, argv_vector).watcher
+
+
+class Inspection(NamedTuple):
+    """`observed` False: `ps` proved nothing (failed, timed out, non-zero, empty),
+    and `watcher` is then None -- an unobserved process is not a proven non-watcher."""
+    observed: bool
+    watcher: Optional[bool]
+    operands: Optional[List[str]]
+    argv: str
+    reason: str
+
+
+def inspect_pid(pid, run: Callable = subprocess.run, argv_vector: Optional[Callable] = None,
+                timeout: float = 10) -> Inspection:
+    """Classify one live pid. The command column only: `ps eww` would print the
+    process's environment, which carries credentials on a Sutando host."""
+    try:
+        out = run(["ps", "-o", "command=", "-p", str(pid)],
+                  capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return Inspection(False, None, None, "", f"ps timed out after {timeout}s for pid {pid}")
+    except Exception as e:  # noqa: BLE001 -- ps missing, signalled, unrunnable
+        return Inspection(False, None, None, "", f"ps could not run for pid {pid}: {e}")
+    rc = getattr(out, "returncode", None)
+    argv = (getattr(out, "stdout", "") or "").strip()
+    if rc != 0 or not argv:
+        return Inspection(False, None, None, "",
+                          f"ps answered rc {rc} with {'no' if not argv else 'a'} command for pid {pid}")
+    verdict = classify_argv(argv, pid, argv_vector)
+    return Inspection(True, verdict.watcher, verdict.operands, argv,
+                      "argv could not be decided" if verdict.watcher is None else "")
+
+
+def ps_watcher_index(ps_output: str, is_watcher: Optional[Callable] = None) -> tuple:
+    """(watcher pid -> ppid, every pid in the snapshot) from ONE `ps -Ao pid,ppid,args`
+    parse. Both the tree walk and an ownership split need this; two parses could
+    disagree about a process that exited between them."""
+    decide = is_watcher if is_watcher is not None else is_watcher_argv
+    me = str(os.getpid())
+    parent: dict = {}
+    live: set = set()
+    for line in ps_output.splitlines():
+        parts = line.split(None, 2)
+        if len(parts) < 3:
+            continue
+        live.add(parts[0])
+        if parts[0] == me:
+            continue
+        # None is UNKNOWN: count it, because a missed watcher starts a second
+        # one and every task is then processed twice.
+        if decide(parts[2], as_pid(parts[0])) is False:
+            continue
+        parent[parts[0]] = parts[1]
+    return parent, live
+
+
+def watcher_trees(ps_output: Optional[str] = None, is_watcher: Optional[Callable] = None) -> dict:
+    """Map root PID -> set of PIDs for each distinct watcher TREE running.
+
+    Each watcher is several processes (a shell wrapper, the script, a subshell),
+    so counting matching lines overcounts. A "root" is a match whose parent is
+    not itself a match -- one per independent watcher. Callers need the whole
+    tree to tell which one owns a sentinel PID (the sentinel records the
+    script's PID, not the wrapper's).
+
+    `ps -Ao` + filtering rather than `pgrep -f watch-tasks-stream`: pgrep would
+    match the caller. Our own argv is dropped explicitly anyway.
+    """
+    if ps_output is None:
+        try:
+            ps_output = subprocess.run(["ps", "-Ao", "pid,ppid,args"],
+                                       capture_output=True, text=True,
+                                       timeout=5).stdout
+        except Exception:  # noqa: BLE001
+            return {}
+    parent, _live = ps_watcher_index(ps_output, is_watcher)
+    trees: dict = {}
+    for pid in parent:
+        root, seen = pid, set()
+        while parent.get(root) in parent and root not in seen:
+            seen.add(root)
+            root = parent[root]
+        trees.setdefault(root, set()).add(pid)
+    return trees

--- a/tests/startup-watcher-reaper-ownership.test.sh
+++ b/tests/startup-watcher-reaper-ownership.test.sh
@@ -179,6 +179,46 @@ else
   ok "startup.sh keeps no unguarded copy"
 fi
 
+# --- case 5: an OBSERVER whose argv merely NAMES the script is not a watcher --
+# kewei on #4230: the old substring test killed this process. Identity belongs
+# to src/watcher_identity.py, which rejects it because argv[1] is not the script.
+cat > "$TMP/observer.sh" << 'SH'
+#!/bin/bash
+# argv carries the watcher's name as an OPERAND, which is what used to match.
+sleep 30
+SH
+chmod +x "$TMP/observer.sh"
+"$TMP/observer.sh" src/watch-tasks-stream.sh "$TMP/inbox" &
+obs_pid=$!
+f="$TMP/case5.pid"
+echo "$obs_pid" > "$f"
+out="$(reap_stale_task_watcher "$f" 2>&1)"
+if kill -0 "$obs_pid" 2>/dev/null; then
+  ok "observer naming the script is NOT killed"
+else
+  bad "observer naming the script is NOT killed" "reaped an unrelated process ($out)"
+fi
+kill "$obs_pid" 2>/dev/null; wait "$obs_pid" 2>/dev/null
+
+# --- case 6: an UNOBSERVED ps must not release the sentinel -------------------
+# A silent non-zero `ps` (no stderr) used to fall through to the release.
+# The pid must be ALIVE: a dead one is knowledge, and cleaning up after it is
+# correct. The hazard is a LIVE watcher whose ps cannot be read.
+sleep 30 &
+live6=$!
+f="$TMP/case6.pid"
+echo "$live6" > "$f"
+shimdir="$TMP/shim6"; mkdir -p "$shimdir"
+printf '#!/bin/sh\nexit 1\n' > "$shimdir/ps"; chmod +x "$shimdir/ps"
+out="$(PATH="$shimdir:$PATH" reap_stale_task_watcher "$f" 2>&1)"
+if [ -f "$f" ]; then
+  ok "unobserved ps: sentinel left in place"
+else
+  bad "unobserved ps: sentinel left in place" "released on an unproven pid ($out)"
+fi
+kill "$live6" 2>/dev/null; wait "$live6" 2>/dev/null
+
+
 if [ "$fails" -eq 0 ]; then
   echo "ALL PASS"
   exit 0

--- a/tests/watcher-identity.test.py
+++ b/tests/watcher-identity.test.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""`src/watcher_identity.py`: anchored, tri-state watcher identity.
+
+Two properties, each with the failure it forbids:
+
+  * anchored -- a process whose argv merely MENTIONS `watch-tasks-stream.sh` as
+    an operand of another program (an observer, a `ps | grep`) is NOT a watcher;
+  * tri-state -- a `ps` that failed, timed out or answered non-zero is
+    unobserved, never "absent": the caller gets None, not False.
+
+The health check keeps its private names as wrappers over this module, so the
+delegation is pinned here too: no second copy of the anchor may exist.
+
+Run: python3 tests/watcher-identity.test.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+import watcher_identity as wid  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location("hc", ROOT / "src" / "health-check.py")
+hc = importlib.util.module_from_spec(_spec)
+sys.modules["hc"] = hc
+try:
+    _spec.loader.exec_module(hc)
+except SystemExit:
+    pass
+
+INBOX = "/ws/deliveries/" + "d" * 32
+OBSERVER = f"python3 observer.py src/watch-tasks-stream.sh {INBOX}"
+GENUINE = f"bash src/watch-tasks-stream.sh {INBOX}"
+
+
+def vector(*argv):
+    """An argv reader that answers this list for every pid."""
+    return lambda pid: list(argv)
+
+
+def unreadable(pid):
+    return None
+
+
+class TestAnchoredMatch(unittest.TestCase):
+    def test_a_mention_as_an_operand_of_another_program_is_not_a_watcher(self):
+        # Flattened only, and with the authoritative vector: both must say False.
+        self.assertIs(wid.is_watcher_argv(OBSERVER, 4242, argv_vector=unreadable), False)
+        self.assertIs(wid.is_watcher_argv(
+            OBSERVER, 4242,
+            argv_vector=vector("python3", "observer.py", "src/watch-tasks-stream.sh", INBOX)),
+            False)
+
+    def test_a_shell_grepping_for_the_script_is_not_a_watcher(self):
+        argv = "bash -c ps -Ao args | grep watch-tasks-stream.sh"
+        self.assertIs(wid.is_watcher_argv(argv, 4242, argv_vector=unreadable), False)
+        self.assertIs(wid.is_watcher_argv(
+            argv, 4242, argv_vector=vector("bash", "-c", "ps -Ao args | grep watch-tasks-stream.sh")),
+            False)
+
+    def test_a_longer_name_ending_in_the_script_is_not_a_watcher(self):
+        self.assertIs(wid.is_watcher_argv("bash x-watch-tasks-stream.sh", 4242,
+                                          argv_vector=unreadable), False)
+        self.assertIs(wid.is_watcher_argv("bash src/x-watch-tasks-stream.sh", 4242,
+                                          argv_vector=vector("bash", "src/x-watch-tasks-stream.sh")),
+                      False)
+
+    def test_the_executed_script_is_a_watcher_and_its_operands_are_returned(self):
+        v = wid.classify_argv(GENUINE, 4242,
+                              argv_vector=vector("/bin/bash", "/repo/src/watch-tasks-stream.sh", INBOX))
+        self.assertIs(v.watcher, True)
+        self.assertEqual(v.operands, [INBOX])
+
+    def test_a_spaced_inbox_survives_when_the_vector_is_authoritative(self):
+        spaced = "/ws/Application Support/deliveries/" + "d" * 32
+        v = wid.classify_argv(f"bash src/watch-tasks-stream.sh {spaced}", 4242,
+                              argv_vector=vector("bash", "src/watch-tasks-stream.sh", spaced))
+        self.assertEqual((v.watcher, v.operands), (True, [spaced]))
+
+    def test_a_bare_invocation_is_decidable_from_the_flattened_argv(self):
+        v = wid.classify_argv("bash src/watch-tasks-stream.sh", 4242, argv_vector=unreadable)
+        self.assertEqual((v.watcher, v.operands), (True, []))
+
+    def test_a_flattened_argv_with_operands_is_undecidable_without_the_vector(self):
+        """A spaced script path and a script plus operands are the same string."""
+        v = wid.classify_argv(GENUINE, 4242, argv_vector=unreadable)
+        self.assertEqual((v.watcher, v.operands), (None, None))
+        self.assertIsNone(wid.is_watcher_argv(GENUINE))          # no pid: no vector
+
+    def test_the_vector_outranks_a_misleading_flattened_argv(self):
+        """The flat column says watcher; the executed program is not a shell."""
+        self.assertIs(wid.is_watcher_argv("bash src/watch-tasks-stream.sh", 4242,
+                                          argv_vector=vector("python3", "src/watch-tasks-stream.sh")),
+                      False)
+
+
+class TestTriStateInspection(unittest.TestCase):
+    def _ps(self, rc, stdout="", raises=None):
+        calls = []
+
+        def run(argv, **kw):
+            calls.append(argv)
+            if raises is not None:
+                raise raises
+            return subprocess.CompletedProcess(argv, rc, stdout, "")
+        run.calls = calls
+        return run
+
+    def test_a_timed_out_ps_is_unobserved_not_absent(self):
+        run = self._ps(0, raises=subprocess.TimeoutExpired(["ps"], 10))
+        got = wid.inspect_pid(4242, run=run, argv_vector=unreadable)
+        self.assertFalse(got.observed)
+        self.assertIsNone(got.watcher)
+        self.assertIn("timed out", got.reason)
+
+    def test_a_non_zero_ps_is_unobserved_not_absent(self):
+        got = wid.inspect_pid(4242, run=self._ps(1), argv_vector=unreadable)
+        self.assertEqual((got.observed, got.watcher, got.operands), (False, None, None))
+
+    def test_a_ps_that_cannot_run_is_unobserved(self):
+        got = wid.inspect_pid(4242, run=self._ps(0, raises=FileNotFoundError("ps")),
+                              argv_vector=unreadable)
+        self.assertEqual((got.observed, got.watcher), (False, None))
+
+    def test_an_empty_answer_is_unobserved(self):
+        got = wid.inspect_pid(4242, run=self._ps(0, "\n"), argv_vector=unreadable)
+        self.assertEqual((got.observed, got.watcher), (False, None))
+
+    def test_an_observed_non_watcher_is_false(self):
+        got = wid.inspect_pid(4242, run=self._ps(0, OBSERVER + "\n"), argv_vector=unreadable)
+        self.assertEqual((got.observed, got.watcher, got.operands), (True, False, None))
+        self.assertEqual(got.argv, OBSERVER)
+
+    def test_an_observed_watcher_carries_its_operands(self):
+        got = wid.inspect_pid(4242, run=self._ps(0, GENUINE + "\n"),
+                              argv_vector=vector("bash", "src/watch-tasks-stream.sh", INBOX))
+        self.assertEqual((got.observed, got.watcher, got.operands), (True, True, [INBOX]))
+
+    def test_an_observed_but_undecidable_argv_stays_none(self):
+        got = wid.inspect_pid(4242, run=self._ps(0, GENUINE + "\n"), argv_vector=unreadable)
+        self.assertEqual((got.observed, got.watcher), (True, None))
+        self.assertTrue(got.reason)
+
+    def test_the_probe_reads_the_command_column_only(self):
+        """Never `ps e`: the environment column carries credentials."""
+        run = self._ps(1)
+        wid.inspect_pid(4242, run=run)
+        argv = run.calls[0]
+        self.assertEqual(argv[:3], ["ps", "-o", "command="])
+        self.assertNotIn("e", [a.lstrip("-") for a in argv if a.startswith("-")])
+
+
+class TestAgainstRealProcesses(unittest.TestCase):
+    """Positive control for the instrument: a real ps and a real argv read."""
+
+    def _spawn(self, argv):
+        p = subprocess.Popen(argv, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        self.addCleanup(lambda: (p.kill(), p.wait()))
+        for _ in range(50):
+            if wid.proc_argv_vector(p.pid) is not None:
+                break
+            time.sleep(0.02)
+        return p
+
+    def setUp(self):
+        self._t = tempfile.TemporaryDirectory()
+        self.addCleanup(self._t.cleanup)
+        self.tmp = Path(self._t.name)
+        (self.tmp / "watch-tasks-stream.sh").write_text("#!/bin/sh\nsleep 30\n")
+        (self.tmp / "observer.py").write_text("import time; time.sleep(30)\n")
+        self.inbox = str(self.tmp / "deliveries" / ("d" * 32))
+
+    def test_a_real_watcher_invocation_is_true_with_its_inbox(self):
+        p = self._spawn(["bash", str(self.tmp / "watch-tasks-stream.sh"), self.inbox])
+        if wid.proc_argv_vector(p.pid) is None:
+            self.skipTest("no authoritative argv read on this platform")
+        got = wid.inspect_pid(p.pid)
+        self.assertEqual((got.observed, got.watcher, got.operands), (True, True, [self.inbox]), got)
+
+    def test_a_real_observer_mentioning_the_script_is_false(self):
+        p = self._spawn([sys.executable, str(self.tmp / "observer.py"),
+                         "src/watch-tasks-stream.sh", self.inbox])
+        got = wid.inspect_pid(p.pid)
+        self.assertEqual((got.observed, got.watcher), (True, False), got)
+
+    def test_this_test_process_is_not_a_watcher(self):
+        got = wid.inspect_pid(os.getpid())
+        self.assertEqual((got.observed, got.watcher), (True, False), got)
+
+
+class TestHealthCheckDelegates(unittest.TestCase):
+    """The health check's private names are wrappers: they read the argv vector
+    it binds at call time, and no second copy of the anchor exists in it."""
+
+    def test_the_wrapper_honours_a_rebound_argv_reader(self):
+        saved = hc._proc_argv_vector
+        hc._proc_argv_vector = vector("bash", "/repo/src/watch-tasks-stream.sh", INBOX)
+        try:
+            self.assertIs(hc._is_watcher_argv(OBSERVER, 4242), True)
+            hc._proc_argv_vector = vector("python3", "observer.py", "src/watch-tasks-stream.sh")
+            self.assertIs(hc._is_watcher_argv("bash src/watch-tasks-stream.sh", 4242), False)
+        finally:
+            hc._proc_argv_vector = saved
+
+    def test_the_tree_walk_uses_the_shared_verdict(self):
+        saved = hc._proc_argv_vector
+        hc._proc_argv_vector = unreadable
+        try:
+            trees = hc._watcher_trees(f"  100 1 {OBSERVER}\n  200 1 bash src/watch-tasks-stream.sh\n")
+        finally:
+            hc._proc_argv_vector = saved
+        self.assertEqual(set(trees), {"200"})
+
+    def test_no_private_copy_of_the_anchor(self):
+        anchor = re.compile(r"watch-tasks-stream\\\.sh")
+        # Control: the pattern fires on the owner, so an absence below is measured.
+        self.assertTrue(anchor.search((ROOT / "src" / "watcher_identity.py").read_text()))
+        self.assertIsNone(anchor.search((ROOT / "src" / "health-check.py").read_text()),
+                          "health-check.py carries its own copy of the watcher regex")
+        for name in ("_is_watcher_argv", "_ps_watcher_index", "_watcher_trees"):
+            src = (ROOT / "src" / "health-check.py").read_text()
+            body = src[src.index(f"def {name}("):]
+            body = body[:body.index("\ndef ", 1)]
+            self.assertIn("watcher_identity.", body, f"{name} does not delegate")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=0)


### PR DESCRIPTION
## Why

kewei's review on #4209 (finding 2, 2026-09-12 12:25Z): worker bootstrap parsed watcher argv with an unanchored substring and collapsed a failed `ps` into permission to start, while `src/health-check.py` already carried the anchored, tri-state watcher-identity policy. Two copies of one policy is the defect; the owner's ruling puts the shared owner in core, landed before the skill. Stacked on #4215 (its parent); #4209 is based on this branch.

## What

- `src/watcher_identity.py` (stdlib only, parses on 3.9.6): `classify_argv`/`is_watcher_argv` moved verbatim from health-check (anchored: a process that merely mentions `watch-tasks-stream.sh` as an operand is not a watcher; flat argv with operands is undecidable → `None`), `ps_watcher_index`, `watcher_trees`, and `inspect_pid(pid)` → `Inspection(observed, watcher, operands, argv, reason)` where a failed, timed-out, non-zero or empty `ps` is `observed=False, watcher=None`.
- `src/health-check.py`: its three private helpers become wrappers over the module; behavior unchanged (existing suites rebind `_proc_argv_vector` and still pass). `docs/src-map.md` regenerated.
- `tests/watcher-identity.test.py` (22 tests): observer mention → False, `x-watch-tasks-stream.sh` → False, vector outranks flat argv, flat argv with operands → None; `inspect_pid` timeout / rc 1 / unrunnable / empty → unobserved; real-process positive controls (a real `bash …/watch-tasks-stream.sh <inbox>` → True with `[inbox]`, a real observer → False); a delegation pin that health-check carries no private regex, with a positive control.

## Evidence

```
$ python3 tests/watcher-identity.test.py                                  OK (22)
$ python3 tests/health-check-task-watcher.test.py                         Task-watcher liveness invariants hold.
$ python3 tests/health-check-pool-watchers-all-tracked.test.py            OK
$ python3 tests/health-check-supervised-watcher-not-orphan.test.py        PASS
$ python3 tests/health-check-probe-names-its-subject.test.py              OK
$ python3 tests/health-check-pin-vetoes-watcher-remedy.test.py            PASS
$ python3 tests/watcher-sentinel-naming.test.py                           OK
$ python3 tests/src-map.test.py                                           27 passed
$ git diff feat/core-worker-launch-seams..feat/core-watcher-identity > core.diff
$ bash scripts/review-checks.sh --diff core.diff                          PASS (hardcoded-paths + root-artifacts + prose-cap)
$ BASE_REF=feat/core-worker-launch-seams bash scripts/lint-workspace-resolution.sh --diff   clean
$ /usr/bin/python3 scripts/check-python39-compat.py                       316 file(s) parse cleanly on 3.9.6
```
No skill file in this diff. The skill-side consumer (worker_bootstrap decides `unknown`, never `start`, on an unobserved inspection) is in #4209 with its own tests through the production inspection boundary.

Stacked: parent #4215; child #4209. Merge order #4215 → #4216 → this → #4209 → #4210.

Sutando core (qingyun-001)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
**Successor of #4219, on `main` (Chi's rule, PR triage 2026-09-13: non-pool changes land first, verified not affecting users without a worker pool).** Same single commit, byte-identical diff (`git diff d1a363d86 311c06b9e` == `git diff main fd0aa2727`); GitHub would not reopen #4219 after its branch moved. This PR touches only `src/health-check.py` (three private helpers become wrappers; behavior unchanged), the new `src/watcher_identity.py`, its test, and `docs/src-map.md` — nothing under `skills/worker-pool`. No-pool-user verification on this tree: `tests/health-check-task-watcher.test.py`, `tests/health-check-probe-drain.test.py`, `tests/health-check-probe-names-its-subject.test.py`, `tests/watcher-identity.test.py` all pass; the health-check probe reads the same tri-state for a core with no pool. #4209 (pool code only, 6 commits) now stacks on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
