### PR TITLE
fix(tests): exit gateway-destined-proactive test past interpreter finalization, saving its coverage fragment first

### DIFF
--- a/tests/gateway-destined-proactive-not-claimed.test.py
+++ b/tests/gateway-destined-proactive-not-claimed.test.py
@@ -141,4 +141,9 @@ if failures:
     print("--- bridge output tail ---")
     print(out)
 print(f"\n{'FAILED' if failures else 'OK'} — {len(failures)} failure(s)")
-sys.exit(1 if failures else 0)
+# The stub gateway's serve_forever runs as a daemon thread with no stop condition;
+# interpreter finalization racing one of its writes aborts the process after the
+# assertions have already passed (same teardown race as #3800).
+sys.stdout.flush()
+sys.stderr.flush()
+os._exit(1 if failures else 0)

--- a/tests/gateway-destined-proactive-not-claimed.test.py
+++ b/tests/gateway-destined-proactive-not-claimed.test.py
@@ -141,9 +141,8 @@ if failures:
     print("--- bridge output tail ---")
     print(out)
 print(f"\n{'FAILED' if failures else 'OK'} — {len(failures)} failure(s)")
-# The stub gateway's serve_forever runs as a daemon thread with no stop condition;
-# interpreter finalization racing one of its writes aborts the process after the
-# assertions have already passed (same teardown race as #3800).
+# serve_forever is a daemon thread with no stop condition; interpreter
+# finalization can race its writes and abort after the assertions pass.
 sys.stdout.flush()
 sys.stderr.flush()
 os._exit(1 if failures else 0)

--- a/tests/gateway-destined-proactive-not-claimed.test.py
+++ b/tests/gateway-destined-proactive-not-claimed.test.py
@@ -145,4 +145,13 @@ print(f"\n{'FAILED' if failures else 'OK'} — {len(failures)} failure(s)")
 # finalization can race its writes and abort after the assertions pass.
 sys.stdout.flush()
 sys.stderr.flush()
+# os._exit skips atexit, where coverage writes this run's fragment; save it first.
+try:
+    import coverage
+
+    _cov = coverage.Coverage.current()
+    if _cov is not None:
+        _cov.save()
+except Exception:
+    pass
 os._exit(1 if failures else 0)


### PR DESCRIPTION
## Why

#4182 (john-the-dev) fixes a real crash: `tests/gateway-destined-proactive-not-claimed.test.py` starts a daemon `serve_forever` thread with no stop, and interpreter finalization can abort the process after the assertions pass (`Fatal Python error: _enter_buffered_busy … at interpreter shutdown`). That crash is currently turning `diff coverage >= 95% (python)` red on unrelated PRs — #4230's job log shows exactly this. yixuan-ag2's review on #4182 found the gap in the fix: `os._exit` skips `atexit`, where coverage writes the run's fragment, so the test's coverage contribution silently disappears. Eleven other `os._exit` tests under `tests/` already flush coverage first. #4182 does not permit maintainer edits, so this PR carries john's two commits **unchanged, his authorship preserved**, plus one commit with the flush — at the owner's ask in PR triage (2026-09-13) to get the fix landed.

## What

- `c65de1b65`, `c5252c9f8`: john-the-dev's commits from #4182, replayed verbatim on `main`.
- `6e6f07378`: the same eight-line `coverage.Coverage.current(); _cov.save()` block the precedent files carry, immediately before `os._exit`.

## Evidence

Fragment control on this tree, `.coveragerc` present (`python3 -m coverage run -p --include='src/*' tests/gateway-destined-proactive-not-claimed.test.py`, then count `.coverage.*`):

```
#4182 head (os._exit, no flush): fragments=0
with flush                     : fragments=1
```

The test itself: `OK — 0 failure(s)`. `ruff check` clean; `review-checks.sh --diff` and `lint-workspace-resolution.sh --diff` clean. One file changed vs `main`.

Supersedes #4182 if john prefers; otherwise he can cherry-pick `6e6f07378` onto his branch and this closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
